### PR TITLE
Fix/macos tts UI

### DIFF
--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -18,11 +18,13 @@ from PySide6.QtCore import (
     Slot,
 )
 from PySide6.QtGui import (
+    QColor,
     QCursor,
     QFont,
     QIcon,
     QKeyEvent,
     QMouseEvent,
+    QPainter,
     QPixmap,
 )
 from PySide6.QtWidgets import (
@@ -218,6 +220,7 @@ class PetWindow(QWidget):
         self.pending_screen_observation_event_reminder_id: str | None = None
         self.pending_visual_observation_jobs: list[VisualObservationJob] = []
         self.pending_event_visual_observation_jobs: list[VisualObservationJob] = []
+        self.hidden_to_tray = False
         self.screen_observation_followup_in_progress = False
         self.active_reminder_id: str | None = None
         self.active_reminder_text = ""
@@ -466,6 +469,8 @@ class PetWindow(QWidget):
         application = QApplication.instance()
         if application is not None:
             application.aboutToQuit.connect(self.close_external_tools)
+            if sys.platform == "darwin":
+                application.installEventFilter(self)
 
     def resizeEvent(self, event) -> None:  # type: ignore[no-untyped-def]
         super().resizeEvent(event)
@@ -473,7 +478,12 @@ class PetWindow(QWidget):
 
     def showEvent(self, event) -> None:  # type: ignore[no-untyped-def]
         super().showEvent(event)
+        self._refresh_tray_menu()
         self._schedule_native_topmost_sync()
+
+    def hideEvent(self, event) -> None:  # type: ignore[no-untyped-def]
+        super().hideEvent(event)
+        self._refresh_tray_menu()
 
     def changeEvent(self, event) -> None:  # type: ignore[no-untyped-def]
         super().changeEvent(event)
@@ -484,6 +494,11 @@ class PetWindow(QWidget):
             self._schedule_native_topmost_sync()
 
     def eventFilter(self, watched, event) -> bool:  # type: ignore[no-untyped-def]
+        application = QApplication.instance()
+        if application is not None and watched is application:
+            if event.type() == QEvent.Type.ApplicationActivate:
+                self._handle_application_activated()
+            return super().eventFilter(watched, event)
         if watched is self.input_edit:
             if event.type() == QEvent.Type.KeyPress:
                 self._log_input_key_event(event)
@@ -496,7 +511,13 @@ class PetWindow(QWidget):
                 self._clear_manual_screen_observation()
                 return True
             return super().eventFilter(watched, event)
-        if isinstance(event, QMouseEvent):
+        if watched in {
+            self.label,
+            self.portrait_transition_label,
+            self.bubble,
+            self.name_label,
+            self.speech_label,
+        } and isinstance(event, QMouseEvent):
             if event.type() == QEvent.Type.MouseButtonPress:
                 return self._handle_mouse_press(event)
             if event.type() == QEvent.Type.MouseMove:
@@ -724,8 +745,9 @@ class PetWindow(QWidget):
         self.input_bar.raise_()
 
     def _update_tray_icon_pixmap(self, pixmap: QPixmap) -> None:
+        _ = pixmap
         if hasattr(self, "tray_icon"):
-            self.tray_icon.setIcon(QIcon(pixmap) if not pixmap.isNull() else QIcon())
+            self.tray_icon.setIcon(_build_status_tray_icon(self.theme_settings.primary_color))
 
     def _apply_fonts(self) -> None:
         text_font = _rounded_chinese_font(13, QFont.Weight.Bold)
@@ -779,8 +801,7 @@ class PetWindow(QWidget):
         self.input_backdrop.update()
 
     def _create_tray_icon(self) -> None:
-        pixmap = self.portrait_controller.pixmap
-        icon = QIcon(pixmap) if not pixmap.isNull() else QIcon()
+        icon = _build_status_tray_icon(self.theme_settings.primary_color)
         self.tray_icon = QSystemTrayIcon(icon, self)
         self.tray_icon.setToolTip(self.character_profile.display_name)
         self.tray_icon.setContextMenu(self._build_menu())
@@ -794,13 +815,22 @@ class PetWindow(QWidget):
             free_access_checked=self.free_access_enabled,
             always_on_top_checked=self.always_on_top_enabled,
             interactions_enabled=not getattr(self, "startup_initializing", False),
-            on_hide=self.hide,
+            window_visible=self.isVisible(),
+            on_hide=self._hide_to_tray,
+            on_show=self._show_from_tray,
             on_toggle_chinese_subtitles=self._toggle_chinese_subtitles,
             on_toggle_free_access=self._toggle_free_access,
             on_toggle_always_on_top=self._toggle_always_on_top,
             on_show_history=self.show_history,
             on_show_settings=self.show_settings,
         )
+
+    def _refresh_tray_menu(self) -> None:
+        if hasattr(self, "tray_icon"):
+            old_menu = self.tray_icon.contextMenu()
+            self.tray_icon.setContextMenu(self._build_menu())
+            if old_menu is not None:
+                old_menu.deleteLater()
 
     def _show_context_menu(self, position: QPoint) -> None:
         _ = position
@@ -2187,10 +2217,27 @@ class PetWindow(QWidget):
 
     def toggle_visible(self) -> None:
         if self.isVisible():
-            self.hide()
+            self._hide_to_tray()
         else:
-            self.show()
-            self.raise_()
+            self._show_from_tray()
+
+    @Slot()
+    def _hide_to_tray(self) -> None:
+        self.hidden_to_tray = True
+        self.hide()
+        self._refresh_tray_menu()
+
+    @Slot()
+    def _show_from_tray(self) -> None:
+        self.hidden_to_tray = False
+        self.show()
+        self.raise_()
+        self.activateWindow()
+        self._refresh_tray_menu()
+
+    def _handle_application_activated(self) -> None:
+        if getattr(self, "hidden_to_tray", False):
+            QTimer.singleShot(0, self._show_from_tray)
 
     @Slot()
     def show_history(self) -> None:
@@ -2745,6 +2792,8 @@ class PetWindow(QWidget):
         self.setStyleSheet(pet_window_stylesheet(self.theme_settings))
         if self.history_window is not None:
             self.history_window.set_theme_settings(self.theme_settings)
+        if hasattr(self, "tray_icon"):
+            self.tray_icon.setIcon(_build_status_tray_icon(self.theme_settings.primary_color))
 
     def _apply_character(self, profile: CharacterProfile) -> None:
         previous_character_id = self.character_profile.id
@@ -2755,10 +2804,10 @@ class PetWindow(QWidget):
         self.setWindowTitle(profile.display_name)
         self.name_label.setText(profile.display_name)
         self.input_edit.setPlaceholderText(f"和{profile.display_name}说点什么...")
-        portrait_pixmap = self.portrait_controller.set_profile(profile)
+        self.portrait_controller.set_profile(profile)
         if hasattr(self, "tray_icon"):
             self.tray_icon.setToolTip(profile.display_name)
-            self.tray_icon.setIcon(QIcon(portrait_pixmap) if not portrait_pixmap.isNull() else QIcon())
+            self.tray_icon.setIcon(_build_status_tray_icon(self.theme_settings.primary_color))
 
         self.history_store = self._create_history_store(profile)
         self.visual_observation_store = self._create_visual_observation_store(profile)
@@ -3050,6 +3099,26 @@ def _configure_reply_history_button(button: QToolButton, *, text: str, tooltip: 
     button.setFixedSize(REPLY_HISTORY_BUTTON_SIZE, REPLY_HISTORY_BUTTON_SIZE)
     button.setToolTip(tooltip)
 
+
+def _build_status_tray_icon(color_text: str) -> QIcon:
+    color = QColor(color_text)
+    if not color.isValid():
+        color = QColor(DEFAULT_THEME_SETTINGS.primary_color)
+
+    pixmap = QPixmap(32, 32)
+    pixmap.fill(Qt.GlobalColor.transparent)
+
+    painter = QPainter(pixmap)
+    painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+    painter.setPen(Qt.PenStyle.NoPen)
+    painter.setBrush(color)
+    painter.drawEllipse(3, 3, 26, 26)
+    painter.setPen(QColor("#ffffff"))
+    painter.setFont(_rounded_chinese_font(18, QFont.Weight.ExtraBold))
+    painter.drawText(pixmap.rect(), Qt.AlignmentFlag.AlignCenter, "S")
+    painter.end()
+
+    return QIcon(pixmap)
 
 
 def _set_macos_window_topmost(window_id: int, enabled: bool) -> None:

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -471,6 +471,18 @@ class PetWindow(QWidget):
         super().resizeEvent(event)
         self._layout_stage()
 
+    def showEvent(self, event) -> None:  # type: ignore[no-untyped-def]
+        super().showEvent(event)
+        self._schedule_native_topmost_sync()
+
+    def changeEvent(self, event) -> None:  # type: ignore[no-untyped-def]
+        super().changeEvent(event)
+        if event.type() in {
+            QEvent.Type.ActivationChange,
+            QEvent.Type.WindowStateChange,
+        }:
+            self._schedule_native_topmost_sync()
+
     def eventFilter(self, watched, event) -> bool:  # type: ignore[no-untyped-def]
         if watched is self.input_edit:
             if event.type() == QEvent.Type.KeyPress:
@@ -2669,25 +2681,37 @@ class PetWindow(QWidget):
         self.setWindowFlags(self._window_flags())
         if was_visible:
             self.show()
-            self._sync_native_topmost_state()
+            self._schedule_native_topmost_sync()
+
+    def _schedule_native_topmost_sync(self) -> None:
+        if sys.platform not in {"win32", "darwin"}:
+            return
+        QTimer.singleShot(0, self._sync_native_topmost_state)
 
     def _sync_native_topmost_state(self) -> None:
-        if sys.platform != "win32" or not self.isVisible():
+        if not self.isVisible():
             return
-        try:
-            import ctypes
+        if sys.platform == "win32":
+            try:
+                import ctypes
 
-            hwnd = int(self.winId())
-            hwnd_topmost = -1
-            hwnd_notopmost = -2
-            swp_no_size = 0x0001
-            swp_no_move = 0x0002
-            swp_no_activate = 0x0010
-            insert_after = hwnd_topmost if self.always_on_top_enabled else hwnd_notopmost
-            flags = swp_no_size | swp_no_move | swp_no_activate
-            ctypes.windll.user32.SetWindowPos(hwnd, insert_after, 0, 0, 0, 0, flags)
-        except Exception as exc:  # noqa: BLE001
-            debug_log("PetWindow", "同步原生置顶状态失败", {"error": str(exc)})
+                hwnd = int(self.winId())
+                hwnd_topmost = -1
+                hwnd_notopmost = -2
+                swp_no_size = 0x0001
+                swp_no_move = 0x0002
+                swp_no_activate = 0x0010
+                insert_after = hwnd_topmost if self.always_on_top_enabled else hwnd_notopmost
+                flags = swp_no_size | swp_no_move | swp_no_activate
+                ctypes.windll.user32.SetWindowPos(hwnd, insert_after, 0, 0, 0, 0, flags)
+            except Exception as exc:  # noqa: BLE001
+                debug_log("PetWindow", "同步原生置顶状态失败", {"error": str(exc)})
+            return
+        if sys.platform == "darwin":
+            try:
+                _set_macos_window_topmost(int(self.winId()), self.always_on_top_enabled)
+            except Exception as exc:  # noqa: BLE001
+                debug_log("PetWindow", "同步 macOS 原生置顶状态失败", {"error": str(exc)})
 
     def _apply_portrait_scale_percent(self, portrait_scale_percent: int) -> None:
         self.portrait_scale_percent = normalize_portrait_scale_percent(portrait_scale_percent)
@@ -3025,3 +3049,79 @@ def _configure_reply_history_button(button: QToolButton, *, text: str, tooltip: 
     button.setText(text)
     button.setFixedSize(REPLY_HISTORY_BUTTON_SIZE, REPLY_HISTORY_BUTTON_SIZE)
     button.setToolTip(tooltip)
+
+
+
+def _set_macos_window_topmost(window_id: int, enabled: bool) -> None:
+    """同步 macOS NSWindow 层级，确保置顶窗口能跟随当前 Space。"""
+
+    import ctypes
+    import ctypes.util
+
+    objc = ctypes.CDLL(ctypes.util.find_library("objc") or "/usr/lib/libobjc.A.dylib")
+    sel_register_name = objc.sel_registerName
+    sel_register_name.argtypes = [ctypes.c_char_p]
+    sel_register_name.restype = ctypes.c_void_p
+
+    def selector(name: bytes) -> int:
+        return int(sel_register_name(name))
+
+    def message(restype: object, *argtypes: object) -> object:
+        return ctypes.CFUNCTYPE(restype, ctypes.c_void_p, ctypes.c_void_p, *argtypes)(
+            ("objc_msgSend", objc)
+        )
+
+    send_bool = message(ctypes.c_bool, ctypes.c_void_p)
+    send_ptr = message(ctypes.c_void_p)
+    send_level = message(None, ctypes.c_long)
+    send_hides_on_deactivate = message(None, ctypes.c_bool)
+    send_ulong = message(ctypes.c_ulong)
+    send_collection = message(None, ctypes.c_ulong)
+
+    obj = ctypes.c_void_p(window_id)
+    sel_window = selector(b"window")
+    sel_responds_to_selector = selector(b"respondsToSelector:")
+    if send_bool(obj, ctypes.c_void_p(sel_responds_to_selector), ctypes.c_void_p(sel_window)):
+        ns_window = send_ptr(obj, ctypes.c_void_p(sel_window))
+        if not ns_window:
+            return
+    else:
+        ns_window = window_id
+
+    ns_window_ptr = ctypes.c_void_p(int(ns_window))
+    ns_window_collection_behavior_can_join_all_spaces = 1 << 0
+    ns_window_collection_behavior_move_to_active_space = 1 << 1
+    ns_window_collection_behavior_full_screen_auxiliary = 1 << 8
+    ns_floating_window_level = 3
+    ns_modal_panel_window_level = 8
+
+    level = ns_modal_panel_window_level if enabled else ns_floating_window_level
+    send_level(ns_window_ptr, ctypes.c_void_p(selector(b"setLevel:")), level)
+
+    sel_set_hides_on_deactivate = selector(b"setHidesOnDeactivate:")
+    if send_bool(
+        ns_window_ptr,
+        ctypes.c_void_p(sel_responds_to_selector),
+        ctypes.c_void_p(sel_set_hides_on_deactivate),
+    ):
+        send_hides_on_deactivate(
+            ns_window_ptr,
+            ctypes.c_void_p(sel_set_hides_on_deactivate),
+            not enabled,
+        )
+
+    collection_behavior = int(send_ulong(ns_window_ptr, ctypes.c_void_p(selector(b"collectionBehavior"))))
+    if enabled:
+        collection_behavior |= (
+            ns_window_collection_behavior_can_join_all_spaces
+            | ns_window_collection_behavior_full_screen_auxiliary
+        )
+        collection_behavior &= ~ns_window_collection_behavior_move_to_active_space
+    else:
+        collection_behavior &= ~ns_window_collection_behavior_can_join_all_spaces
+        collection_behavior |= ns_window_collection_behavior_move_to_active_space
+    send_collection(
+        ns_window_ptr,
+        ctypes.c_void_p(selector(b"setCollectionBehavior:")),
+        collection_behavior,
+    )

--- a/app/ui/tray_menu.py
+++ b/app/ui/tray_menu.py
@@ -13,20 +13,22 @@ def build_pet_tray_menu(
     free_access_checked: bool,
     always_on_top_checked: bool,
     on_hide: Callable[[], None],
+    on_show: Callable[[], None],
     on_toggle_chinese_subtitles: Callable[[bool], None],
     on_toggle_free_access: Callable[[bool], None],
     on_toggle_always_on_top: Callable[[bool], None],
     on_show_history: Callable[[], None],
     on_show_settings: Callable[[], None],
+    window_visible: bool = True,
     interactions_enabled: bool = True,
 ) -> QMenu:
     """构建桌宠托盘和右键菜单。"""
 
     menu = QMenu(parent)
 
-    hide_action = QAction("隐藏至托盘", parent)
-    hide_action.triggered.connect(on_hide)
-    menu.addAction(hide_action)
+    visibility_action = QAction("隐藏至托盘" if window_visible else "显示桌宠", parent)
+    visibility_action.triggered.connect(on_hide if window_visible else on_show)
+    menu.addAction(visibility_action)
 
     menu.addSeparator()
 

--- a/scripts/install_gpt_sovits_macos.sh
+++ b/scripts/install_gpt_sovits_macos.sh
@@ -76,10 +76,21 @@ verify_sha256() {
     fi
 }
 
+conda_usable() {
+    [ -x "$MINIFORGE_DIR/bin/conda" ] || return 1
+    [ -f "$MINIFORGE_DIR/etc/profile.d/conda.sh" ] || return 1
+    "$MINIFORGE_DIR/bin/conda" --version >/dev/null 2>&1 || return 1
+}
+
 mkdir -p "$INSTALL_ROOT" "$DOWNLOADS_DIR"
 
 progress prepare 5
-if [ ! -x "$MINIFORGE_DIR/bin/conda" ]; then
+if [ -d "$MINIFORGE_DIR" ] && ! conda_usable; then
+    echo "Existing Miniforge runtime is unusable, reinstalling: $MINIFORGE_DIR"
+    rm -rf "$MINIFORGE_DIR"
+fi
+
+if ! conda_usable; then
     INSTALLER="$DOWNLOADS_DIR/$MINIFORGE_FILENAME"
     if [ -f "$INSTALLER" ] && ! verify_sha256 "$INSTALLER" "$MINIFORGE_SHA256"; then
         rm -f "$INSTALLER"
@@ -91,6 +102,11 @@ if [ ! -x "$MINIFORGE_DIR/bin/conda" ]; then
     verify_sha256 "$INSTALLER" "$MINIFORGE_SHA256"
     progress install 20
     bash "$INSTALLER" -b -p "$MINIFORGE_DIR"
+fi
+
+if ! conda_usable; then
+    echo "Miniforge runtime is still unusable after installation: $MINIFORGE_DIR"
+    exit 1
 fi
 
 # shellcheck source=/dev/null

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -3704,7 +3704,7 @@ def test_pet_window_apply_window_flags_syncs_native_topmost_state() -> None:
         def show(self) -> None:
             self.show_count += 1
 
-        def _sync_native_topmost_state(self) -> None:
+        def _schedule_native_topmost_sync(self) -> None:
             self.sync_count += 1
 
     window = MinimalWindow()
@@ -3738,7 +3738,7 @@ def test_pet_window_apply_window_flags_does_not_sync_native_state_before_visible
         def show(self) -> None:
             self.show_count += 1
 
-        def _sync_native_topmost_state(self) -> None:
+        def _schedule_native_topmost_sync(self) -> None:
             self.sync_count += 1
 
     window = MinimalWindow()
@@ -3747,6 +3747,29 @@ def test_pet_window_apply_window_flags_does_not_sync_native_state_before_visible
 
     assert window.show_count == 0
     assert window.sync_count == 0
+
+
+def test_pet_window_schedules_native_topmost_sync_on_macos(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    import app.ui.pet_window as pet_window_module
+    from app.ui.pet_window import PetWindow
+
+    events: list[str] = []
+    monkeypatch.setattr(pet_window_module.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        pet_window_module.QTimer,
+        "singleShot",
+        lambda _delay, callback: events.append("timer") or callback(),
+    )
+
+    class MinimalWindow:
+        _schedule_native_topmost_sync = PetWindow._schedule_native_topmost_sync
+
+        def _sync_native_topmost_state(self) -> None:
+            events.append("sync")
+
+    MinimalWindow()._schedule_native_topmost_sync()
+
+    assert events == ["timer", "sync"]
 
 
 def test_pet_window_context_menu_resyncs_topmost_after_menu_closes() -> None:
@@ -3776,6 +3799,62 @@ def test_pet_window_context_menu_resyncs_topmost_after_menu_closes() -> None:
     window._show_context_menu(object())  # type: ignore[arg-type]
 
     assert window.events == ["exec", "sync"]
+
+
+def test_pet_window_syncs_macos_native_topmost_state(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    import app.ui.pet_window as pet_window_module
+    from app.ui.pet_window import PetWindow
+
+    calls: list[tuple[int, bool]] = []
+    monkeypatch.setattr(pet_window_module.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        pet_window_module,
+        "_set_macos_window_topmost",
+        lambda window_id, enabled: calls.append((window_id, enabled)),
+    )
+
+    class MinimalWindow:
+        _sync_native_topmost_state = PetWindow._sync_native_topmost_state
+
+        always_on_top_enabled = True
+
+        def isVisible(self) -> bool:
+            return True
+
+        def winId(self) -> int:
+            return 123
+
+    MinimalWindow()._sync_native_topmost_state()
+
+    assert calls == [(123, True)]
+
+
+def test_pet_window_skips_macos_native_topmost_sync_when_hidden(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    import app.ui.pet_window as pet_window_module
+    from app.ui.pet_window import PetWindow
+
+    calls: list[tuple[int, bool]] = []
+    monkeypatch.setattr(pet_window_module.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        pet_window_module,
+        "_set_macos_window_topmost",
+        lambda window_id, enabled: calls.append((window_id, enabled)),
+    )
+
+    class MinimalWindow:
+        _sync_native_topmost_state = PetWindow._sync_native_topmost_state
+
+        always_on_top_enabled = True
+
+        def isVisible(self) -> bool:
+            return False
+
+        def winId(self) -> int:
+            return 123
+
+    MinimalWindow()._sync_native_topmost_state()
+
+    assert calls == []
 
 
 def test_screen_observation_followup_uses_last_user_message_after_progress(monkeypatch) -> None:  # type: ignore[no-untyped-def]

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -68,11 +68,15 @@ def test_pet_window_menu_keeps_only_allowed_checkable_switches() -> None:
     host.subtitle_language = SUBTITLE_LANGUAGE_ZH
     host.free_access_enabled = True
     host.always_on_top_enabled = False
+    host._hide_to_tray = lambda: None
+    host._show_from_tray = lambda: None
     host._toggle_chinese_subtitles = lambda _checked: None
     host._toggle_free_access = lambda _checked: None
     host._toggle_always_on_top = lambda _checked: None
     host.show_history = lambda: None
     host.show_settings = lambda: None
+    host.show()
+    app.processEvents()
 
     menu = PetWindow._build_menu(host)  # type: ignore[arg-type]
     actions = [action for action in menu.actions() if not action.isSeparator()]
@@ -91,6 +95,145 @@ def test_pet_window_menu_keeps_only_allowed_checkable_switches() -> None:
     menu.deleteLater()
     host.deleteLater()
     app.processEvents()
+
+
+def test_pet_window_menu_shows_restore_action_when_hidden() -> None:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    if not hasattr(qtwidgets, "QApplication") or not hasattr(qtwidgets, "QWidget"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+
+    from app.ui.pet_window import PetWindow, SUBTITLE_LANGUAGE_ZH
+
+    QApplication = qtwidgets.QApplication
+    QWidget = qtwidgets.QWidget
+    app = QApplication.instance() or QApplication([])
+    host = QWidget()
+    host.subtitle_language = SUBTITLE_LANGUAGE_ZH
+    host.free_access_enabled = True
+    host.always_on_top_enabled = False
+    host._hide_to_tray = lambda: None
+    host._show_from_tray = lambda: None
+    host._toggle_chinese_subtitles = lambda _checked: None
+    host._toggle_free_access = lambda _checked: None
+    host._toggle_always_on_top = lambda _checked: None
+    host.show_history = lambda: None
+    host.show_settings = lambda: None
+
+    menu = PetWindow._build_menu(host)  # type: ignore[arg-type]
+    actions = [action for action in menu.actions() if not action.isSeparator()]
+
+    assert actions[0].text() == "显示桌宠"
+
+    menu.deleteLater()
+    host.deleteLater()
+    app.processEvents()
+
+
+def test_pet_window_status_tray_icon_is_not_empty() -> None:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    if not hasattr(qtwidgets, "QApplication"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+
+    from app.ui.pet_window import _build_status_tray_icon
+
+    QApplication = qtwidgets.QApplication
+    app = QApplication.instance() or QApplication([])
+
+    icon = _build_status_tray_icon("#d55b91")
+
+    assert not icon.isNull()
+    app.processEvents()
+
+
+def test_pet_window_hide_and_show_to_tray_tracks_hidden_state() -> None:
+    from app.ui.pet_window import PetWindow
+
+    class MinimalWindow:
+        _hide_to_tray = PetWindow._hide_to_tray
+        _show_from_tray = PetWindow._show_from_tray
+
+        def __init__(self) -> None:
+            self.hidden_to_tray = False
+            self.events: list[str] = []
+
+        def hide(self) -> None:
+            self.events.append("hide")
+
+        def show(self) -> None:
+            self.events.append("show")
+
+        def raise_(self) -> None:
+            self.events.append("raise")
+
+        def activateWindow(self) -> None:
+            self.events.append("activate")
+
+        def _refresh_tray_menu(self) -> None:
+            self.events.append("refresh")
+
+    window = MinimalWindow()
+
+    window._hide_to_tray()
+    assert window.hidden_to_tray is True
+    assert window.events == ["hide", "refresh"]
+
+    window._show_from_tray()
+    assert window.hidden_to_tray is False
+    assert window.events == ["hide", "refresh", "show", "raise", "activate", "refresh"]
+
+
+def test_pet_window_application_activation_restores_when_hidden_to_tray(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    import app.ui.pet_window as pet_window_module
+    from app.ui.pet_window import PetWindow
+
+    events: list[str] = []
+    monkeypatch.setattr(
+        pet_window_module.QTimer,
+        "singleShot",
+        lambda delay, callback: events.append(f"timer:{delay}") or callback(),
+    )
+
+    class MinimalWindow:
+        _handle_application_activated = PetWindow._handle_application_activated
+
+        def __init__(self) -> None:
+            self.hidden_to_tray = True
+
+        def _show_from_tray(self) -> None:
+            self.hidden_to_tray = False
+            events.append("show")
+
+    window = MinimalWindow()
+
+    window._handle_application_activated()
+
+    assert window.hidden_to_tray is False
+    assert events == ["timer:0", "show"]
+
+
+def test_pet_window_application_activation_ignores_visible_window(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    import app.ui.pet_window as pet_window_module
+    from app.ui.pet_window import PetWindow
+
+    events: list[str] = []
+    monkeypatch.setattr(
+        pet_window_module.QTimer,
+        "singleShot",
+        lambda _delay, _callback: events.append("timer"),
+    )
+
+    class MinimalWindow:
+        _handle_application_activated = PetWindow._handle_application_activated
+        hidden_to_tray = False
+
+        def _show_from_tray(self) -> None:
+            events.append("show")
+
+    MinimalWindow()._handle_application_activated()
+
+    assert events == []
 
 
 def test_pet_window_context_menu_opens_on_right_release_not_press() -> None:


### PR DESCRIPTION
这个 PR 聚焦 macOS 运行体验的补充修复：

1. macOS GPT-SoVITS 安装脚本在已有 Miniforge 目录损坏或路径失效时，只检查 `conda` 文件是否存在，可能继续使用不可运行的运行时。
2. macOS 下“保持置顶”仅依赖 Qt window flag，窗口在应用失焦、Space 切换或状态变化后仍可能被其他页面遮挡。
3. “隐藏至托盘”更偏 Windows 托盘交互；macOS 用户隐藏后如果顶部状态栏图标不可见，可能缺少可靠唤回入口。

## 变更

### macOS GPT-SoVITS 安装脚本

- 新增 `conda_usable()`，同时检查：
  - `miniforge3/bin/conda` 可执行；
  - `etc/profile.d/conda.sh` 存在；
  - `conda --version` 能正常运行。
- 如果已有 Miniforge 目录但不可用，则清理后重装。
- 安装后再次校验 Miniforge 是否可用，不可用时直接失败并输出明确错误。
- 保留原有下载缓存、SHA256 校验和进度输出逻辑。

### macOS 原生置顶同步

- 保留 Windows 原有 `SetWindowPos` 分支。
- 新增 macOS 原生 NSWindow 同步逻辑，不引入 PyObjC，使用 `ctypes` 调用 Objective-C runtime。
- 置顶开启时同步：
  - NSWindow level；
  - `CanJoinAllSpaces` / `FullScreenAuxiliary`；
  - `hidesOnDeactivate=False`。
- 置顶关闭时恢复对应窗口层级和 Space 行为。
- 在窗口显示、窗口状态变化、激活状态变化后延迟同步原生置顶状态。

### macOS 隐藏至托盘恢复

- 托盘/状态栏菜单第一项根据窗口可见状态切换：
  - 可见时显示“隐藏至托盘”；
  - 隐藏时显示“显示桌宠”。
- 新增 `_hide_to_tray()` / `_show_from_tray()`，统一隐藏和恢复逻辑。
- macOS 下监听应用激活事件；如果窗口是主动隐藏至托盘状态，则可通过应用重新激活唤回。
- 状态栏图标改为稳定的 32x32 Sakura 标识，不再直接使用角色立绘缩略图。
- 应用级事件过滤器仅在 macOS 注册。
- 鼠标事件过滤限制在桌宠本体控件，避免影响菜单、设置窗口等其他 UI 组件。

## 测试

- `QT_QPA_PLATFORM=offscreen ... python3 -m pytest`
  - `451 passed, 6 warnings`
- 相关 UI 测试：
  - `8 passed`
- `git diff --check`
- `bash -n scripts/install_gpt_sovits_macos.sh`
- `python3 -m py_compile app/ui/pet_window.py app/ui/tray_menu.py tests/ui/test_pet_window.py`

## 范围说明

- 本 PR 只包含 macOS GPT-SoVITS 安装鲁棒性与 macOS UI 行为修复。
- 不包含长期记忆/Hugging Face 本地缓存路径修复。
- 不修改 Windows TTS 整合包安装逻辑。
- Windows 原有原生置顶同步分支保留。