### PR TITLE
Fix/macos tts runtime gpt sovits&command file no function

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,8 +179,17 @@ jobs:
         if: matrix.platform != 'windows-x64'
         shell: bash
         run: |
-          cp scripts/install.command install.command
-          cp scripts/start.command start.command
+          cat > install.command <<'EOF'
+          #!/bin/bash
+          SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+          exec "$SCRIPT_DIR/scripts/install.sh"
+          EOF
+          cat > start.command <<'EOF'
+          #!/bin/bash
+          SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+          exec "$SCRIPT_DIR/scripts/start.sh"
+          EOF
+          chmod +x install.command start.command
           rm -f install.bat start.bat
 
       - name: Tidy Windows bundle layout

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Release 里常见的文件含义如下：
 
 - **[百度网盘](https://pan.baidu.com/s/5ZXvAi6n6i7-OJAYeWDpprg)**：包含所有已发布的角色包.
 
+角色包会携带角色卡、立绘、语音参考音频，以及该角色可用的 GPT-SoVITS 权重（例如 `voice/models/*.ckpt`、`voice/models/*.pth`）。源码仓库和 TTS 运行环境安装脚本不会单独下载这些角色声线权重；如果完整包中没有对应角色资源，需要先通过角色包渠道获取并导入。
+
 #### 安装方式
 
 1. 下载角色包
@@ -281,7 +283,7 @@ tts:
     timeout_seconds: 60
 ```
 
-Windows 用户可以在设置窗口的 TTS 页点击“一键下载 TTS 整合包”安装当前内置的 Windows 整合包。macOS 用户会看到“GPT-SoVITS macOS 源码安装包”，点击后会在 `data/tts_bundles/installed/gpt_sovits_macos/` 下自动安装 Miniforge、创建 Python 3.10 环境、拉取 GPT-SoVITS 源码并生成 macOS 可用的推理配置。下载窗口会按当前系统过滤整合包；Windows 不会展示 macOS 安装项，macOS 也不会展示只包含 Windows 运行时的整合包。
+Windows 用户可以在设置窗口的 TTS 页点击“一键下载 TTS 整合包”安装当前内置的 Windows 整合包。macOS 用户会看到“GPT-SoVITS macOS 源码安装包”，点击后会在 `data/tts_bundles/installed/gpt_sovits_macos/` 下自动安装 Miniforge、创建 Python 3.10 环境、拉取 GPT-SoVITS 源码并生成 macOS 可用的推理配置。这个 macOS 安装项只负责 GPT-SoVITS 源码、Python 环境和官方预训练基础模型；Sakura 等角色声线权重仍来自角色包的 `voice/models/`，由 `character.json` 读取后在启动 TTS 时切换。下载窗口会按当前系统过滤整合包；Windows 不会展示 macOS 安装项，macOS 也不会展示只包含 Windows 运行时的整合包。
 
 设置页新增的 `TTS Python` 和 `推理配置` 字段只用于自定义或 macOS 源码版 GPT-SoVITS；Windows 内置整合包无需填写。
 

--- a/README.md
+++ b/README.md
@@ -281,6 +281,27 @@ tts:
     timeout_seconds: 60
 ```
 
+Windows 用户可以在设置窗口的 TTS 页点击“一键下载 TTS 整合包”安装当前内置的 Windows 整合包。macOS 用户会看到“GPT-SoVITS macOS 源码安装包”，点击后会在 `data/tts_bundles/installed/gpt_sovits_macos/` 下自动安装 Miniforge、创建 Python 3.10 环境、拉取 GPT-SoVITS 源码并生成 macOS 可用的推理配置。下载窗口会按当前系统过滤整合包；Windows 不会展示 macOS 安装项，macOS 也不会展示只包含 Windows 运行时的整合包。
+
+设置页新增的 `TTS Python` 和 `推理配置` 字段只用于自定义或 macOS 源码版 GPT-SoVITS；Windows 内置整合包无需填写。
+
+如果已经在 macOS / Linux 上自行安装了 GPT-SoVITS 源码版，也可以在设置窗口把 TTS 提供器切到“自定义 GPT-SoVITS（macOS/Linux）”，并配置本地源码目录、Python 解释器和可选推理配置：
+
+```yaml
+tts:
+  provider: custom-gpt-sovits
+  enabled: true
+  gpt_sovits:
+    api_url: http://127.0.0.1:9880/tts
+    work_dir: /path/to/GPT-SoVITS
+    python_path: /path/to/miniforge3/envs/gpt-sovits/bin/python
+    tts_config_path: /path/to/GPT-SoVITS/GPT_SoVITS/configs/tts_infer.yaml
+    ref_lang: ja
+    text_lang: ja
+```
+
+自定义 GPT-SoVITS 启动时会使用配置的 `python_path` 运行工作目录下的 `api_v2.py`；如果配置了 `tts_config_path`，会追加 `-c` 参数，并根据 `api_url` 追加监听地址和端口。macOS 一键安装完成后会自动回填这些字段。内置整合包如果只包含其他平台的运行时，Sakura 会提示运行时不兼容，而不会直接执行到系统级 `Exec format error`。
+
 ## 配置项
 
 所有配置集中在 `data/config/` 下的 YAML 文件中。
@@ -293,6 +314,8 @@ tts:
 | `api.yaml: llm.timeout_seconds` | 超时时间 | `60` |
 | `api.yaml: tts.enabled` | 启用 TTS | `false` |
 | `api.yaml: tts.gpt_sovits.api_url` | TTS 接口 | `http://127.0.0.1:9880/tts` |
+| `api.yaml: tts.gpt_sovits.python_path` | 自定义 GPT-SoVITS Python | 空 |
+| `api.yaml: tts.gpt_sovits.tts_config_path` | 自定义 GPT-SoVITS 推理配置 | 空 |
 | `system_config.yaml: ui.subtitle_language` | 气泡语言 `ja`/`zh` | `ja` |
 | `system_config.yaml: ui.portrait_scale_percent` | 立绘缩放 | `100` |
 | `system_config.yaml: proactive_care.enabled` | 主动关怀 | `false` |

--- a/app/config/settings_service.py
+++ b/app/config/settings_service.py
@@ -124,6 +124,8 @@ class AppSettingsService:
         default_api_url = DEFAULT_GENIE_TTS_API_URL if provider == TTS_PROVIDER_GENIE else DEFAULT_GPT_SOVITS_API_URL
         api_url = str(provider_data.get("api_url", default_api_url)).strip()
         work_dir = _optional_path(provider_data.get("work_dir"), self.base_dir)
+        python_path = _optional_path(provider_data.get("python_path"), self.base_dir)
+        tts_config_path = _optional_path(provider_data.get("tts_config_path"), self.base_dir)
         ref_lang = str(provider_data.get("ref_lang", gpt_sovits.get("ref_lang", "zh"))).strip()
         text_lang = str(provider_data.get("text_lang", gpt_sovits.get("text_lang", "zh"))).strip()
         timeout_seconds = _int_value(provider_data.get("timeout_seconds"), 60)
@@ -152,6 +154,8 @@ class AppSettingsService:
                 timeout_seconds=timeout_seconds,
                 provider=provider,
                 work_dir=work_dir,
+                python_path=python_path,
+                tts_config_path=tts_config_path,
                 onnx_model_dir=onnx_model_dir,
                 validate_enabled=validate_enabled,
             )
@@ -166,6 +170,8 @@ class AppSettingsService:
                 ref_text="",
                 provider=provider,
                 work_dir=work_dir,
+                python_path=python_path,
+                tts_config_path=tts_config_path,
                 character_name="sakura",
                 onnx_model_dir=onnx_model_dir,
                 ref_lang=ref_lang,
@@ -201,6 +207,8 @@ class AppSettingsService:
             tts_data["gpt_sovits"] = {
                 "api_url": settings.api_url.strip(),
                 "work_dir": _path_for_config(settings.work_dir, self.base_dir),
+                "python_path": _path_for_config(settings.python_path, self.base_dir),
+                "tts_config_path": _path_for_config(settings.tts_config_path, self.base_dir),
                 "ref_lang": settings.ref_lang.strip(),
                 "text_lang": settings.text_lang.strip(),
                 "timeout_seconds": int(settings.timeout_seconds),

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -543,7 +543,7 @@ class SettingsDialog(QDialog):
         self.tts_provider_combo = QComboBox(tab)
         self.tts_provider_combo.addItem("GPT-SoVITS 整合包（GPU）", TTS_PROVIDER_GPT_SOVITS)
         self.tts_provider_combo.addItem("Genie TTS 整合包（CPU）", TTS_PROVIDER_GENIE)
-        self.tts_provider_combo.addItem("自定义外部 GPT-SoVITS", TTS_PROVIDER_CUSTOM_GPT_SOVITS)
+        self.tts_provider_combo.addItem("自定义 GPT-SoVITS（macOS/Linux）", TTS_PROVIDER_CUSTOM_GPT_SOVITS)
         provider_index = self.tts_provider_combo.findData(settings.provider)
         self.tts_provider_combo.setCurrentIndex(provider_index if provider_index >= 0 else 0)
 
@@ -551,7 +551,14 @@ class SettingsDialog(QDialog):
         self.tts_api_url_edit.setPlaceholderText(_default_tts_api_url(settings.provider))
         self.tts_work_dir_edit = QLineEdit(str(settings.work_dir or ""), tab)
         self.tts_work_dir_edit.setPlaceholderText("data/tts_bundles/installed/gpt_sovits_nvidia50/GPT-SoVITS-v2pro-20250604-nvidia50")
+        self.tts_python_path_edit = QLineEdit(str(settings.python_path or ""), tab)
+        self.tts_python_path_edit.setPlaceholderText("macOS/Linux Python，例如 /path/to/miniforge3/envs/gpt-sovits/bin/python")
+        self.tts_config_path_edit = QLineEdit(str(settings.tts_config_path or ""), tab)
+        self.tts_config_path_edit.setPlaceholderText("可选：GPT-SoVITS tts_infer.yaml")
         self.tts_bundle_download_button = QPushButton("一键下载 TTS 整合包", tab)
+        self.tts_bundle_download_button.setToolTip(
+            "Windows 可一键下载内置整合包；macOS/Linux 请使用自定义 GPT-SoVITS 接入源码版运行环境。"
+        )
         self.tts_bundle_download_button.clicked.connect(self._download_gpt_sovits_bundle)
         self.tts_provider_combo.currentIndexChanged.connect(lambda _index: self._sync_tts_provider_controls(apply_defaults=True))
 
@@ -570,6 +577,8 @@ class SettingsDialog(QDialog):
         form_layout.addRow("TTS 提供器", self.tts_provider_combo)
         form_layout.addRow("API URL", self.tts_api_url_edit)
         form_layout.addRow("TTS 工作目录", self.tts_work_dir_edit)
+        form_layout.addRow("TTS Python", self.tts_python_path_edit)
+        form_layout.addRow("推理配置", self.tts_config_path_edit)
         form_layout.addRow("", self.tts_bundle_download_button)
         form_layout.addRow("参考语言", self.ref_lang_edit)
         form_layout.addRow("文本语言", self.text_lang_edit)
@@ -1701,10 +1710,20 @@ class SettingsDialog(QDialog):
         if dialog.exec() != QDialog.DialogCode.Accepted or dialog.downloaded_work_dir is None:
             return
         provider = getattr(dialog, "downloaded_provider", None) or TTS_PROVIDER_GPT_SOVITS
+        python_path = getattr(dialog, "downloaded_python_path", None)
+        tts_config_path = getattr(dialog, "downloaded_tts_config_path", None)
         provider_index = self.tts_provider_combo.findData(provider)
         if provider_index >= 0:
             self.tts_provider_combo.setCurrentIndex(provider_index)
         self.tts_work_dir_edit.setText(str(dialog.downloaded_work_dir))
+        if python_path is not None:
+            self.tts_python_path_edit.setText(str(python_path))
+        else:
+            self.tts_python_path_edit.clear()
+        if tts_config_path is not None:
+            self.tts_config_path_edit.setText(str(tts_config_path))
+        else:
+            self.tts_config_path_edit.clear()
         self.tts_api_url_edit.setText(_default_tts_api_url(provider))
         self.tts_enabled_check.setChecked(True)
         self._sync_tts_provider_controls()
@@ -1716,16 +1735,20 @@ class SettingsDialog(QDialog):
         if provider == TTS_PROVIDER_GENIE:
             self.tts_work_dir_edit.setPlaceholderText("data/tts_bundles/installed/genie_tts_server/Genie-TTS Server")
         elif provider == TTS_PROVIDER_CUSTOM_GPT_SOVITS:
-            self.tts_work_dir_edit.setPlaceholderText("外部 GPT-SoVITS 工作目录，可留空")
+            self.tts_work_dir_edit.setPlaceholderText("外部 GPT-SoVITS 源码目录，可留空")
         else:
             self.tts_work_dir_edit.setPlaceholderText("data/tts_bundles/installed/gpt_sovits_nvidia50/GPT-SoVITS-v2pro-20250604-nvidia50")
         bundled = _is_bundled_tts_provider(provider)
         self.tts_api_url_edit.setReadOnly(bundled)
         self.tts_work_dir_edit.setReadOnly(bundled)
+        self.tts_python_path_edit.setReadOnly(bundled or provider == TTS_PROVIDER_GENIE)
+        self.tts_config_path_edit.setReadOnly(bundled or provider == TTS_PROVIDER_GENIE)
         if bundled and apply_defaults:
             self.tts_api_url_edit.setText(_default_tts_api_url(provider))
             work_dir = default_provider_bundle_work_dir(provider, self.base_dir)
             self.tts_work_dir_edit.setText(str(work_dir or ""))
+            self.tts_python_path_edit.clear()
+            self.tts_config_path_edit.clear()
         elif provider == TTS_PROVIDER_CUSTOM_GPT_SOVITS and apply_defaults:
             work_dir = _optional_path(self.tts_work_dir_edit.text(), self.base_dir)
             if work_dir is not None and is_provider_bundle_work_dir(work_dir, self.base_dir):
@@ -1857,6 +1880,8 @@ class SettingsDialog(QDialog):
         provider = str(self.tts_provider_combo.currentData() or TTS_PROVIDER_GPT_SOVITS)
         api_url = self.tts_api_url_edit.text().strip()
         work_dir = _optional_path(self.tts_work_dir_edit.text(), self.base_dir)
+        python_path = _optional_path(self.tts_python_path_edit.text(), self.base_dir)
+        tts_config_path = _optional_path(self.tts_config_path_edit.text(), self.base_dir)
         ref_lang = self.ref_lang_edit.text().strip()
         text_lang = self.text_lang_edit.text().strip()
 
@@ -1875,6 +1900,8 @@ class SettingsDialog(QDialog):
                 timeout_seconds=self.tts_timeout_spin.value(),
                 provider=provider,
                 work_dir=work_dir,
+                python_path=python_path,
+                tts_config_path=tts_config_path,
                 onnx_model_dir=_default_genie_onnx_dir(self.base_dir, selected_profile) if provider == TTS_PROVIDER_GENIE else None,
                 validate_enabled=False,
             )
@@ -1889,6 +1916,8 @@ class SettingsDialog(QDialog):
                 gpt_model_path=self.tts_settings.gpt_model_path,
                 sovits_model_path=self.tts_settings.sovits_model_path,
                 work_dir=work_dir,
+                python_path=python_path,
+                tts_config_path=tts_config_path,
                 character_name=self.tts_settings.character_name or "sakura",
                 onnx_model_dir=(
                     self.tts_settings.onnx_model_dir or _default_genie_onnx_dir(self.base_dir, selected_profile)

--- a/app/ui/tts_bundle_dialog.py
+++ b/app/ui/tts_bundle_dialog.py
@@ -16,14 +16,15 @@ from PySide6.QtWidgets import (
 )
 
 from app.voice.tts_bundle import (
-    TTS_BUNDLES,
     TTSBundleEntry,
+    TTSBundleInstallResult,
     cleanup_stale_download_archives,
+    compatible_tts_bundles,
     DownloadCancelledError,
-    download_and_extract_bundle,
     format_bundle_label,
     format_gpu_summary,
     format_platform_summary,
+    install_tts_bundle,
     list_nvidia_gpus,
     recommend_tts_bundle,
 )
@@ -32,7 +33,7 @@ from app.voice.tts_bundle import (
 class TTSBundleDownloadThread(QThread):
     progress = Signal(int)
     status = Signal(str)
-    succeeded = Signal(str)
+    succeeded = Signal(object)
     failed = Signal(str)
     cancelled = Signal()
 
@@ -51,7 +52,7 @@ class TTSBundleDownloadThread(QThread):
             if self._cancel_flag:
                 raise DownloadCancelledError("用户取消了下载")
         try:
-            work_dir = download_and_extract_bundle(
+            result = install_tts_bundle(
                 self.entry,
                 self.base_dir,
                 check_cancel=_check_cancel,
@@ -64,7 +65,7 @@ class TTSBundleDownloadThread(QThread):
         except Exception as exc:  # noqa: BLE001
             self.failed.emit(str(exc))
             return
-        self.succeeded.emit(str(work_dir))
+        self.succeeded.emit(result)
 
 
 class TTSBundleDownloadDialog(QDialog):
@@ -73,7 +74,10 @@ class TTSBundleDownloadDialog(QDialog):
         self.base_dir = base_dir
         self.downloaded_work_dir: Path | None = None
         self.downloaded_provider: str | None = None
+        self.downloaded_python_path: Path | None = None
+        self.downloaded_tts_config_path: Path | None = None
         self._thread: TTSBundleDownloadThread | None = None
+        self._entries = compatible_tts_bundles()
         self.setWindowTitle("下载 TTS 整合包")
         self.setMinimumWidth(520)
         self._cleanup_legacy_archives()
@@ -85,14 +89,22 @@ class TTSBundleDownloadDialog(QDialog):
         self.platform_label.setWordWrap(True)
         self.gpu_label = QLabel(f"显卡检测：\n{format_gpu_summary(gpus)}", self)
         self.gpu_label.setWordWrap(True)
-        self.recommend_label = QLabel(f"推荐下载：{format_bundle_label(recommended)}", self)
+        recommend_text = (
+            f"推荐下载：{format_bundle_label(recommended)}"
+            if recommended is not None
+            else "推荐下载：当前平台暂无可一键下载的整合包，请在 TTS 提供器中选择“自定义 GPT-SoVITS（macOS/Linux）”。"
+        )
+        self.recommend_label = QLabel(recommend_text, self)
         self.recommend_label.setWordWrap(True)
 
         self.bundle_combo = QComboBox(self)
-        for entry in TTS_BUNDLES:
+        for entry in self._entries:
             self.bundle_combo.addItem(format_bundle_label(entry), entry.key)
-            if entry.key == recommended.key:
+            if recommended is not None and entry.key == recommended.key:
                 self.bundle_combo.setCurrentIndex(self.bundle_combo.count() - 1)
+        if not self._entries:
+            self.bundle_combo.addItem("当前平台暂无可用整合包", "")
+            self.bundle_combo.setEnabled(False)
 
         self.status_label = QLabel("", self)
         self.status_label.setVisible(False)
@@ -101,6 +113,7 @@ class TTSBundleDownloadDialog(QDialog):
         self.progress_bar.setVisible(False)
 
         self.start_button = QPushButton("开始下载", self)
+        self.start_button.setEnabled(bool(self._entries))
         self.start_button.clicked.connect(self._start_download)
         self.cancel_button = QPushButton("关闭", self)
         self.cancel_button.clicked.connect(self._on_cancel_clicked)
@@ -127,9 +140,15 @@ class TTSBundleDownloadDialog(QDialog):
     def _start_download(self) -> None:
         if self._thread is not None:
             return
-        entry = self._selected_entry()
+        try:
+            entry = self._selected_entry()
+        except RuntimeError as exc:
+            QMessageBox.warning(self, "暂无可用整合包", str(exc))
+            return
         self.downloaded_work_dir = None
         self.downloaded_provider = None
+        self.downloaded_python_path = None
+        self.downloaded_tts_config_path = None
         self.bundle_combo.setEnabled(False)
         self.start_button.setEnabled(False)
         self.cancel_button.setText("取消下载")
@@ -156,22 +175,27 @@ class TTSBundleDownloadDialog(QDialog):
             "verify": "正在校验本地压缩包...",
             "download": "正在下载整合包...",
             "extract": "正在解压整合包...",
+            "prepare": "正在准备安装环境...",
+            "install": "正在安装 TTS 运行环境...",
+            "configure": "正在生成 TTS 配置...",
             "cleanup": "正在清理下载压缩包...",
         }.get(status, status)
         self.status_label.setText(text)
 
-    @Slot(str)
-    def _handle_success(self, work_dir: str) -> None:
-        self.downloaded_work_dir = Path(work_dir)
-        self.downloaded_provider = self._selected_entry().provider
-        QMessageBox.information(self, "下载完成", f"TTS 整合包已就绪：\n{work_dir}")
+    @Slot(object)
+    def _handle_success(self, result: TTSBundleInstallResult) -> None:
+        self.downloaded_work_dir = result.work_dir
+        self.downloaded_provider = result.provider
+        self.downloaded_python_path = result.python_path
+        self.downloaded_tts_config_path = result.tts_config_path
+        QMessageBox.information(self, "下载完成", f"TTS 整合包已就绪：\n{result.work_dir}")
         self.accept()
 
     @Slot(str)
     def _handle_failure(self, message: str) -> None:
         QMessageBox.warning(self, "下载失败", message)
-        self.bundle_combo.setEnabled(True)
-        self.start_button.setEnabled(True)
+        self.bundle_combo.setEnabled(bool(self._entries))
+        self.start_button.setEnabled(bool(self._entries))
         self.cancel_button.setText("关闭")
         self.cancel_button.setEnabled(True)
         self._thread = None
@@ -183,8 +207,8 @@ class TTSBundleDownloadDialog(QDialog):
     @Slot()
     def _handle_cancelled(self) -> None:
         """下载被用户取消后，恢复界面状态。"""
-        self.bundle_combo.setEnabled(True)
-        self.start_button.setEnabled(True)
+        self.bundle_combo.setEnabled(bool(self._entries))
+        self.start_button.setEnabled(bool(self._entries))
         self.cancel_button.setText("关闭")
         self.cancel_button.setEnabled(True)
         self.status_label.setText("下载已取消")
@@ -227,7 +251,7 @@ class TTSBundleDownloadDialog(QDialog):
 
     def _selected_entry(self) -> TTSBundleEntry:
         key = str(self.bundle_combo.currentData() or "")
-        for entry in TTS_BUNDLES:
+        for entry in self._entries:
             if entry.key == key:
                 return entry
-        return TTS_BUNDLES[0]
+        raise RuntimeError("当前平台没有可一键下载的 TTS 整合包。")

--- a/app/voice/runtime_compat.py
+++ b/app/voice/runtime_compat.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import os
+import platform
+import sys
+from pathlib import Path
+
+
+_MACHO_MAGICS = {
+    b"\xfe\xed\xfa\xce",
+    b"\xce\xfa\xed\xfe",
+    b"\xfe\xed\xfa\xcf",
+    b"\xcf\xfa\xed\xfe",
+    b"\xca\xfe\xba\xbe",
+    b"\xca\xfe\xba\xbf",
+}
+
+
+def current_system_name() -> str:
+    if sys.platform == "win32":
+        return "windows"
+    if sys.platform == "darwin":
+        return "macos"
+    if sys.platform.startswith("linux"):
+        return "linux"
+    return sys.platform.lower()
+
+
+def current_platform_label() -> str:
+    system = {
+        "windows": "Windows",
+        "macos": "macOS",
+        "linux": "Linux",
+    }.get(current_system_name(), platform.system() or sys.platform)
+    machine = platform.machine().strip()
+    return f"{system} {machine}".strip()
+
+
+def executable_system_name(path: Path) -> str | None:
+    try:
+        with path.open("rb") as file:
+            header = file.read(4)
+    except OSError:
+        return None
+    if header.startswith(b"MZ"):
+        return "windows"
+    if header == b"\x7fELF":
+        return "linux"
+    if header in _MACHO_MAGICS:
+        return "macos"
+    return None
+
+
+def is_executable_for_current_system(path: Path) -> bool:
+    executable_system = executable_system_name(path)
+    if executable_system is None:
+        return True
+    return executable_system == current_system_name()
+
+
+def has_runtime_execute_permission(path: Path) -> bool:
+    if sys.platform == "win32":
+        return True
+    return os.access(path, os.X_OK)
+
+
+def runtime_python_candidates(runtime_dir: Path) -> tuple[Path, ...]:
+    if sys.platform == "win32":
+        relative_names = ("python.exe", "python")
+    else:
+        relative_names = ("bin/python3", "bin/python", "python3", "python", "python.exe")
+    candidates: list[Path] = []
+    for relative_name in relative_names:
+        candidate = runtime_dir / relative_name
+        if candidate not in candidates:
+            candidates.append(candidate)
+    return tuple(candidates)
+
+
+def find_usable_runtime_python(runtime_dir: Path) -> Path | None:
+    for candidate in runtime_python_candidates(runtime_dir):
+        if (
+            candidate.is_file()
+            and is_executable_for_current_system(candidate)
+            and has_runtime_execute_permission(candidate)
+        ):
+            return candidate
+    return None
+
+
+def format_runtime_python_issue(runtime_dir: Path) -> str:
+    for candidate in runtime_python_candidates(runtime_dir):
+        if not candidate.is_file():
+            continue
+        executable_system = executable_system_name(candidate)
+        if executable_system is not None and executable_system != current_system_name():
+            expected = {
+                "windows": "Windows",
+                "macos": "macOS",
+                "linux": "Linux",
+            }.get(executable_system, executable_system)
+            return (
+                f"检测到 {expected} Python 运行时：{candidate}；"
+                f"当前系统是 {current_platform_label()}。"
+                "请安装适配当前系统的 TTS 运行环境，或改用已在运行的外部 TTS 服务。"
+            )
+        if not has_runtime_execute_permission(candidate):
+            return f"Python 运行时没有执行权限：{candidate}"
+    return f"未找到当前系统可执行的 Python 运行时（查找目录：{runtime_dir}）。"

--- a/app/voice/tts.py
+++ b/app/voice/tts.py
@@ -26,6 +26,7 @@ from PySide6.QtMultimedia import QAudioOutput, QMediaPlayer
 from app.config.character_loader import CharacterProfile
 from app.llm.chat_reply import DEFAULT_TONE
 from app.core.debug_log import debug_log
+from app.voice.runtime_compat import find_usable_runtime_python, format_runtime_python_issue
 
 
 TTSCallback = Callable[[], None]
@@ -230,6 +231,8 @@ class GPTSoVITSTTSSettings:
     gpt_model_path: Path | None = None
     sovits_model_path: Path | None = None
     work_dir: Path | None = None
+    python_path: Path | None = None
+    tts_config_path: Path | None = None
     character_name: str = ""
     onnx_model_dir: Path | None = None
     ref_lang: str = "ja"
@@ -248,6 +251,8 @@ class GPTSoVITSTTSSettings:
         timeout_seconds: int,
         provider: str = TTS_PROVIDER_GPT_SOVITS,
         work_dir: Path | None = None,
+        python_path: Path | None = None,
+        tts_config_path: Path | None = None,
         onnx_model_dir: Path | None = None,
         validate_enabled: bool = True,
     ) -> "GPTSoVITSTTSSettings":
@@ -264,6 +269,8 @@ class GPTSoVITSTTSSettings:
                 text_lang=text_lang,
                 timeout_seconds=timeout_seconds,
                 work_dir=work_dir,
+                python_path=python_path,
+                tts_config_path=tts_config_path,
                 character_name=character_profile.display_name or character_profile.id,
                 onnx_model_dir=onnx_model_dir,
             )
@@ -287,6 +294,8 @@ class GPTSoVITSTTSSettings:
             gpt_model_path=voice.gpt_model_path,
             sovits_model_path=voice.sovits_model_path,
             work_dir=work_dir,
+            python_path=python_path,
+            tts_config_path=tts_config_path,
             character_name=character_profile.display_name or character_profile.id,
             onnx_model_dir=onnx_model_dir,
             ref_lang=ref_lang,
@@ -303,6 +312,10 @@ class GPTSoVITSTTSSettings:
             raise TTSConfigError("缺少 TTS API URL。")
         if self.provider not in _SUPPORTED_TTS_PROVIDERS:
             raise TTSConfigError(f"不支持的 TTS Provider：{self.provider}")
+        if self.python_path is not None and not self.python_path.exists():
+            raise TTSConfigError(f"TTS Python 不存在：{self.python_path}")
+        if self.tts_config_path is not None and not self.tts_config_path.exists():
+            raise TTSConfigError(f"GPT-SoVITS 推理配置不存在：{self.tts_config_path}")
         if self.gpt_model_path is not None and not self.gpt_model_path.exists():
             raise TTSConfigError(f"GPT 模型不存在：{self.gpt_model_path}")
         if self.sovits_model_path is not None and not self.sovits_model_path.exists():
@@ -780,13 +793,21 @@ class GPTSoVITSTTSProvider(QObject):
         if work_dir is None:
             return False
         work_dir = work_dir.resolve()
-        python_exe = work_dir / "runtime" / "python.exe"
+        runtime_dir = work_dir / "runtime"
+        python_exe = self.settings.python_path
+        if python_exe is not None:
+            python_exe = python_exe.resolve()
+        else:
+            python_exe = find_usable_runtime_python(runtime_dir)
         api_script = work_dir / "api_v2.py"
         if not work_dir.is_dir():
             fail_callback(f"GPT-SoVITS 工作目录不存在：{work_dir}")
             return False
+        if python_exe is None:
+            fail_callback(f"GPT-SoVITS 运行时不可用：{format_runtime_python_issue(runtime_dir)}")
+            return False
         if not python_exe.is_file():
-            fail_callback(f"GPT-SoVITS 运行时不存在：{python_exe}")
+            fail_callback(f"GPT-SoVITS Python 不存在：{python_exe}")
             return False
         if not api_script.is_file():
             fail_callback(f"GPT-SoVITS 启动脚本不存在：{api_script}")
@@ -809,7 +830,10 @@ class GPTSoVITSTTSProvider(QObject):
                 log_file.write(f"\n[{time.strftime('%Y-%m-%d %H:%M:%S')}] 启动 GPT-SoVITS：{work_dir}\n")
                 log_file.flush()
                 kwargs["stdout"] = log_file
-                self._server_process = subprocess.Popen([str(python_exe), str(api_script)], **kwargs)
+                self._server_process = subprocess.Popen(
+                    _build_gpt_sovits_start_command(python_exe, api_script, self.settings),
+                    **kwargs,
+                )
         except OSError as exc:
             debug_log("TTS", "本地 GPT-SoVITS 服务启动失败", {"work_dir": str(work_dir), "error": str(exc)})
             fail_callback(f"GPT-SoVITS 服务启动失败：{exc}")
@@ -1382,12 +1406,13 @@ class GenieTTSProvider(GPTSoVITSTTSProvider):
         if work_dir is None:
             return False
         work_dir = work_dir.resolve()
-        python_exe = work_dir / "runtime" / "python.exe"
+        runtime_dir = work_dir / "runtime"
+        python_exe = find_usable_runtime_python(runtime_dir)
         if not work_dir.is_dir():
             fail_callback(f"Genie TTS 工作目录不存在：{work_dir}")
             return False
-        if not python_exe.is_file():
-            fail_callback(f"Genie TTS 运行时不存在：{python_exe}")
+        if python_exe is None:
+            fail_callback(f"Genie TTS 运行时不可用：{format_runtime_python_issue(runtime_dir)}")
             return False
 
         if self._server_process is not None and self._server_process.poll() is None:
@@ -1516,9 +1541,10 @@ class GenieTTSProvider(GPTSoVITSTTSProvider):
         if converter_script is None:
             fail_callback(f"Genie TTS 工作目录缺少 convert.py/convery.py：{self.settings.work_dir}")
             return False
-        python_exe = converter_script.parent / "runtime" / "python.exe"
-        if not python_exe.is_file():
-            fail_callback(f"Genie TTS 转换运行时不存在：{python_exe}")
+        runtime_dir = converter_script.parent / "runtime"
+        python_exe = find_usable_runtime_python(runtime_dir)
+        if python_exe is None:
+            fail_callback(f"Genie TTS 转换运行时不可用：{format_runtime_python_issue(runtime_dir)}")
             return False
 
         onnx_dir.mkdir(parents=True, exist_ok=True)
@@ -1667,7 +1693,8 @@ def _command_line_matches_local_tts(
         return False
 
     normalized_command = _normalize_process_text(command_line)
-    python_exe = _normalize_process_text(str(work_dir.resolve() / "runtime" / "python.exe"))
+    configured_python = settings.python_path.resolve() if settings.python_path is not None else None
+    python_exe = _normalize_process_text(str(configured_python or work_dir.resolve() / "runtime" / "python.exe"))
     if python_exe not in normalized_command:
         return False
 
@@ -1766,6 +1793,28 @@ def _build_genie_start_command(python_exe: Path, host: str, port: int) -> list[s
         f"genie_tts.start_server(host={start_host!r}, port={int(port)}, workers=1)\n"
     )
     return [str(python_exe), "-c", start_code]
+
+
+def _build_gpt_sovits_start_command(
+    python_exe: Path,
+    api_script: Path,
+    settings: GPTSoVITSTTSSettings,
+) -> list[str]:
+    cmd = [str(python_exe), str(api_script)]
+    if settings.tts_config_path is not None:
+        cmd.extend(["-c", str(settings.tts_config_path)])
+
+    parsed_url = urlparse(settings.api_url)
+    if parsed_url.hostname:
+        host = "127.0.0.1" if parsed_url.hostname == "localhost" else parsed_url.hostname
+        cmd.extend(["-a", host])
+    try:
+        port = parsed_url.port
+    except ValueError:
+        port = None
+    if port is not None:
+        cmd.extend(["-p", str(port)])
+    return cmd
 
 
 def _probe_tcp_port(host: str, port: int, timeout: int) -> bool:

--- a/app/voice/tts_bundle.py
+++ b/app/voice/tts_bundle.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import importlib
+import os
 import platform
 import re
 import shutil
@@ -12,6 +13,8 @@ import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Protocol
+
+from app.voice.runtime_compat import current_platform_label, current_system_name, find_usable_runtime_python
 
 
 ProgressCallback = Callable[[int], None]
@@ -37,11 +40,25 @@ class UrlOpenCallable(Protocol):
 class TTSBundleEntry:
     key: str
     label: str
-    filename: str
-    download_url: str
-    size: int
-    sha256: str
+    filename: str = ""
+    download_url: str = ""
+    size: int = 0
+    sha256: str = ""
     provider: str = "gpt-sovits"
+    supported_systems: tuple[str, ...] = ()
+    install_method: str = "archive"
+    installer_script: str | None = None
+    work_dir_name: str | None = None
+    python_path_name: str | None = None
+    tts_config_path_name: str | None = None
+
+
+@dataclass(frozen=True)
+class TTSBundleInstallResult:
+    work_dir: Path
+    provider: str
+    python_path: Path | None = None
+    tts_config_path: Path | None = None
 
 
 @dataclass(frozen=True)
@@ -61,6 +78,7 @@ GENIE_TTS = TTSBundleEntry(
     size=1041915345,
     sha256="8f06077b6102aa29f1c9473926db9a74890d627f077393aa8ebb928b52f15de1",
     provider="genie-tts",
+    supported_systems=("windows",),
 )
 GPT_SOVITS_STANDARD = TTSBundleEntry(
     key="gpt_sovits_v2pro",
@@ -72,6 +90,7 @@ GPT_SOVITS_STANDARD = TTSBundleEntry(
     ),
     size=8185086602,
     sha256="bd60d0796553ff05d8568136e199c13e0dc22ebe2ed24273134e34ed6f215cd6",
+    supported_systems=("windows",),
 )
 GPT_SOVITS_NVIDIA50 = TTSBundleEntry(
     key="gpt_sovits_nvidia50",
@@ -83,11 +102,28 @@ GPT_SOVITS_NVIDIA50 = TTSBundleEntry(
     ),
     size=8835144925,
     sha256="97b4edcd451c42357db7e26e6c1c877ca5d85144fe97beaff6d7005d35bee008",
+    supported_systems=("windows",),
+)
+GPT_SOVITS_MACOS_INSTALLER = TTSBundleEntry(
+    key="gpt_sovits_macos",
+    label="GPT-SoVITS macOS 源码安装包",
+    provider="custom-gpt-sovits",
+    supported_systems=("macos",),
+    install_method="script",
+    installer_script="scripts/install_gpt_sovits_macos.sh",
+    work_dir_name="GPT-SoVITS",
+    python_path_name="miniforge3/envs/gpt-sovits310/bin/python",
+    tts_config_path_name="GPT-SoVITS/GPT_SoVITS/configs/tts_infer_sakura_macos.yaml",
 )
 GPT_SOVITS_BUNDLES = (GPT_SOVITS_STANDARD, GPT_SOVITS_NVIDIA50)
-TTS_BUNDLES = (GENIE_TTS, GPT_SOVITS_STANDARD, GPT_SOVITS_NVIDIA50)
+TTS_BUNDLES = (GENIE_TTS, GPT_SOVITS_STANDARD, GPT_SOVITS_NVIDIA50, GPT_SOVITS_MACOS_INSTALLER)
 MIN_GPT_SOVITS_VRAM_GB = 6.0
 _GPT_SOVITS_VRAM_TOLERANCE_GB = 0.25
+_SYSTEM_LABELS = {
+    "windows": "Windows",
+    "macos": "macOS",
+    "linux": "Linux",
+}
 
 
 def format_platform_summary() -> str:
@@ -136,12 +172,22 @@ def list_nvidia_gpus() -> list[GPUInfo]:
 
 
 def format_gpu_summary(gpus: list[GPUInfo]) -> str:
+    if not compatible_tts_bundles():
+        return (
+            f"当前平台 {current_platform_label()} 暂无可一键下载的 TTS 整合包；"
+            "可在设置中选择“自定义 GPT-SoVITS（macOS/Linux）”接入本机源码版运行环境。"
+        )
     if not gpus:
+        recommended = recommend_tts_bundle(gpus)
+        if recommended is not None and recommended != GENIE_TTS:
+            return f"未检测到 NVIDIA GPU，将推荐 {format_bundle_label(recommended)}。"
         return "未检测到 NVIDIA GPU，将推荐 Genie TTS CPU 整合包。"
     return "\n".join(f"#{i} NVIDIA | {gpu.name} | {gpu.vram_gb} GB" for i, gpu in enumerate(gpus, start=1))
 
 
 def format_bundle_size(entry: TTSBundleEntry) -> str:
+    if entry.install_method == "script":
+        return "在线安装"
     gb = entry.size / 1_000_000_000
     if gb >= 1:
         return f"约 {gb:.1f} GB"
@@ -149,30 +195,58 @@ def format_bundle_size(entry: TTSBundleEntry) -> str:
 
 
 def format_bundle_label(entry: TTSBundleEntry) -> str:
-    return f"{entry.label}（{format_bundle_size(entry)}）"
+    details = [format_bundle_size(entry)]
+    if entry.supported_systems:
+        details.append(f"仅 {format_supported_systems(entry.supported_systems)}")
+    return f"{entry.label}（{'，'.join(details)}）"
 
 
-def recommend_gpt_sovits_bundle(gpus: list[GPUInfo] | None = None) -> TTSBundleEntry:
+def format_supported_systems(supported_systems: tuple[str, ...]) -> str:
+    if not supported_systems:
+        return "全部平台"
+    return "、".join(_SYSTEM_LABELS.get(system, system) for system in supported_systems)
+
+
+def is_bundle_supported(entry: TTSBundleEntry) -> bool:
+    supported_systems = tuple(system.lower() for system in entry.supported_systems)
+    return not supported_systems or current_system_name() in supported_systems
+
+
+def compatible_tts_bundles() -> tuple[TTSBundleEntry, ...]:
+    return tuple(entry for entry in TTS_BUNDLES if is_bundle_supported(entry))
+
+
+def recommend_gpt_sovits_bundle(gpus: list[GPUInfo] | None = None) -> TTSBundleEntry | None:
+    compatible_gpt_bundles = tuple(entry for entry in GPT_SOVITS_BUNDLES if is_bundle_supported(entry))
+    if not compatible_gpt_bundles:
+        return None
     gpus = list_nvidia_gpus() if gpus is None else gpus
-    if any(_is_rtx_50_series(gpu.name) for gpu in gpus):
+    if GPT_SOVITS_NVIDIA50 in compatible_gpt_bundles and any(_is_rtx_50_series(gpu.name) for gpu in gpus):
         return GPT_SOVITS_NVIDIA50
+    if GPT_SOVITS_STANDARD not in compatible_gpt_bundles:
+        return compatible_gpt_bundles[0]
     return GPT_SOVITS_STANDARD
 
 
-def recommend_tts_bundle(gpus: list[GPUInfo] | None = None) -> TTSBundleEntry:
+def recommend_tts_bundle(gpus: list[GPUInfo] | None = None) -> TTSBundleEntry | None:
+    compatible_bundles = compatible_tts_bundles()
+    if not compatible_bundles:
+        return None
     gpus = list_nvidia_gpus() if gpus is None else gpus
     capable_nvidia = [gpu for gpu in gpus if _has_gpt_sovits_vram(gpu)]
     if not capable_nvidia:
-        return GENIE_TTS
-    if any(_is_rtx_50_series(gpu.name) for gpu in capable_nvidia):
+        return GENIE_TTS if GENIE_TTS in compatible_bundles else compatible_bundles[0]
+    if GPT_SOVITS_NVIDIA50 in compatible_bundles and any(_is_rtx_50_series(gpu.name) for gpu in capable_nvidia):
         return GPT_SOVITS_NVIDIA50
-    return GPT_SOVITS_STANDARD
+    return GPT_SOVITS_STANDARD if GPT_SOVITS_STANDARD in compatible_bundles else compatible_bundles[0]
 
 
 def default_bundle_work_dir(entry: TTSBundleEntry, base_dir: Path) -> Path:
     """返回整合包对应的工作目录；已安装时解析真实解压根目录，未安装时返回预期目录。"""
 
     installed_dir = base_dir / "data" / "tts_bundles" / "installed" / entry.key
+    if entry.install_method == "script" and entry.work_dir_name:
+        return installed_dir / entry.work_dir_name
     if installed_dir.is_dir():
         try:
             return _resolve_extracted_root(installed_dir)
@@ -186,16 +260,20 @@ def default_provider_bundle_work_dir(provider: str, base_dir: Path) -> Path | No
 
     normalized = provider.strip().lower().replace("_", "-")
     if normalized in {"genie", "genie-tts", "genietts"}:
-        return default_bundle_work_dir(GENIE_TTS, base_dir)
+        return default_bundle_work_dir(GENIE_TTS, base_dir) if is_bundle_supported(GENIE_TTS) else None
     if normalized not in {"gpt-sovits", "gpt-so-vits", "gptsovits"}:
         return None
 
+    if not any(is_bundle_supported(entry) for entry in GPT_SOVITS_BUNDLES):
+        return None
     for entry in GPT_SOVITS_BUNDLES:
+        if not is_bundle_supported(entry):
+            continue
         installed_dir = base_dir / "data" / "tts_bundles" / "installed" / entry.key
         if _is_installed_bundle_ready(installed_dir):
             return default_bundle_work_dir(entry, base_dir)
     recommended = recommend_gpt_sovits_bundle()
-    return default_bundle_work_dir(recommended, base_dir)
+    return default_bundle_work_dir(recommended, base_dir) if recommended is not None else None
 
 
 def is_provider_bundle_work_dir(path: Path, base_dir: Path) -> bool:
@@ -208,6 +286,38 @@ def is_provider_bundle_work_dir(path: Path, base_dir: Path) -> bool:
     return True
 
 
+def install_tts_bundle(
+    entry: TTSBundleEntry,
+    base_dir: Path,
+    *,
+    check_cancel: Callable[[], None] | None = None,
+    on_progress: ProgressCallback | None = None,
+    on_status: StatusCallback | None = None,
+    urlopen: UrlOpenCallable = urllib.request.urlopen,
+    extractor: Callable[[Path, Path], str | None] | None = None,
+) -> TTSBundleInstallResult:
+    if entry.install_method == "archive":
+        work_dir = download_and_extract_bundle(
+            entry,
+            base_dir,
+            check_cancel=check_cancel,
+            on_progress=on_progress,
+            on_status=on_status,
+            urlopen=urlopen,
+            extractor=extractor,
+        )
+        return TTSBundleInstallResult(work_dir=work_dir, provider=entry.provider)
+    if entry.install_method == "script":
+        return _run_script_bundle_installer(
+            entry,
+            base_dir,
+            check_cancel=check_cancel,
+            on_progress=on_progress,
+            on_status=on_status,
+        )
+    raise RuntimeError(f"不支持的 TTS 整合包安装方式：{entry.install_method}")
+
+
 def download_and_extract_bundle(
     entry: TTSBundleEntry,
     base_dir: Path,
@@ -218,6 +328,14 @@ def download_and_extract_bundle(
     urlopen: UrlOpenCallable = urllib.request.urlopen,
     extractor: Callable[[Path, Path], str | None] | None = None,
 ) -> Path:
+    if entry.install_method != "archive":
+        raise RuntimeError(f"{entry.label} 不是压缩包整合包，请使用安装器入口。")
+    if not is_bundle_supported(entry):
+        raise RuntimeError(
+            f"{entry.label} 不支持当前平台：{current_platform_label()}；"
+            f"支持平台：{format_supported_systems(entry.supported_systems)}。"
+        )
+
     bundle_base = base_dir / "data" / "tts_bundles"
     downloads_dir = bundle_base / "downloads"
     installed_dir = bundle_base / "installed" / entry.key
@@ -255,6 +373,8 @@ def cleanup_stale_download_archives(base_dir: Path) -> list[Path]:
 
     cleaned: list[Path] = []
     for entry in TTS_BUNDLES:
+        if entry.install_method != "archive" or not entry.filename:
+            continue
         archive = downloads_dir / entry.filename
         installed_dir = installed_base / entry.key
         if not archive.is_file() or not _is_installed_bundle_ready(installed_dir):
@@ -262,6 +382,117 @@ def cleanup_stale_download_archives(base_dir: Path) -> list[Path]:
         _cleanup_archive(archive)
         cleaned.append(archive)
     return cleaned
+
+
+def _run_script_bundle_installer(
+    entry: TTSBundleEntry,
+    base_dir: Path,
+    *,
+    check_cancel: Callable[[], None] | None,
+    on_progress: ProgressCallback | None,
+    on_status: StatusCallback | None,
+) -> TTSBundleInstallResult:
+    if not is_bundle_supported(entry):
+        raise RuntimeError(
+            f"{entry.label} 不支持当前平台：{current_platform_label()}；"
+            f"支持平台：{format_supported_systems(entry.supported_systems)}。"
+        )
+    if not entry.installer_script:
+        raise RuntimeError(f"{entry.label} 缺少安装脚本。")
+
+    script = _resolve_installer_script(entry.installer_script, base_dir)
+    installed_dir = base_dir / "data" / "tts_bundles" / "installed" / entry.key
+    downloads_dir = base_dir / "data" / "tts_bundles" / "downloads"
+    installed_dir.mkdir(parents=True, exist_ok=True)
+    downloads_dir.mkdir(parents=True, exist_ok=True)
+
+    _emit_status(on_status, "install")
+    _emit_progress(on_progress, 0)
+    env = os.environ.copy()
+    env["SAKURA_TTS_INSTALL_DIR"] = str(installed_dir)
+    env["SAKURA_TTS_DOWNLOADS_DIR"] = str(downloads_dir)
+    env.setdefault("PYTHONIOENCODING", "utf-8")
+    cmd = ["bash", str(script), str(installed_dir)]
+    process = subprocess.Popen(
+        cmd,
+        cwd=str(base_dir),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+    tail: list[str] = []
+    assert process.stdout is not None
+    try:
+        for raw_line in process.stdout:
+            line = raw_line.strip()
+            if line:
+                tail.append(line)
+                tail = tail[-20:]
+                _handle_installer_progress_line(line, on_progress=on_progress, on_status=on_status)
+            if check_cancel is not None:
+                try:
+                    check_cancel()
+                except Exception:
+                    process.terminate()
+                    try:
+                        process.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                    raise
+    finally:
+        process.stdout.close()
+    return_code = process.wait()
+    if return_code != 0:
+        detail = "\n".join(tail) or f"exit {return_code}"
+        raise RuntimeError(f"{entry.label} 安装失败：\n{detail}"[:2000])
+
+    result = _build_script_install_result(entry, installed_dir)
+    _emit_status(on_status, "cleanup")
+    _emit_progress(on_progress, 100)
+    return result
+
+
+def _resolve_installer_script(relative_script: str, base_dir: Path) -> Path:
+    candidates = [base_dir / relative_script, _project_root() / relative_script]
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    raise RuntimeError(f"未找到 TTS 整合包安装脚本：{relative_script}")
+
+
+def _handle_installer_progress_line(
+    line: str,
+    *,
+    on_progress: ProgressCallback | None,
+    on_status: StatusCallback | None,
+) -> None:
+    match = re.search(r"::sakura-progress\s+status=([a-z_]+)\s+progress=(\d+)", line)
+    if match is None:
+        return
+    _emit_status(on_status, match.group(1))
+    _emit_progress(on_progress, int(match.group(2)))
+
+
+def _build_script_install_result(entry: TTSBundleEntry, installed_dir: Path) -> TTSBundleInstallResult:
+    work_dir = installed_dir / entry.work_dir_name if entry.work_dir_name else installed_dir
+    python_path = installed_dir / entry.python_path_name if entry.python_path_name else None
+    tts_config_path = installed_dir / entry.tts_config_path_name if entry.tts_config_path_name else None
+    if not work_dir.is_dir():
+        raise RuntimeError(f"{entry.label} 安装后未找到工作目录：{work_dir}")
+    if not (work_dir / "api_v2.py").is_file():
+        raise RuntimeError(f"{entry.label} 安装后未找到 api_v2.py：{work_dir}")
+    if python_path is not None and not python_path.is_file():
+        raise RuntimeError(f"{entry.label} 安装后未找到 Python：{python_path}")
+    if tts_config_path is not None and not tts_config_path.is_file():
+        raise RuntimeError(f"{entry.label} 安装后未找到推理配置：{tts_config_path}")
+    return TTSBundleInstallResult(
+        work_dir=work_dir.resolve(),
+        provider=entry.provider,
+        python_path=python_path.resolve() if python_path is not None else None,
+        tts_config_path=tts_config_path.resolve() if tts_config_path is not None else None,
+    )
 
 
 def _is_rtx_50_series(name: str) -> bool:
@@ -287,7 +518,7 @@ def _is_installed_bundle_ready(installed_dir: Path) -> bool:
         root = _resolve_extracted_root(installed_dir)
     except OSError:
         return False
-    return (root / "runtime" / "python.exe").is_file()
+    return find_usable_runtime_python(root / "runtime") is not None
 
 
 def _emit_progress(callback: ProgressCallback | None, value: int) -> None:

--- a/scripts/install_gpt_sovits_macos.sh
+++ b/scripts/install_gpt_sovits_macos.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+set -euo pipefail
+
+INSTALL_ROOT="${1:-${SAKURA_TTS_INSTALL_DIR:-}}"
+if [ -z "$INSTALL_ROOT" ]; then
+    echo "usage: bash scripts/install_gpt_sovits_macos.sh <install-root>"
+    exit 2
+fi
+
+if [ "$(uname -s)" != "Darwin" ]; then
+    echo "GPT-SoVITS macOS installer can only run on macOS."
+    exit 2
+fi
+
+ARCH="$(uname -m)"
+case "$ARCH" in
+arm64 | x86_64) ;;
+*)
+    echo "Unsupported macOS architecture: $ARCH"
+    exit 2
+    ;;
+esac
+
+progress() {
+    echo "::sakura-progress status=$1 progress=$2"
+}
+
+require_command() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "Missing required command: $1"
+        exit 2
+    fi
+}
+
+require_command curl
+require_command git
+
+INSTALL_PARENT="$(dirname "$INSTALL_ROOT")"
+mkdir -p "$INSTALL_PARENT"
+INSTALL_ROOT="$(cd "$INSTALL_PARENT" && pwd)/$(basename "$INSTALL_ROOT")"
+DOWNLOADS_DIR="${SAKURA_TTS_DOWNLOADS_DIR:-$INSTALL_ROOT/downloads}"
+MINIFORGE_DIR="$INSTALL_ROOT/miniforge3"
+ENV_NAME="${GPT_SOVITS_ENV_NAME:-gpt-sovits310}"
+ENV_DIR="$MINIFORGE_DIR/envs/$ENV_NAME"
+ENV_PYTHON="$ENV_DIR/bin/python"
+GPT_DIR="$INSTALL_ROOT/GPT-SoVITS"
+GPT_REPO="${GPT_SOVITS_REPO:-https://github.com/RVC-Boss/GPT-SoVITS.git}"
+GPT_REF="${GPT_SOVITS_REF:-08d627c3338173c3229286d8787060d6559fe0f8}"
+MODEL_SOURCE="${GPT_SOVITS_MODEL_SOURCE:-ModelScope}"
+DEVICE="${GPT_SOVITS_DEVICE:-MPS}"
+CONFIG_PATH="$GPT_DIR/GPT_SoVITS/configs/tts_infer_sakura_macos.yaml"
+
+mkdir -p "$INSTALL_ROOT" "$DOWNLOADS_DIR"
+
+progress prepare 5
+if [ ! -x "$MINIFORGE_DIR/bin/conda" ]; then
+    INSTALLER="$DOWNLOADS_DIR/Miniforge3-MacOSX-$ARCH.sh"
+    if [ ! -f "$INSTALLER" ]; then
+        progress download 10
+        curl -fL -o "$INSTALLER" \
+            "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-$ARCH.sh"
+    fi
+    progress install 20
+    bash "$INSTALLER" -b -p "$MINIFORGE_DIR"
+fi
+
+# shellcheck source=/dev/null
+source "$MINIFORGE_DIR/etc/profile.d/conda.sh"
+
+if [ ! -x "$ENV_PYTHON" ]; then
+    progress install 30
+    conda create -y -p "$ENV_DIR" python=3.10
+fi
+
+progress install 38
+conda activate "$ENV_DIR"
+conda install -y -c conda-forge wget
+
+if [ ! -d "$GPT_DIR/.git" ]; then
+    progress download 45
+    rm -rf "$GPT_DIR"
+    git clone "$GPT_REPO" "$GPT_DIR"
+fi
+
+progress install 55
+git -C "$GPT_DIR" fetch --tags origin
+git -C "$GPT_DIR" checkout "$GPT_REF"
+
+if [ ! -f "$GPT_DIR/install.sh" ]; then
+    echo "GPT-SoVITS install.sh not found: $GPT_DIR"
+    exit 1
+fi
+
+progress install 65
+cd "$GPT_DIR"
+WORKFLOW=false bash install.sh --device "$DEVICE" --source "$MODEL_SOURCE"
+
+progress configure 92
+SAKURA_TTS_CONFIG_PATH="$CONFIG_PATH" "$ENV_PYTHON" - <<'PY'
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import yaml
+
+config_path = Path(os.environ["SAKURA_TTS_CONFIG_PATH"])
+source_path = config_path.with_name("tts_infer.yaml")
+data = yaml.safe_load(source_path.read_text(encoding="utf-8")) or {}
+preferred = dict(data.get("v2ProPlus") or data.get("v2") or {})
+custom = dict(data.get("custom") or {})
+custom.update(preferred)
+custom["device"] = "cpu"
+custom["is_half"] = False
+data["custom"] = custom
+config_path.write_text(
+    yaml.safe_dump(data, allow_unicode=True, sort_keys=False),
+    encoding="utf-8",
+)
+PY
+
+progress cleanup 100
+echo "GPT-SoVITS macOS installer completed."

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -551,10 +551,19 @@ def test_settings_dialog_exposes_tts_bundle_controls() -> None:
     )
 
     labels = [label.text() for label in dialog.findChildren(qtwidgets.QLabel)]
+    custom_index = dialog.tts_provider_combo.findData("custom-gpt-sovits")
 
     assert any("TTS 工作目录" in text for text in labels)
     assert any("TTS 提供器" in text for text in labels)
+    assert any("TTS Python" in text for text in labels)
+    assert any("推理配置" in text for text in labels)
+    assert custom_index >= 0
+    assert "macOS/Linux" in dialog.tts_provider_combo.itemText(custom_index)
     assert dialog.tts_bundle_download_button.text() == "一键下载 TTS 整合包"
+    dialog.tts_provider_combo.setCurrentIndex(custom_index)
+    app.processEvents()
+    assert not dialog.tts_python_path_edit.isReadOnly()
+    assert not dialog.tts_config_path_edit.isReadOnly()
     dialog.deleteLater()
     app.processEvents()
 
@@ -669,6 +678,87 @@ def test_settings_dialog_download_success_fills_genie_provider(monkeypatch) -> N
     assert dialog.result_tts_settings.provider == "genie-tts"
     assert dialog.result_tts_settings.work_dir == root / "data" / "tts_bundles" / "installed" / "genie_tts_server"
     assert dialog.result_tts_settings.onnx_model_dir == root / "data" / "tts_bundles" / "onnx" / "sakura"
+    dialog.deleteLater()
+    app.processEvents()
+
+
+def test_settings_dialog_download_success_fills_macos_gptsovits_paths(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    if not hasattr(qtwidgets, "QApplication"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+
+    import app.ui.settings_dialog as settings_dialog_module
+    from app.ui.settings_dialog import SettingsDialog
+
+    root = _ui_runtime_root("tts_bundle_macos_ui")
+    work_dir = root / "data" / "tts_bundles" / "installed" / "gpt_sovits_macos" / "GPT-SoVITS"
+    python_path = (
+        root
+        / "data"
+        / "tts_bundles"
+        / "installed"
+        / "gpt_sovits_macos"
+        / "miniforge3"
+        / "envs"
+        / "gpt-sovits310"
+        / "bin"
+        / "python"
+    )
+    tts_config_path = work_dir / "GPT_SoVITS" / "configs" / "tts_infer_sakura_macos.yaml"
+    work_dir.mkdir(parents=True, exist_ok=True)
+    python_path.parent.mkdir(parents=True, exist_ok=True)
+    python_path.write_text("fake", encoding="utf-8")
+    tts_config_path.parent.mkdir(parents=True, exist_ok=True)
+    tts_config_path.write_text("custom: {}", encoding="utf-8")
+
+    class DialogStub:
+        def __init__(self, *_args, **_kwargs) -> None:
+            self.downloaded_work_dir = work_dir
+            self.downloaded_provider = "custom-gpt-sovits"
+            self.downloaded_python_path = python_path
+            self.downloaded_tts_config_path = tts_config_path
+
+        def exec(self):  # type: ignore[no-untyped-def]
+            return settings_dialog_module.QDialog.DialogCode.Accepted
+
+    monkeypatch.setattr(settings_dialog_module, "TTSBundleDownloadDialog", DialogStub)
+
+    QApplication = qtwidgets.QApplication
+    app = QApplication.instance() or QApplication([])
+    dialog = SettingsDialog(
+        api_settings=ApiSettings(
+            base_url="https://api.example.com/v1",
+            api_key="test-key",
+            model="test-model",
+        ),
+        tts_settings=_minimal_tts_settings(),
+        base_dir=root,
+        **_settings_dialog_character_kwargs(root),
+        proactive_care_settings=ProactiveCareSettings(screen_context_enabled=True),
+        mcp_settings=MCPRuntimeSettings(windows_enabled=False),
+    )
+
+    dialog._download_gpt_sovits_bundle()
+
+    assert dialog.tts_enabled_check.isChecked()
+    assert dialog.tts_provider_combo.currentData() == "custom-gpt-sovits"
+    assert dialog.tts_work_dir_edit.text() == str(work_dir)
+    assert dialog.tts_python_path_edit.text() == str(python_path)
+    assert dialog.tts_config_path_edit.text() == str(tts_config_path)
+    monkeypatch.setattr(
+        dialog,
+        "_start_tts_settings_test",
+        lambda _settings, accept_values: dialog._complete_accept(accept_values),
+    )
+
+    dialog.accept()
+
+    assert dialog.result_tts_settings is not None
+    assert dialog.result_tts_settings.provider == "custom-gpt-sovits"
+    assert dialog.result_tts_settings.work_dir == work_dir
+    assert dialog.result_tts_settings.python_path == python_path
+    assert dialog.result_tts_settings.tts_config_path == tts_config_path
     dialog.deleteLater()
     app.processEvents()
 

--- a/tests/unit/test_settings_service.py
+++ b/tests/unit/test_settings_service.py
@@ -74,6 +74,17 @@ def test_settings_service_saves_runtime_config_to_yaml() -> None:
             ref_text_path=root / "ref.txt",
             ref_text="hello",
             work_dir=root / "data" / "tts_bundles" / "installed" / "gpt_sovits_v2pro",
+            python_path=root / "data" / "tts_bundles" / "installed" / "gpt_sovits_v2pro" / "runtime" / "bin" / "python",
+            tts_config_path=(
+                root
+                / "data"
+                / "tts_bundles"
+                / "installed"
+                / "gpt_sovits_v2pro"
+                / "GPT_SoVITS"
+                / "configs"
+                / "tts_infer.yaml"
+            ),
             ref_lang="ja",
             text_lang="ja",
             timeout_seconds=22,
@@ -99,6 +110,14 @@ def test_settings_service_saves_runtime_config_to_yaml() -> None:
     assert api["llm"]["model"] == "demo-model"
     assert api["tts"]["provider"] == "gpt-sovits"
     assert api["tts"]["gpt_sovits"]["work_dir"] == "data/tts_bundles/installed/gpt_sovits_v2pro"
+    assert (
+        api["tts"]["gpt_sovits"]["python_path"]
+        == "data/tts_bundles/installed/gpt_sovits_v2pro/runtime/bin/python"
+    )
+    assert (
+        api["tts"]["gpt_sovits"]["tts_config_path"]
+        == "data/tts_bundles/installed/gpt_sovits_v2pro/GPT_SoVITS/configs/tts_infer.yaml"
+    )
     assert api["tts"]["gpt_sovits"]["timeout_seconds"] == 22
     assert characters["current_character_id"] == "nanami"
     assert system["mcp"]["windows_enabled"] is False
@@ -129,6 +148,8 @@ tts:
     settings = service.load_tts_settings(validate_enabled=False)
 
     assert settings.work_dir == root / "data" / "tts_bundles" / "installed" / "gpt_sovits_v2pro"
+    assert settings.python_path is None
+    assert settings.tts_config_path is None
 
     service.api_config_path.write_text(
         """
@@ -189,6 +210,8 @@ def test_settings_service_saves_and_loads_custom_gpt_sovits_settings() -> None:
         ref_text_path=root / "ref.txt",
         ref_text="hello",
         work_dir=root / "external" / "GPT-SoVITS",
+        python_path=root / "external" / "miniforge3" / "envs" / "gpt-sovits" / "bin" / "python",
+        tts_config_path=root / "external" / "GPT-SoVITS" / "GPT_SoVITS" / "configs" / "tts_infer.yaml",
         ref_lang="ja",
         text_lang="ja",
         timeout_seconds=44,
@@ -201,9 +224,13 @@ def test_settings_service_saves_and_loads_custom_gpt_sovits_settings() -> None:
     assert saved["tts"]["provider"] == TTS_PROVIDER_CUSTOM_GPT_SOVITS
     assert saved["tts"]["gpt_sovits"]["api_url"] == "http://192.168.1.20:9880/tts"
     assert saved["tts"]["gpt_sovits"]["work_dir"] == "external/GPT-SoVITS"
+    assert saved["tts"]["gpt_sovits"]["python_path"] == "external/miniforge3/envs/gpt-sovits/bin/python"
+    assert saved["tts"]["gpt_sovits"]["tts_config_path"] == "external/GPT-SoVITS/GPT_SoVITS/configs/tts_infer.yaml"
     assert loaded.provider == TTS_PROVIDER_CUSTOM_GPT_SOVITS
     assert loaded.api_url == "http://192.168.1.20:9880/tts"
     assert loaded.work_dir == root / "external" / "GPT-SoVITS"
+    assert loaded.python_path == root / "external" / "miniforge3" / "envs" / "gpt-sovits" / "bin" / "python"
+    assert loaded.tts_config_path == root / "external" / "GPT-SoVITS" / "GPT_SoVITS" / "configs" / "tts_infer.yaml"
     assert loaded.timeout_seconds == 44
 
 

--- a/tests/unit/test_tts.py
+++ b/tests/unit/test_tts.py
@@ -75,6 +75,7 @@ from app.voice.tts import (
     GPTSoVITSTTSProvider,
     GPTSoVITSTTSSettings,
     TTSPreparedAudio,
+    _build_gpt_sovits_start_command,
     _build_genie_endpoint_url,
     _load_tone_references,
     _resolve_request_text_lang,
@@ -287,7 +288,9 @@ def test_tts_provider_adopts_existing_local_process_on_init(monkeypatch) -> None
 def test_tts_service_probe_starts_local_gptsovits_when_port_is_down(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     work_dir = _runtime_root("gptsovits_start") / "gpt-sovits"
     (work_dir / "runtime").mkdir(parents=True)
-    (work_dir / "runtime" / "python.exe").write_text("fake", encoding="utf-8")
+    runtime_python = work_dir / "runtime" / "python.exe"
+    runtime_python.write_text("fake", encoding="utf-8")
+    runtime_python.chmod(0o755)
     (work_dir / "api_v2.py").write_text("fake", encoding="utf-8")
     monkeypatch.chdir(work_dir.parent)
     provider = types.SimpleNamespace()
@@ -328,8 +331,40 @@ def test_tts_service_probe_starts_local_gptsovits_when_port_is_down(monkeypatch)
     assert GPTSoVITSTTSProvider._ensure_service_available(provider, messages.append)
     assert messages == []
     assert len(popen_calls) == 1
-    assert popen_calls[0] == [str(work_dir / "runtime" / "python.exe"), str(work_dir / "api_v2.py")]
+    assert popen_calls[0] == [
+        str(work_dir / "runtime" / "python.exe"),
+        str(work_dir / "api_v2.py"),
+        "-a",
+        "127.0.0.1",
+        "-p",
+        "9880",
+    ]
     assert (work_dir.parent / "data" / "logs" / "gpt-sovits-service.log").is_file()
+
+
+def test_gptsovits_start_command_uses_custom_python_and_tts_config() -> None:
+    root = _runtime_root("gptsovits_custom_python")
+    work_dir = root / "GPT-SoVITS"
+    python_path = root / "miniforge3" / "envs" / "gpt-sovits" / "bin" / "python"
+    api_script = work_dir / "api_v2.py"
+    tts_config_path = work_dir / "GPT_SoVITS" / "configs" / "tts_infer_sakura.yaml"
+    settings = _minimal_tts_settings(
+        work_dir=work_dir,
+        api_url="http://localhost:9880/tts",
+        python_path=python_path,
+        tts_config_path=tts_config_path,
+    )
+
+    assert _build_gpt_sovits_start_command(python_path, api_script, settings) == [
+        str(python_path),
+        str(api_script),
+        "-c",
+        str(tts_config_path),
+        "-a",
+        "127.0.0.1",
+        "-p",
+        "9880",
+    ]
 
 
 def test_tts_service_probe_reports_missing_local_runtime(monkeypatch) -> None:  # type: ignore[no-untyped-def]
@@ -347,8 +382,33 @@ def test_tts_service_probe_reports_missing_local_runtime(monkeypatch) -> None:  
     monkeypatch.setattr("app.voice.tts.socket.create_connection", fake_create_connection)
 
     assert not GPTSoVITSTTSProvider._ensure_service_available(provider, messages.append)
-    assert "运行时不存在" in messages[0]
-    assert "python.exe" in messages[0]
+    assert "运行时不可用" in messages[0]
+    assert "未找到当前系统可执行的 Python 运行时" in messages[0]
+
+
+def test_tts_service_probe_reports_incompatible_windows_runtime_on_macos(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    work_dir = _runtime_root("gptsovits_incompatible_runtime") / "gpt-sovits"
+    runtime_python = work_dir / "runtime" / "python.exe"
+    runtime_python.parent.mkdir(parents=True)
+    runtime_python.write_bytes(b"MZ\x00\x00")
+    runtime_python.chmod(0o755)
+    (work_dir / "api_v2.py").write_text("fake", encoding="utf-8")
+    provider = types.SimpleNamespace()
+    provider.settings = _minimal_tts_settings(work_dir=work_dir)
+    provider._service_checked = False
+    provider._server_process = None
+    messages: list[str] = []
+
+    def fake_create_connection(*_args: object, **_kwargs: object) -> object:
+        raise OSError("connection refused")
+
+    monkeypatch.setattr("app.voice.tts.sys.platform", "darwin")
+    monkeypatch.setattr("app.voice.runtime_compat.sys.platform", "darwin")
+    monkeypatch.setattr("app.voice.tts.socket.create_connection", fake_create_connection)
+
+    assert not GPTSoVITSTTSProvider._ensure_service_available(provider, messages.append)
+    assert "检测到 Windows Python 运行时" in messages[0]
+    assert "当前系统是 macOS" in messages[0]
 
 
 def test_gptsovits_ensure_ready_returns_success_after_service_and_weights(monkeypatch) -> None:  # type: ignore[no-untyped-def]
@@ -407,7 +467,9 @@ def test_gptsovits_ensure_ready_returns_weight_failure(monkeypatch) -> None:  # 
 def test_genie_service_probe_starts_local_server_when_port_is_down(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     work_dir = _runtime_root("genie_start") / "genie"
     (work_dir / "runtime").mkdir(parents=True)
-    (work_dir / "runtime" / "python.exe").write_text("fake", encoding="utf-8")
+    runtime_python = work_dir / "runtime" / "python.exe"
+    runtime_python.write_text("fake", encoding="utf-8")
+    runtime_python.chmod(0o755)
     provider = types.SimpleNamespace()
     provider.settings = _minimal_tts_settings(provider="genie-tts", work_dir=work_dir, api_url="http://127.0.0.1:9881/")
     provider._service_checked = False
@@ -499,7 +561,9 @@ def test_genie_ensure_ready_returns_reference_failure(monkeypatch) -> None:  # t
 def test_genie_service_probe_moves_to_fallback_port_when_9880_is_gptsovits(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     work_dir = _runtime_root("genie_fallback_port") / "genie"
     (work_dir / "runtime").mkdir(parents=True)
-    (work_dir / "runtime" / "python.exe").write_text("fake", encoding="utf-8")
+    runtime_python = work_dir / "runtime" / "python.exe"
+    runtime_python.write_text("fake", encoding="utf-8")
+    runtime_python.chmod(0o755)
     provider = types.SimpleNamespace()
     provider.settings = _minimal_tts_settings(provider="genie-tts", work_dir=work_dir, api_url="http://127.0.0.1:9880/")
     provider._service_checked = False
@@ -934,6 +998,8 @@ def _minimal_tts_settings(
     *,
     provider: str = "gpt-sovits",
     api_url: str = "http://127.0.0.1:9880/tts",
+    python_path: Path | None = None,
+    tts_config_path: Path | None = None,
 ) -> GPTSoVITSTTSSettings:
     root = _runtime_root("minimal_tts")
     ref_audio_path = root / "voice" / "refs" / "tone_refs" / "neutral.wav"
@@ -952,6 +1018,8 @@ def _minimal_tts_settings(
         ref_text_path=ref_text_path,
         ref_text="テスト",
         work_dir=work_dir,
+        python_path=python_path,
+        tts_config_path=tts_config_path,
         character_name="夜乃桜",
         onnx_model_dir=Path("data/tts_bundles/onnx/sakura") if provider == "genie-tts" else None,
         ref_lang="ja",

--- a/tests/unit/test_tts_bundle.py
+++ b/tests/unit/test_tts_bundle.py
@@ -14,6 +14,7 @@ from app.voice.tts_bundle import (
     cleanup_stale_download_archives,
     default_provider_bundle_work_dir,
     download_and_extract_bundle,
+    install_tts_bundle,
 )
 
 
@@ -148,7 +149,8 @@ def test_tts_bundle_reports_extract_failure() -> None:
     assert archive.read_bytes() == payload
 
 
-def test_tts_bundle_cleans_legacy_archive_when_bundle_is_installed() -> None:
+def test_tts_bundle_cleans_legacy_archive_when_bundle_is_installed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(tts_bundle.sys, "platform", "win32")
     root = _runtime_root("cleanup_legacy_archive")
     entry = tts_bundle.GPT_SOVITS_STANDARD
     archive = root / "data" / "tts_bundles" / "downloads" / entry.filename
@@ -190,7 +192,8 @@ def test_tts_bundle_legacy_cleanup_preserves_uninstalled_and_unknown_archives() 
     assert unknown_archive.exists()
 
 
-def test_tts_bundle_default_provider_work_dir_uses_installed_root() -> None:
+def test_tts_bundle_default_provider_work_dir_uses_installed_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(tts_bundle.sys, "platform", "win32")
     root = _runtime_root("default_provider_work_dir")
     work_dir = (
         root
@@ -207,12 +210,14 @@ def test_tts_bundle_default_provider_work_dir_uses_installed_root() -> None:
     assert default_provider_bundle_work_dir("gpt-sovits", root) == work_dir.resolve()
 
 
-def test_tts_bundle_recommends_genie_for_cpu_or_small_gpu() -> None:
+def test_tts_bundle_recommends_genie_for_cpu_or_small_gpu(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(tts_bundle.sys, "platform", "win32")
     assert tts_bundle.recommend_tts_bundle([]).key == "genie_tts_server"
     assert tts_bundle.recommend_tts_bundle([GPUInfo("NVIDIA GeForce GTX 1050 Ti", 4.0)]).key == "genie_tts_server"
 
 
-def test_tts_bundle_recommends_gptsovits_for_capable_nvidia() -> None:
+def test_tts_bundle_recommends_gptsovits_for_capable_nvidia(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(tts_bundle.sys, "platform", "win32")
     assert tts_bundle.recommend_tts_bundle([GPUInfo("NVIDIA GeForce GTX 1060", 6.0)]).key == "gpt_sovits_v2pro"
     assert tts_bundle.recommend_tts_bundle([GPUInfo("NVIDIA GeForce GTX 1060", 5.96)]).key == "gpt_sovits_v2pro"
     assert tts_bundle.recommend_tts_bundle([GPUInfo("NVIDIA GeForce RTX 4070", 12.0)]).key == "gpt_sovits_v2pro"
@@ -221,7 +226,90 @@ def test_tts_bundle_recommends_gptsovits_for_capable_nvidia() -> None:
 
 
 def test_tts_bundle_label_includes_approx_size() -> None:
-    assert tts_bundle.format_bundle_label(tts_bundle.GPT_SOVITS_NVIDIA50).endswith("（约 8.8 GB）")
+    assert tts_bundle.format_bundle_label(tts_bundle.GPT_SOVITS_NVIDIA50).endswith("（约 8.8 GB，仅 Windows）")
+
+
+def test_tts_bundle_filters_incompatible_platform(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(tts_bundle.sys, "platform", "darwin")
+
+    assert tts_bundle.compatible_tts_bundles() == (tts_bundle.GPT_SOVITS_MACOS_INSTALLER,)
+    assert tts_bundle.recommend_tts_bundle([]) == tts_bundle.GPT_SOVITS_MACOS_INSTALLER
+    assert "GPT-SoVITS macOS" in tts_bundle.format_gpu_summary([])
+
+    monkeypatch.setattr(tts_bundle.sys, "platform", "win32")
+
+    assert tts_bundle.GPT_SOVITS_MACOS_INSTALLER not in tts_bundle.compatible_tts_bundles()
+    assert tts_bundle.GENIE_TTS in tts_bundle.compatible_tts_bundles()
+    assert tts_bundle.GPT_SOVITS_STANDARD in tts_bundle.compatible_tts_bundles()
+
+
+def test_tts_bundle_rejects_incompatible_platform_before_download(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(tts_bundle.sys, "platform", "darwin")
+    root = _runtime_root("bundle_incompatible_platform")
+
+    def fail_urlopen(_request, _timeout: int):  # type: ignore[no-untyped-def]
+        raise AssertionError("平台不兼容时不应开始下载")
+
+    with pytest.raises(RuntimeError, match="不支持当前平台"):
+        download_and_extract_bundle(
+            tts_bundle.GPT_SOVITS_STANDARD,
+            root,
+            urlopen=fail_urlopen,
+            extractor=lambda *_args: None,
+        )
+
+
+def test_tts_bundle_runs_script_installer_and_returns_runtime_paths() -> None:
+    root = _runtime_root("bundle_script_installer")
+    script = root / "fake_installer.sh"
+    script.write_text(
+        """#!/bin/bash
+set -e
+install_root="$1"
+echo "::sakura-progress status=install progress=50"
+mkdir -p "$install_root/GPT-SoVITS/GPT_SoVITS/configs"
+mkdir -p "$install_root/miniforge3/envs/gpt-sovits310/bin"
+echo "fake api" > "$install_root/GPT-SoVITS/api_v2.py"
+echo "custom: {}" > "$install_root/GPT-SoVITS/GPT_SoVITS/configs/tts_infer_sakura_macos.yaml"
+echo '#!/bin/sh' > "$install_root/miniforge3/envs/gpt-sovits310/bin/python"
+chmod +x "$install_root/miniforge3/envs/gpt-sovits310/bin/python"
+""",
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+    entry = TTSBundleEntry(
+        key="script_demo",
+        label="Script Demo",
+        provider="custom-gpt-sovits",
+        install_method="script",
+        installer_script="fake_installer.sh",
+        work_dir_name="GPT-SoVITS",
+        python_path_name="miniforge3/envs/gpt-sovits310/bin/python",
+        tts_config_path_name="GPT-SoVITS/GPT_SoVITS/configs/tts_infer_sakura_macos.yaml",
+    )
+    progress: list[int] = []
+    statuses: list[str] = []
+
+    result = install_tts_bundle(entry, root, on_progress=progress.append, on_status=statuses.append)
+
+    assert result.provider == "custom-gpt-sovits"
+    assert result.work_dir == (
+        root / "data" / "tts_bundles" / "installed" / entry.key / "GPT-SoVITS"
+    ).resolve()
+    assert result.python_path == (
+        root / "data" / "tts_bundles" / "installed" / entry.key / "miniforge3/envs/gpt-sovits310/bin/python"
+    ).resolve()
+    assert result.tts_config_path == (
+        root
+        / "data"
+        / "tts_bundles"
+        / "installed"
+        / entry.key
+        / "GPT-SoVITS/GPT_SoVITS/configs/tts_infer_sakura_macos.yaml"
+    ).resolve()
+    assert "install" in statuses
+    assert 50 in progress
+    assert progress[-1] == 100
 
 
 def test_extract_archive_prefers_py7zz(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
原有的一键 TTS 整合包主要面向 Windows，内置运行时依赖 python.exe，在 macOS 上无法直接启动，容易触发运行时不兼容问题。
同时，macOS release 包根目录下的 install.command / start.command 会指向不存在的根目录 install.sh / start.sh，实际只有 scripts/ 目录下的命令脚本可以正常工作。
1.为 macOS 增加可用的 GPT-SoVITS 源码版安装与启动配置，支持从角色包读取并切换 voice/models/ 内的 GPT/SoVITS 权重。该安装项只部署 GPT-SoVITS 运行环境，不单独下载角色声线模型。
2.修复 macOS release 根目录下 install.command / start.command 的错误指向，使其正确调用 scripts/install.sh 和 scripts/start.sh。
