### PR TITLE
test: make fake TTS runtimes executable

### DIFF
--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -1032,6 +1032,11 @@ def _ui_runtime_root(name: str) -> Path:
     return root
 
 
+def _write_fake_runtime_python(path: Path, content: str = "fake") -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
 def test_settings_dialog_allows_import_without_existing_character_registry(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
     qtwidgets = pytest.importorskip("PySide6.QtWidgets")
@@ -2236,7 +2241,7 @@ tts:
         / "python.exe"
     )
     runtime_python.parent.mkdir(parents=True)
-    runtime_python.write_text("fake", encoding="utf-8")
+    _write_fake_runtime_python(runtime_python)
 
     migrations = sakura_main._pending_startup_tts_migrations(root)
 
@@ -2265,7 +2270,7 @@ tts:
     )
     gpt_runtime = root / "tts" / "g50" / "runtime" / "python.exe"
     gpt_runtime.parent.mkdir(parents=True)
-    gpt_runtime.write_text("gpt", encoding="utf-8")
+    _write_fake_runtime_python(gpt_runtime, "gpt")
     genie_runtime = (
         root
         / "data"
@@ -2277,7 +2282,7 @@ tts:
         / "python.exe"
     )
     genie_runtime.parent.mkdir(parents=True)
-    genie_runtime.write_text("genie", encoding="utf-8")
+    _write_fake_runtime_python(genie_runtime, "genie")
 
     migrations = sakura_main._pending_startup_tts_migrations(root)
 

--- a/tests/unit/test_tts.py
+++ b/tests/unit/test_tts.py
@@ -1077,6 +1077,6 @@ def _runtime_root(name: str) -> Path:
     return root
 
 
-def _write_fake_runtime_python(path: Path) -> None:
-    path.write_text("fake", encoding="utf-8")
+def _write_fake_runtime_python(path: Path, content: str = "fake") -> None:
+    path.write_text(content, encoding="utf-8")
     path.chmod(0o755)

--- a/tests/unit/test_tts.py
+++ b/tests/unit/test_tts.py
@@ -222,7 +222,7 @@ def test_tts_service_probe_does_not_start_process_when_port_is_ready(monkeypatch
 def test_genie_service_probe_adopts_existing_local_process_when_port_is_ready(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     work_dir = _runtime_root("genie_adopt") / "genie"
     (work_dir / "runtime").mkdir(parents=True)
-    (work_dir / "runtime" / "python.exe").write_text("fake", encoding="utf-8")
+    _write_fake_runtime_python(work_dir / "runtime" / "python.exe")
     provider = types.SimpleNamespace()
     provider.settings = _minimal_tts_settings(provider="genie-tts", work_dir=work_dir, api_url="http://127.0.0.1:9881/")
     provider._service_checked = False
@@ -290,8 +290,7 @@ def test_tts_service_probe_starts_local_gptsovits_when_port_is_down(monkeypatch)
     work_dir = _runtime_root("gptsovits_start") / "gpt-sovits"
     (work_dir / "runtime").mkdir(parents=True)
     runtime_python = work_dir / "runtime" / "python.exe"
-    runtime_python.write_text("fake", encoding="utf-8")
-    runtime_python.chmod(0o755)
+    _write_fake_runtime_python(runtime_python)
     (work_dir / "api_v2.py").write_text("fake", encoding="utf-8")
     monkeypatch.chdir(work_dir.parent)
     provider = types.SimpleNamespace()
@@ -371,7 +370,7 @@ def test_gptsovits_start_command_uses_custom_python_and_tts_config() -> None:
 def test_tts_service_waits_past_thirty_seconds_for_slow_gptsovits_start(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     work_dir = _runtime_root("gptsovits_slow_start") / "gpt-sovits"
     (work_dir / "runtime").mkdir(parents=True)
-    (work_dir / "runtime" / "python.exe").write_text("fake", encoding="utf-8")
+    _write_fake_runtime_python(work_dir / "runtime" / "python.exe")
     (work_dir / "api_v2.py").write_text("fake", encoding="utf-8")
     monkeypatch.chdir(work_dir.parent)
     provider = types.SimpleNamespace()
@@ -514,8 +513,7 @@ def test_genie_service_probe_starts_local_server_when_port_is_down(monkeypatch) 
     work_dir = _runtime_root("genie_start") / "genie"
     (work_dir / "runtime").mkdir(parents=True)
     runtime_python = work_dir / "runtime" / "python.exe"
-    runtime_python.write_text("fake", encoding="utf-8")
-    runtime_python.chmod(0o755)
+    _write_fake_runtime_python(runtime_python)
     provider = types.SimpleNamespace()
     provider.settings = _minimal_tts_settings(provider="genie-tts", work_dir=work_dir, api_url="http://127.0.0.1:9881/")
     provider._service_checked = False
@@ -608,8 +606,7 @@ def test_genie_service_probe_moves_to_fallback_port_when_9880_is_gptsovits(monke
     work_dir = _runtime_root("genie_fallback_port") / "genie"
     (work_dir / "runtime").mkdir(parents=True)
     runtime_python = work_dir / "runtime" / "python.exe"
-    runtime_python.write_text("fake", encoding="utf-8")
-    runtime_python.chmod(0o755)
+    _write_fake_runtime_python(runtime_python)
     provider = types.SimpleNamespace()
     provider.settings = _minimal_tts_settings(provider="genie-tts", work_dir=work_dir, api_url="http://127.0.0.1:9880/")
     provider._service_checked = False
@@ -1078,3 +1075,8 @@ def _runtime_root(name: str) -> Path:
     root = Path(__file__).resolve().parents[2] / "__pycache__" / "test_runtime" / name / uuid.uuid4().hex
     root.mkdir(parents=True, exist_ok=True)
     return root
+
+
+def _write_fake_runtime_python(path: Path) -> None:
+    path.write_text("fake", encoding="utf-8")
+    path.chmod(0o755)

--- a/tests/unit/test_tts_bundle.py
+++ b/tests/unit/test_tts_bundle.py
@@ -165,7 +165,7 @@ def test_tts_bundle_flattens_single_extracted_root() -> None:
     def fake_extract(_archive: Path, out_dir: Path) -> str | None:
         runtime_python = out_dir / "GPT-SoVITS" / "runtime" / "python.exe"
         runtime_python.parent.mkdir(parents=True)
-        runtime_python.write_text("fake", encoding="utf-8")
+        _write_fake_runtime_python(runtime_python)
         return None
 
     work_dir = download_and_extract_bundle(entry, root, urlopen=fake_urlopen, extractor=fake_extract)
@@ -193,7 +193,7 @@ def test_tts_bundle_cleans_legacy_archive_when_bundle_is_installed(monkeypatch: 
         / "python.exe"
     )
     runtime_python.parent.mkdir(parents=True, exist_ok=True)
-    runtime_python.write_text("fake", encoding="utf-8")
+    _write_fake_runtime_python(runtime_python)
 
     cleaned = cleanup_stale_download_archives(root)
 
@@ -231,17 +231,18 @@ def test_tts_bundle_default_provider_work_dir_uses_installed_root(monkeypatch: p
     )
     runtime_python = work_dir / "runtime" / "python.exe"
     runtime_python.parent.mkdir(parents=True)
-    runtime_python.write_text("fake", encoding="utf-8")
+    _write_fake_runtime_python(runtime_python)
 
     assert default_provider_bundle_work_dir("gpt-sovits", root) == work_dir.resolve()
 
 
-def test_tts_bundle_default_provider_prefers_short_installed_root() -> None:
+def test_tts_bundle_default_provider_prefers_short_installed_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(tts_bundle.sys, "platform", "win32")
     root = _runtime_root("default_provider_short_work_dir")
     work_dir = root / "tts" / "g50"
     runtime_python = work_dir / "runtime" / "python.exe"
     runtime_python.parent.mkdir(parents=True)
-    runtime_python.write_text("fake", encoding="utf-8")
+    _write_fake_runtime_python(runtime_python)
 
     assert default_provider_bundle_work_dir("gpt-sovits", root) == work_dir.resolve()
 
@@ -259,7 +260,7 @@ def test_tts_bundle_detects_and_migrates_legacy_install() -> None:
     )
     runtime_python = legacy_work_dir / "runtime" / "python.exe"
     runtime_python.parent.mkdir(parents=True)
-    runtime_python.write_text("fake", encoding="utf-8")
+    _write_fake_runtime_python(runtime_python)
 
     migrations = find_pending_bundle_migrations(root, "gpt-sovits")
 
@@ -289,7 +290,7 @@ def test_tts_bundle_migration_copies_with_progress(monkeypatch: pytest.MonkeyPat
     model_file = legacy_work_dir / "models" / "demo.bin"
     runtime_python.parent.mkdir(parents=True)
     model_file.parent.mkdir(parents=True)
-    runtime_python.write_text("fake", encoding="utf-8")
+    _write_fake_runtime_python(runtime_python)
     model_file.write_bytes(b"model")
     migration = find_pending_bundle_migrations(root, "gpt-sovits")[0]
     progress: list[tts_bundle.TTSBundleMigrationProgress] = []
@@ -315,12 +316,12 @@ def test_tts_bundle_migration_resumes_existing_staging_file(monkeypatch: pytest.
     voice_file = legacy_work_dir / "voices" / "demo.dat"
     runtime_python.parent.mkdir(parents=True)
     voice_file.parent.mkdir(parents=True)
-    runtime_python.write_text("fake", encoding="utf-8")
+    _write_fake_runtime_python(runtime_python)
     voice_file.write_text("voice", encoding="utf-8")
     migration = find_pending_bundle_migrations(root, "genie-tts")[0]
     staging_runtime = root / "tts" / ".migrating" / entry.key / "runtime" / "python.exe"
     staging_runtime.parent.mkdir(parents=True)
-    staging_runtime.write_text("fake", encoding="utf-8")
+    _write_fake_runtime_python(staging_runtime)
     original_copy = tts_bundle._copy_file_resumable
     copied: list[str] = []
 
@@ -346,7 +347,7 @@ def test_tts_bundle_migration_cleans_empty_legacy_dirs_but_keeps_onnx() -> None:
     legacy_work_dir = root / "data" / "tts_bundles" / "installed" / entry.key / "Genie-TTS Server"
     runtime_python = legacy_work_dir / "runtime" / "python.exe"
     runtime_python.parent.mkdir(parents=True)
-    runtime_python.write_text("fake", encoding="utf-8")
+    _write_fake_runtime_python(runtime_python)
     downloads_dir = root / "data" / "tts_bundles" / "downloads"
     downloads_dir.mkdir(parents=True)
     onnx_file = root / "data" / "tts_bundles" / "onnx" / "sakura" / "model.onnx"
@@ -378,9 +379,9 @@ def test_tts_bundle_migration_skips_existing_short_dir() -> None:
         / "python.exe"
     )
     short_runtime.parent.mkdir(parents=True)
-    short_runtime.write_text("short", encoding="utf-8")
+    _write_fake_runtime_python(short_runtime, "short")
     legacy_runtime.parent.mkdir(parents=True)
-    legacy_runtime.write_text("legacy", encoding="utf-8")
+    _write_fake_runtime_python(legacy_runtime, "legacy")
 
     migrations = find_pending_bundle_migrations(root, "gpt-sovits")
 
@@ -405,7 +406,7 @@ def test_tts_bundle_migration_replaces_invalid_short_dir() -> None:
     )
     runtime_python = legacy_work_dir / "runtime" / "python.exe"
     runtime_python.parent.mkdir(parents=True)
-    runtime_python.write_text("legacy", encoding="utf-8")
+    _write_fake_runtime_python(runtime_python, "legacy")
 
     migrations = find_pending_bundle_migrations(root, "gpt-sovits")
 
@@ -426,7 +427,7 @@ def test_tts_bundle_migration_failure_preserves_legacy_install(monkeypatch: pyte
     legacy_work_dir = root / "data" / "tts_bundles" / "installed" / entry.key / "Genie-TTS Server"
     runtime_python = legacy_work_dir / "runtime" / "python.exe"
     runtime_python.parent.mkdir(parents=True)
-    runtime_python.write_text("fake", encoding="utf-8")
+    _write_fake_runtime_python(runtime_python)
     migration = find_pending_bundle_migrations(root, "genie-tts")[0]
 
     def fail_copy(_source: Path, _target: Path) -> None:
@@ -457,7 +458,7 @@ def test_tts_bundle_normalizes_legacy_config_path_after_migration() -> None:
     short_work_dir = root / "tts" / "gpt"
     runtime_python = short_work_dir / "runtime" / "python.exe"
     runtime_python.parent.mkdir(parents=True)
-    runtime_python.write_text("fake", encoding="utf-8")
+    _write_fake_runtime_python(runtime_python)
 
     assert normalize_bundle_work_dir(legacy_work_dir, root) == short_work_dir.resolve()
 
@@ -744,3 +745,8 @@ def _runtime_root(name: str) -> Path:
     root = Path(__file__).resolve().parents[2] / "__pycache__" / "test_runtime" / name / uuid.uuid4().hex
     root.mkdir(parents=True, exist_ok=True)
     return root
+
+
+def _write_fake_runtime_python(path: Path, content: str = "fake") -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)


### PR DESCRIPTION
问题
合并 #9 后，macOS CI 上部分单元测试失败。

根因：find_usable_runtime_python 在非 Windows 平台会通过 os.access(path, os.X_OK) 检查执行权限，而测试中通过 write_text() 创建的假 Python 文件默认权限为 0644（无执行位），导致运行时发现逻辑返回 None，断言失败。

此外，test_tts_bundle_default_provider_prefers_short_installed_root 测试的是仅 Windows 可用的短路径 bundle（tts/g50），在 macOS 上 is_bundle_supported() 直接返回 False，导致测试失败。

改动
在 test_tts.py、test_tts_bundle.py、test_pet_window.py 中提取 _write_fake_runtime_python(path, content="fake") 辅助函数，写入后统一 chmod(0o755)，共替换 22 处调用。
为 test_tts_bundle_default_provider_prefers_short_installed_root 添加 monkeypatch.setattr(tts_bundle.sys, "platform", "win32")，使其在 macOS 上也能正确发现 Windows-only bundle。