### PR TITLE
fix: handle chat completion compatibility fallbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__/
 .venv/
 venv/
 runtime/
+/tts/
 env/
 node_modules/
 characters/

--- a/app/llm/api_client.py
+++ b/app/llm/api_client.py
@@ -31,6 +31,7 @@ SUPPORTED_CHAT_COMPLETION_PARAMS = {
     "tool_choice",
 }
 
+
 class ApiConfigError(RuntimeError):
     """API 配置缺失或格式错误。"""
 
@@ -69,10 +70,12 @@ class ChatCompletionTurn:
 class OpenAICompatibleClient:
     def __init__(self, settings: ApiSettings) -> None:
         self.settings = settings
+        self._unsupported_chat_params: set[str] = set()
 
     def update_settings(self, settings: ApiSettings) -> None:
         """运行时更新 API 配置，供设置界面保存后立即生效。"""
         self.settings = settings
+        self._unsupported_chat_params.clear()
 
     def test_connection(self) -> str:
         """发送一次最小聊天请求，验证 Base URL、API Key 和模型是否可用。"""
@@ -86,10 +89,10 @@ class OpenAICompatibleClient:
                     "content": "Reply with only OK.",
                 },
             ],
-            "temperature": 0,
             "max_tokens": 8,
+            "temperature": 0,
         }
-        data = self._post_chat_completions_with_response_format_fallback(payload)
+        data = self._post_chat_completions_with_compatibility_fallbacks(payload)
 
         try:
             content = data["choices"][0]["message"]["content"]
@@ -157,7 +160,7 @@ class OpenAICompatibleClient:
                 "chat_params": _filter_supported_chat_params(chat_params),
             },
         )
-        data = self._post_chat_completions_with_response_format_fallback(payload)
+        data = self._post_chat_completions_with_compatibility_fallbacks(payload)
 
         try:
             content = data["choices"][0]["message"]["content"]
@@ -211,7 +214,7 @@ class OpenAICompatibleClient:
                 "chat_params": _filter_supported_chat_params(chat_params),
             },
         )
-        data = self._post_chat_completions_with_response_format_fallback(payload)
+        data = self._post_chat_completions_with_compatibility_fallbacks(payload)
 
         try:
             raw_message = data["choices"][0]["message"]
@@ -240,23 +243,36 @@ class OpenAICompatibleClient:
             message=normalized_message,
         )
 
-    def _post_chat_completions_with_response_format_fallback(
+    def _post_chat_completions_with_compatibility_fallbacks(
         self,
         payload: dict[str, Any],
     ) -> dict[str, Any]:
-        try:
-            return self._post_chat_completions(payload)
-        except ApiRequestError as exc:
-            if "response_format" not in payload or not _is_response_format_unsupported_error(exc):
+        fallback_payload = dict(payload)
+        for param in self._unsupported_chat_params:
+            fallback_payload.pop(param, None)
+        while True:
+            try:
+                return self._post_chat_completions(fallback_payload)
+            except ApiRequestError as exc:
+                if "response_format" in fallback_payload and _is_response_format_unsupported_error(exc):
+                    self._unsupported_chat_params.add("response_format")
+                    fallback_payload.pop("response_format", None)
+                    debug_log(
+                        "API",
+                        "结构化 response_format 不受支持，已回退普通请求",
+                        {"error": str(exc)},
+                    )
+                    continue
+                if "temperature" in fallback_payload and _is_temperature_unsupported_error(exc):
+                    self._unsupported_chat_params.add("temperature")
+                    fallback_payload.pop("temperature", None)
+                    debug_log(
+                        "API",
+                        "模型不支持自定义 temperature，已回退默认温度",
+                        {"error": str(exc)},
+                    )
+                    continue
                 raise
-            fallback_payload = dict(payload)
-            fallback_payload.pop("response_format", None)
-            debug_log(
-                "API",
-                "结构化 response_format 不受支持，已回退普通请求",
-                {"error": str(exc)},
-            )
-            return self._post_chat_completions(fallback_payload)
 
     def _ensure_chat_config(self, api_key_message: str) -> None:
         if not self.settings.api_key:
@@ -414,9 +430,10 @@ def _build_chat_completion_payload(
             },
             *messages,
         ],
-        "temperature": temperature,
     }
+    payload["temperature"] = temperature
     payload.update(_filter_supported_chat_params(chat_params or {}))
+    _ensure_json_keyword_for_json_object_response(payload)
     return payload
 
 
@@ -432,9 +449,58 @@ def _filter_supported_chat_params(params: dict[str, Any]) -> dict[str, Any]:
     return filtered
 
 
+def _ensure_json_keyword_for_json_object_response(payload: dict[str, Any]) -> None:
+    """json_object 模式下，部分兼容网关要求请求消息显式包含英文 json。"""
+    response_format = payload.get("response_format")
+    if not isinstance(response_format, dict) or response_format.get("type") != "json_object":
+        return
+    messages = payload.get("messages")
+    if not isinstance(messages, list) or _messages_contain_json_keyword(messages):
+        return
+    system_message = messages[0] if messages else None
+    if not isinstance(system_message, dict) or system_message.get("role") != "system":
+        return
+    content = system_message.get("content")
+    if isinstance(content, str):
+        system_message["content"] = f"{content}\n\n请只输出 JSON（json）对象。"
+
+
+def _messages_contain_json_keyword(messages: list[Any]) -> bool:
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        if _value_contains_json_keyword(message.get("content")):
+            return True
+    return False
+
+
+def _value_contains_json_keyword(value: Any) -> bool:
+    if isinstance(value, str):
+        return "json" in value.lower()
+    if isinstance(value, list):
+        return any(_value_contains_json_keyword(item) for item in value)
+    if isinstance(value, dict):
+        return any(_value_contains_json_keyword(item) for item in value.values())
+    return False
+
+
 def _is_response_format_unsupported_error(exc: ApiRequestError) -> bool:
     text = str(exc).lower()
     return "response_format" in text or "json_object" in text or "json schema" in text
+
+
+def _is_temperature_unsupported_error(exc: ApiRequestError) -> bool:
+    text = str(exc).lower()
+    if "temperature" not in text:
+        return False
+    markers = (
+        "unsupported",
+        "not support",
+        "does not support",
+        "only the default",
+        "default value",
+    )
+    return any(marker in text for marker in markers)
 
 
 def _parse_native_tool_calls(raw_tool_calls: Any) -> list[NativeToolCall]:

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -46,6 +46,30 @@ def test_build_chat_payload_drops_unsupported_params() -> None:
     assert payload["messages"][0] == {"role": "system", "content": "system"}
 
 
+def test_build_chat_payload_adds_json_keyword_for_json_object_response() -> None:
+    payload = _build_chat_completion_payload(
+        model="gpt-compatible",
+        system_prompt="只返回对象，不要解释。",
+        messages=[{"role": "user", "content": "提取字段"}],
+        temperature=0.8,
+        chat_params={"response_format": {"type": "json_object"}},
+    )
+
+    assert "json" in payload["messages"][0]["content"].lower()
+
+
+def test_build_chat_payload_keeps_existing_json_keyword() -> None:
+    payload = _build_chat_completion_payload(
+        model="gpt-compatible",
+        system_prompt="Return a JSON object only.",
+        messages=[{"role": "user", "content": "提取字段"}],
+        temperature=0.8,
+        chat_params={"response_format": {"type": "json_object"}},
+    )
+
+    assert payload["messages"][0]["content"] == "Return a JSON object only."
+
+
 def test_complete_raw_applies_param_filter(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     captured: dict[str, Any] = {}
     client = OpenAICompatibleClient(
@@ -73,6 +97,93 @@ def test_complete_raw_applies_param_filter(monkeypatch) -> None:  # type: ignore
     assert captured["temperature"] == 0.1
     assert captured["max_tokens"] == 8
     assert "unsupported_internal_flag" not in captured
+
+
+def test_complete_raw_retries_without_temperature_when_provider_rejects(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    calls: list[dict[str, Any]] = []
+    client = OpenAICompatibleClient(
+        ApiSettings(
+            base_url="https://api.example.com/v1",
+            api_key="key",
+            model="compatible-model",
+        )
+    )
+
+    def fake_post(payload: dict[str, Any]) -> dict[str, Any]:
+        calls.append(dict(payload))
+        if "temperature" in payload:
+            raise ApiRequestError("Unsupported value: temperature only supports the default value")
+        return {"choices": [{"message": {"content": "OK"}}]}
+
+    monkeypatch.setattr(client, "_post_chat_completions", fake_post)
+
+    assert client.complete_raw(
+        "system",
+        [{"role": "user", "content": "hello"}],
+        temperature=0.8,
+    ) == "OK"
+
+    assert "temperature" in calls[0]
+    assert "temperature" not in calls[1]
+
+
+def test_complete_raw_remembers_temperature_unsupported(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    calls: list[dict[str, Any]] = []
+    client = OpenAICompatibleClient(
+        ApiSettings(
+            base_url="https://api.example.com/v1",
+            api_key="key",
+            model="compatible-model",
+        )
+    )
+
+    def fake_post(payload: dict[str, Any]) -> dict[str, Any]:
+        calls.append(dict(payload))
+        if "temperature" in payload:
+            raise ApiRequestError("temperature does not support non-default values")
+        return {"choices": [{"message": {"content": "OK"}}]}
+
+    monkeypatch.setattr(client, "_post_chat_completions", fake_post)
+
+    client.complete_raw("system", [{"role": "user", "content": "hello"}], temperature=0.8)
+    client.complete_raw("system", [{"role": "user", "content": "again"}], temperature=0.8)
+
+    assert "temperature" in calls[0]
+    assert "temperature" not in calls[1]
+    assert "temperature" not in calls[2]
+
+
+def test_update_settings_clears_cached_unsupported_params(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    calls: list[dict[str, Any]] = []
+    client = OpenAICompatibleClient(
+        ApiSettings(
+            base_url="https://api.example.com/v1",
+            api_key="key",
+            model="old-model",
+        )
+    )
+
+    def fake_post(payload: dict[str, Any]) -> dict[str, Any]:
+        calls.append(dict(payload))
+        if len(calls) == 1:
+            raise ApiRequestError("temperature only supports the default value")
+        return {"choices": [{"message": {"content": "OK"}}]}
+
+    monkeypatch.setattr(client, "_post_chat_completions", fake_post)
+
+    client.complete_raw("system", [{"role": "user", "content": "hello"}], temperature=0.8)
+    client.update_settings(
+        ApiSettings(
+            base_url="https://api.example.com/v1",
+            api_key="key",
+            model="new-model",
+        )
+    )
+    client.complete_raw("system", [{"role": "user", "content": "again"}], temperature=0.8)
+
+    assert "temperature" in calls[0]
+    assert "temperature" not in calls[1]
+    assert "temperature" in calls[2]
 
 
 def test_complete_raw_requests_structured_json_by_default_for_chat(monkeypatch) -> None:  # type: ignore[no-untyped-def]


### PR DESCRIPTION
## Summary
- cache unsupported chat completion parameters after provider rejection
- retry without unsupported temperature or response_format instead of failing the request
- ensure json_object requests include an explicit json keyword for compatible gateways
- include current .gitignore tts ignore change

## Tests
- .\\runtime\\python.exe -m pytest tests/unit/test_api_client.py