### PR TITLE
Fix: 修复设置页的TTS检测和启动逻辑

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 concurrency:
   group: test-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -138,6 +138,7 @@ class TTSTestWorker(QObject):
     @Slot()
     def run(self) -> None:
         provider = None
+        should_close_provider = True
         try:
             provider = (
                 GenieTTSProvider(self.settings)
@@ -146,19 +147,20 @@ class TTSTestWorker(QObject):
             )
             ok, message = provider.ensure_ready()
             if ok:
+                should_close_provider = False
                 self.succeeded.emit(provider.settings, message)
             else:
                 self.failed.emit(message)
         except Exception as exc:  # UI 边界统一转成可读错误。
             self.failed.emit(str(exc))
         finally:
-            if provider is not None:
+            if should_close_provider and provider is not None:
                 close = getattr(provider, "close", None)
                 if callable(close):
                     try:
                         close()
                     except Exception as exc:  # noqa: BLE001
-                        debug_log("TTS", "TTS 检测完成后关闭 Provider 失败", {"error": str(exc)})
+                        debug_log("TTS", "TTS 检测失败后清理 Provider 失败", {"error": str(exc)})
             self.finished.emit()
 
 
@@ -274,6 +276,8 @@ class SettingsDialog(QDialog):
         super().__init__(parent)
         self.base_dir = base_dir
         self.tts_settings = tts_settings
+        self._initial_api_settings = api_settings
+        self._initial_character_id = current_character.id if current_character is not None else None
         self.theme_settings = (theme_settings or DEFAULT_THEME_SETTINGS).normalized()
         self.character_registry = character_registry
         self.current_character = current_character
@@ -306,6 +310,7 @@ class SettingsDialog(QDialog):
         self._api_test_worker: ApiConnectionTestWorker | None = None
         self._tts_test_thread: QThread | None = None
         self._tts_test_worker: TTSTestWorker | None = None
+        self._pending_api_accept_values: dict[str, object] | None = None
         self._pending_accept_values: dict[str, object] | None = None
         self._save_button_text: str | None = None
         self._memory_list_thread: QThread | None = None
@@ -1456,12 +1461,34 @@ class SettingsDialog(QDialog):
         accept_values = self._collect_accept_values()
         if accept_values is None:
             return
-        tts_settings = accept_values["tts_settings"]
-        if isinstance(tts_settings, GPTSoVITSTTSSettings) and tts_settings.enabled:
-            self._start_tts_settings_test(tts_settings, accept_values)
+        api_settings = accept_values["api_settings"]
+        if isinstance(api_settings, ApiSettings) and self._should_test_api_on_accept(api_settings):
+            self._start_api_settings_test(api_settings, accept_values)
             return
 
+        self._continue_accept_after_api_test(accept_values)
+
+    def _continue_accept_after_api_test(self, accept_values: dict[str, object]) -> None:
+        tts_settings = accept_values["tts_settings"]
+        if self._should_test_tts_on_accept(tts_settings, accept_values["character_id"]):
+            self._start_tts_settings_test(tts_settings, accept_values)
+            return
         self._complete_accept(accept_values)
+
+    def _should_test_api_on_accept(self, api_settings: ApiSettings) -> bool:
+        return api_settings != self._initial_api_settings
+
+    def _should_test_tts_on_accept(
+        self,
+        tts_settings: object,
+        character_id: object,
+    ) -> bool:
+        return (
+            isinstance(tts_settings, GPTSoVITSTTSSettings)
+            and tts_settings.enabled
+            and isinstance(character_id, str)
+            and character_id != self._initial_character_id
+        )
 
     def _collect_accept_values(self) -> dict[str, object] | None:
         api_settings = self._validated_api_settings()
@@ -1592,9 +1619,18 @@ class SettingsDialog(QDialog):
         if settings is None or self._api_test_thread is not None:
             return
 
-        self.api_test_button.setEnabled(False)
-        self.api_test_button.setText("测试中...")
+        self._start_api_settings_test(settings)
 
+    def _start_api_settings_test(
+        self,
+        settings: ApiSettings,
+        accept_values: dict[str, object] | None = None,
+    ) -> None:
+        if self._api_test_thread is not None:
+            return
+
+        self._pending_api_accept_values = dict(accept_values) if accept_values is not None else None
+        self._set_api_test_busy(True)
         thread = QThread()
         worker = ApiConnectionTestWorker(settings)
         worker.moveToThread(thread)
@@ -1612,18 +1648,44 @@ class SettingsDialog(QDialog):
 
     @Slot(str)
     def _handle_api_test_success(self, message: str) -> None:
+        accept_values = self._pending_api_accept_values
+        if accept_values is not None:
+            self._continue_accept_after_api_test(accept_values)
+            return
         QMessageBox.information(self, "测试成功", f"API 连接成功，模型返回：{message}")
 
     @Slot(str)
     def _handle_api_test_failed(self, message: str) -> None:
+        if self._pending_api_accept_values is not None:
+            QMessageBox.warning(self, "API 检测失败", f"{message}\n\n设置尚未保存，请修正 API 配置后再保存。")
+            return
         QMessageBox.warning(self, "测试失败", message)
 
     @Slot()
     def _reset_api_test_state(self) -> None:
-        self.api_test_button.setEnabled(True)
-        self.api_test_button.setText("测试 API")
         self._api_test_thread = None
         self._api_test_worker = None
+        self._pending_api_accept_values = None
+        self._set_api_test_busy(False)
+
+    def _set_api_test_busy(self, busy: bool) -> None:
+        self.api_test_button.setEnabled(not busy)
+        self.api_test_button.setText("测试中..." if busy else "测试 API")
+        if not hasattr(self, "button_box"):
+            return
+        save_button = self.button_box.button(QDialogButtonBox.StandardButton.Save)
+        if save_button is None:
+            return
+        if busy:
+            if self._save_button_text is None:
+                self._save_button_text = save_button.text()
+            save_button.setText("测试 API...")
+        elif self._tts_test_thread is not None:
+            return
+        elif self._save_button_text is not None:
+            save_button.setText(self._save_button_text)
+            self._save_button_text = None
+        save_button.setEnabled(not busy)
 
     def _start_tts_settings_test(
         self,

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -800,7 +800,7 @@ def test_settings_dialog_skips_tts_test_when_tts_disabled(monkeypatch) -> None: 
     app.processEvents()
 
 
-def test_settings_dialog_enabled_tts_saves_after_successful_test(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_settings_dialog_enabled_tts_skips_test_when_character_unchanged(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
     qtwidgets = pytest.importorskip("PySide6.QtWidgets")
     if not hasattr(qtwidgets, "QApplication"):
@@ -824,17 +824,63 @@ def test_settings_dialog_enabled_tts_saves_after_successful_test(monkeypatch) ->
         mcp_settings=MCPRuntimeSettings(windows_enabled=False),
     )
     dialog.tts_enabled_check.setChecked(True)
+    monkeypatch.setattr(
+        dialog,
+        "_start_tts_settings_test",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("角色未变时不应检测 TTS")),
+    )
+
+    dialog.accept()
+
+    assert dialog.result_tts_settings is not None
+    assert dialog.result_tts_settings.enabled
+    dialog.deleteLater()
+    app.processEvents()
+
+
+def test_settings_dialog_enabled_tts_tests_when_character_changes(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    if not hasattr(qtwidgets, "QApplication"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+
+    from app.config.character_loader import CharacterRegistry
+    from app.ui.settings_dialog import SettingsDialog
+
+    QApplication = qtwidgets.QApplication
+    app = QApplication.instance() or QApplication([])
+    root = _ui_runtime_root("tts_save_character_changed")
+    current_profile = _build_settings_dialog_character(root, "sakura", "Sakura")
+    _build_settings_dialog_character(root, "nanami", "Nanami")
+    dialog = SettingsDialog(
+        api_settings=ApiSettings(
+            base_url="https://api.example.com/v1",
+            api_key="test-key",
+            model="test-model",
+        ),
+        tts_settings=_minimal_tts_settings(),
+        base_dir=root,
+        character_registry=CharacterRegistry(root),
+        current_character=current_profile,
+        proactive_care_settings=ProactiveCareSettings(screen_context_enabled=True),
+        mcp_settings=MCPRuntimeSettings(windows_enabled=False),
+    )
+    dialog.tts_enabled_check.setChecked(True)
+    nanami_index = dialog.character_combo.findData("nanami")
+    assert nanami_index >= 0
+    dialog.character_combo.setCurrentIndex(nanami_index)
     calls: list[str] = []
 
     def fake_start_tts_test(settings, accept_values):  # type: ignore[no-untyped-def]
-        calls.append(settings.api_url)
+        calls.append(settings.character_name)
         dialog._complete_accept(accept_values)
 
     monkeypatch.setattr(dialog, "_start_tts_settings_test", fake_start_tts_test)
 
     dialog.accept()
 
-    assert calls == ["http://127.0.0.1:9880/tts"]
+    assert calls == ["Nanami"]
+    assert dialog.result_character_id == "nanami"
     assert dialog.result_tts_settings is not None
     assert dialog.result_tts_settings.enabled
     dialog.deleteLater()
@@ -848,11 +894,14 @@ def test_settings_dialog_tts_test_failure_disables_tts_and_saves(monkeypatch) ->
         pytest.skip("当前测试环境只提供了 PySide6 stub。")
 
     import app.ui.settings_dialog as settings_dialog_module
+    from app.config.character_loader import CharacterRegistry
     from app.ui.settings_dialog import SettingsDialog
 
     QApplication = qtwidgets.QApplication
     app = QApplication.instance() or QApplication([])
     root = _ui_runtime_root("tts_save_failure")
+    current_profile = _build_settings_dialog_character(root, "sakura", "Sakura")
+    _build_settings_dialog_character(root, "nanami", "Nanami")
     dialog = SettingsDialog(
         api_settings=ApiSettings(
             base_url="https://api.example.com/v1",
@@ -861,11 +910,15 @@ def test_settings_dialog_tts_test_failure_disables_tts_and_saves(monkeypatch) ->
         ),
         tts_settings=_minimal_tts_settings(),
         base_dir=root,
-        **_settings_dialog_character_kwargs(root),
+        character_registry=CharacterRegistry(root),
+        current_character=current_profile,
         proactive_care_settings=ProactiveCareSettings(screen_context_enabled=True),
         mcp_settings=MCPRuntimeSettings(windows_enabled=False),
     )
     dialog.tts_enabled_check.setChecked(True)
+    nanami_index = dialog.character_combo.findData("nanami")
+    assert nanami_index >= 0
+    dialog.character_combo.setCurrentIndex(nanami_index)
     warnings: list[str] = []
     monkeypatch.setattr(
         settings_dialog_module.QMessageBox,
@@ -885,6 +938,188 @@ def test_settings_dialog_tts_test_failure_disables_tts_and_saves(monkeypatch) ->
     assert not dialog.tts_enabled_check.isChecked()
     assert dialog.result_tts_settings is not None
     assert not dialog.result_tts_settings.enabled
+    dialog.deleteLater()
+    app.processEvents()
+
+
+def test_settings_dialog_skips_api_test_when_api_unchanged(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    if not hasattr(qtwidgets, "QApplication"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+
+    from app.ui.settings_dialog import SettingsDialog
+
+    QApplication = qtwidgets.QApplication
+    app = QApplication.instance() or QApplication([])
+    root = _ui_runtime_root("api_save_unchanged")
+    dialog = SettingsDialog(
+        api_settings=ApiSettings(
+            base_url="https://api.example.com/v1",
+            api_key="test-key",
+            model="test-model",
+        ),
+        tts_settings=_minimal_tts_settings(),
+        base_dir=root,
+        **_settings_dialog_character_kwargs(root),
+        proactive_care_settings=ProactiveCareSettings(screen_context_enabled=True),
+        mcp_settings=MCPRuntimeSettings(windows_enabled=False),
+    )
+    monkeypatch.setattr(
+        dialog,
+        "_start_api_settings_test",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("API 未变时不应自动测试")),
+    )
+
+    dialog.accept()
+
+    assert dialog.result_api_settings is not None
+    assert dialog.result_api_settings.model == "test-model"
+    dialog.deleteLater()
+    app.processEvents()
+
+
+def test_settings_dialog_tests_api_when_api_changes(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    if not hasattr(qtwidgets, "QApplication"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+
+    from app.ui.settings_dialog import SettingsDialog
+
+    QApplication = qtwidgets.QApplication
+    app = QApplication.instance() or QApplication([])
+    root = _ui_runtime_root("api_save_changed")
+    dialog = SettingsDialog(
+        api_settings=ApiSettings(
+            base_url="https://api.example.com/v1",
+            api_key="test-key",
+            model="test-model",
+        ),
+        tts_settings=_minimal_tts_settings(),
+        base_dir=root,
+        **_settings_dialog_character_kwargs(root),
+        proactive_care_settings=ProactiveCareSettings(screen_context_enabled=True),
+        mcp_settings=MCPRuntimeSettings(windows_enabled=False),
+    )
+    dialog.model_edit.setText("new-model")
+    calls: list[str] = []
+
+    def fake_start_api_test(settings, accept_values=None):  # type: ignore[no-untyped-def]
+        calls.append(settings.model)
+        assert accept_values is not None
+        dialog._continue_accept_after_api_test(accept_values)
+
+    monkeypatch.setattr(dialog, "_start_api_settings_test", fake_start_api_test)
+
+    dialog.accept()
+
+    assert calls == ["new-model"]
+    assert dialog.result_api_settings is not None
+    assert dialog.result_api_settings.model == "new-model"
+    dialog.deleteLater()
+    app.processEvents()
+
+
+def test_settings_dialog_api_test_failure_blocks_save(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    if not hasattr(qtwidgets, "QApplication"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+
+    import app.ui.settings_dialog as settings_dialog_module
+    from app.ui.settings_dialog import SettingsDialog
+
+    QApplication = qtwidgets.QApplication
+    app = QApplication.instance() or QApplication([])
+    root = _ui_runtime_root("api_save_failure")
+    dialog = SettingsDialog(
+        api_settings=ApiSettings(
+            base_url="https://api.example.com/v1",
+            api_key="test-key",
+            model="test-model",
+        ),
+        tts_settings=_minimal_tts_settings(),
+        base_dir=root,
+        **_settings_dialog_character_kwargs(root),
+        proactive_care_settings=ProactiveCareSettings(screen_context_enabled=True),
+        mcp_settings=MCPRuntimeSettings(windows_enabled=False),
+    )
+    dialog.model_edit.setText("bad-model")
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        settings_dialog_module.QMessageBox,
+        "warning",
+        lambda _parent, _title, message: warnings.append(message),
+    )
+
+    def fake_start_api_test(_settings, accept_values=None):  # type: ignore[no-untyped-def]
+        dialog._pending_api_accept_values = accept_values
+        dialog._handle_api_test_failed("模型不可用")
+
+    monkeypatch.setattr(dialog, "_start_api_settings_test", fake_start_api_test)
+
+    dialog.accept()
+
+    assert warnings and "模型不可用" in warnings[0]
+    assert dialog.result_api_settings is None
+    assert dialog.result_tts_settings is None
+    dialog.deleteLater()
+    app.processEvents()
+
+
+def test_settings_dialog_api_success_continues_to_tts_test(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    if not hasattr(qtwidgets, "QApplication"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+
+    from app.config.character_loader import CharacterRegistry
+    from app.ui.settings_dialog import SettingsDialog
+
+    QApplication = qtwidgets.QApplication
+    app = QApplication.instance() or QApplication([])
+    root = _ui_runtime_root("api_success_then_tts")
+    current_profile = _build_settings_dialog_character(root, "sakura", "Sakura")
+    _build_settings_dialog_character(root, "nanami", "Nanami")
+    dialog = SettingsDialog(
+        api_settings=ApiSettings(
+            base_url="https://api.example.com/v1",
+            api_key="test-key",
+            model="test-model",
+        ),
+        tts_settings=_minimal_tts_settings(),
+        base_dir=root,
+        character_registry=CharacterRegistry(root),
+        current_character=current_profile,
+        proactive_care_settings=ProactiveCareSettings(screen_context_enabled=True),
+        mcp_settings=MCPRuntimeSettings(windows_enabled=False),
+    )
+    dialog.model_edit.setText("new-model")
+    dialog.tts_enabled_check.setChecked(True)
+    nanami_index = dialog.character_combo.findData("nanami")
+    assert nanami_index >= 0
+    dialog.character_combo.setCurrentIndex(nanami_index)
+    calls: list[str] = []
+
+    def fake_start_api_test(_settings, accept_values=None):  # type: ignore[no-untyped-def]
+        calls.append("api")
+        assert accept_values is not None
+        dialog._continue_accept_after_api_test(accept_values)
+
+    def fake_start_tts_test(_settings, accept_values):  # type: ignore[no-untyped-def]
+        calls.append("tts")
+        dialog._complete_accept(accept_values)
+
+    monkeypatch.setattr(dialog, "_start_api_settings_test", fake_start_api_test)
+    monkeypatch.setattr(dialog, "_start_tts_settings_test", fake_start_tts_test)
+
+    dialog.accept()
+
+    assert calls == ["api", "tts"]
+    assert dialog.result_api_settings is not None
+    assert dialog.result_api_settings.model == "new-model"
+    assert dialog.result_character_id == "nanami"
     dialog.deleteLater()
     app.processEvents()
 
@@ -4104,7 +4339,7 @@ def _minimal_tts_settings() -> GPTSoVITSTTSSettings:
     )
 
 
-def test_tts_test_worker_closes_provider_after_success(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_tts_test_worker_keeps_provider_after_success(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
     pytest.importorskip("PySide6.QtCore")
     import app.ui.settings_dialog as settings_dialog
@@ -4126,10 +4361,10 @@ def test_tts_test_worker_closes_provider_after_success(monkeypatch) -> None:  # 
     worker = settings_dialog.TTSTestWorker(_minimal_tts_settings())
     worker.run()
 
-    assert closed == [True]
+    assert closed == []
 
 
-def test_tts_test_worker_emits_finished_when_provider_close_fails(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_tts_test_worker_closes_provider_after_failure(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
     pytest.importorskip("PySide6.QtCore")
     import app.ui.settings_dialog as settings_dialog
@@ -4141,19 +4376,19 @@ def test_tts_test_worker_emits_finished_when_provider_close_fails(monkeypatch) -
             self.settings = settings
 
         def ensure_ready(self) -> tuple[bool, str]:
-            return True, "ok"
+            return False, "启动失败"
 
         def close(self) -> None:
-            raise RuntimeError("关闭失败")
+            events.append("closed")
 
     monkeypatch.setattr(settings_dialog, "GPTSoVITSTTSProvider", FakeProvider)
 
     worker = settings_dialog.TTSTestWorker(_minimal_tts_settings())
-    worker.succeeded.connect(lambda *_args: events.append("succeeded"))
+    worker.failed.connect(lambda _message: events.append("failed"))
     worker.finished.connect(lambda: events.append("finished"))
     worker.run()
 
-    assert events == ["succeeded", "finished"]
+    assert events == ["failed", "closed", "finished"]
 
 
 def _minimal_settings_window(pet_window_cls, settings_service, api_client, memory_store):  # type: ignore[no-untyped-def]


### PR DESCRIPTION
原先的设置页每次点击保存都会检测TTS服务, 而且检测完就直接关闭TTS进程, 导致第一句语音需要等待tts服务启动, 启动慢的机器甚至会超时报错

并且为dev分支加入CI持续集成, 规范开发流程