### PR TITLE
fix: 修复记忆热重载与弹窗通知

### DIFF
--- a/app/agent/memory.py
+++ b/app/agent/memory.py
@@ -179,11 +179,19 @@ class MemoryStore:
             self._reload_generation += 1
             generation = self._reload_generation
             self._reload_error = ""
+            existing_memory = self._memory
+            reload_llm_only = self._supports_memory_llm_reload(existing_memory)
 
         if wait:
             try:
                 self._publish_status("reloading", "长期记忆系统正在根据新的 API 设置重载。")
-                memory = self._create_memory_client(api_settings)
+                if reload_llm_only:
+                    llm_config, llm = self._create_memory_llm(api_settings)
+                    memory = existing_memory
+                else:
+                    llm_config = None
+                    llm = None
+                    memory = self._create_memory_client(api_settings)
             except Exception as exc:
                 logger.exception("mem0 后台重载失败")
                 current_generation = False
@@ -197,8 +205,14 @@ class MemoryStore:
             applied = False
             with self._lock:
                 if generation == self._reload_generation:
-                    self._memory = memory
+                    if reload_llm_only and self._memory is not existing_memory:
+                        return
+                    if reload_llm_only:
+                        self._apply_memory_llm(memory, llm_config, llm)
+                    else:
+                        self._memory = memory
                     self._load_error = ""
+                    self._reload_error = ""
                     self._loading = False
                     self._reloading = False
                     applied = True
@@ -216,7 +230,13 @@ class MemoryStore:
 
         def reload() -> None:
             try:
-                memory = self._create_memory_client(api_settings)
+                if reload_llm_only:
+                    llm_config, llm = self._create_memory_llm(api_settings)
+                    memory = existing_memory
+                else:
+                    llm_config = None
+                    llm = None
+                    memory = self._create_memory_client(api_settings)
             except Exception as exc:
                 logger.exception("mem0 后台重载失败")
                 current_generation = False
@@ -232,7 +252,12 @@ class MemoryStore:
             with self._lock:
                 if generation != self._reload_generation:
                     return
-                self._memory = memory
+                if reload_llm_only and self._memory is not existing_memory:
+                    return
+                if reload_llm_only:
+                    self._apply_memory_llm(memory, llm_config, llm)
+                else:
+                    self._memory = memory
                 self._load_error = ""
                 self._reload_error = ""
                 self._loading = False
@@ -475,6 +500,34 @@ class MemoryStore:
             from mem0 import Memory
 
             return Memory.from_config(self.build_mem0_config(api_settings))
+
+    def _supports_memory_llm_reload(self, memory: Any | None) -> bool:
+        if memory is None:
+            return False
+        config = getattr(memory, "config", None)
+        return hasattr(memory, "llm") and hasattr(config, "llm")
+
+    def _create_memory_llm(self, api_settings: "ApiSettings") -> tuple[Any, Any]:
+        """只按新 API 设置重建 mem0 的 LLM，避免重开本地 Qdrant 客户端。"""
+
+        with _MEM0_CREATE_LOCK:
+            install_mem0_vendor()
+            from mem0.llms.configs import LlmConfig
+            from mem0.utils.factory import LlmFactory
+
+            llm_section = self.build_mem0_config(api_settings)["llm"]
+            llm_config = LlmConfig(
+                provider=llm_section["provider"],
+                config=dict(llm_section.get("config") or {}),
+            )
+            llm = LlmFactory.create(llm_config.provider, llm_config.config)
+            return llm_config, llm
+
+    def _apply_memory_llm(self, memory: Any, llm_config: Any, llm: Any) -> None:
+        if memory is None or llm_config is None or llm is None:
+            return
+        memory.config.llm = llm_config
+        memory.llm = llm
 
     def _set_status_locked(
         self,

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -121,7 +121,7 @@ from app.ui import (
     capture_virtual_desktop_pixmap,
 )
 from app.ui.styles import pet_window_stylesheet
-from app.ui.theme import DEFAULT_THEME_SETTINGS, ThemeSettings
+from app.ui.theme import DEFAULT_THEME_SETTINGS, ThemeSettings, build_message_box_stylesheet
 from app.voice import VoicePlaybackController
 
 if TYPE_CHECKING:
@@ -152,6 +152,84 @@ REPLY_HISTORY_PREVIOUS_SYMBOL = "▲"
 REPLY_HISTORY_NEXT_SYMBOL = "▼"
 DEFAULT_STAGE_WIDTH = 860
 DEFAULT_STAGE_HEIGHT = 640
+
+
+def _message_box_theme(parent: QWidget | None, theme_settings: ThemeSettings | None) -> ThemeSettings:
+    theme = theme_settings or getattr(parent, "theme_settings", DEFAULT_THEME_SETTINGS)
+    if not isinstance(theme, ThemeSettings):
+        theme = DEFAULT_THEME_SETTINGS
+    return theme.normalized()
+
+
+def show_themed_message_box(
+    parent: QWidget | None,
+    icon: QMessageBox.Icon,
+    title: str,
+    text: str,
+    *,
+    theme_settings: ThemeSettings | None = None,
+    buttons: QMessageBox.StandardButton = QMessageBox.StandardButton.Ok,
+    default_button: QMessageBox.StandardButton = QMessageBox.StandardButton.Ok,
+) -> QMessageBox.StandardButton:
+    """使用当前 Sakura 主题显示 QMessageBox。"""
+
+    box = QMessageBox(parent)
+    box.setIcon(icon)
+    box.setWindowTitle(title)
+    box.setText(text)
+    box.setStandardButtons(buttons)
+    if default_button != QMessageBox.StandardButton.NoButton:
+        box.setDefaultButton(default_button)
+    box.setStyleSheet(build_message_box_stylesheet(_message_box_theme(parent, theme_settings)))
+    return QMessageBox.StandardButton(box.exec())
+
+
+def show_themed_information(
+    parent: QWidget | None,
+    title: str,
+    text: str,
+    *,
+    theme_settings: ThemeSettings | None = None,
+) -> QMessageBox.StandardButton:
+    return show_themed_message_box(
+        parent,
+        QMessageBox.Icon.Information,
+        title,
+        text,
+        theme_settings=theme_settings,
+    )
+
+
+def show_themed_warning(
+    parent: QWidget | None,
+    title: str,
+    text: str,
+    *,
+    theme_settings: ThemeSettings | None = None,
+) -> QMessageBox.StandardButton:
+    return show_themed_message_box(
+        parent,
+        QMessageBox.Icon.Warning,
+        title,
+        text,
+        theme_settings=theme_settings,
+    )
+
+
+def show_themed_critical(
+    parent: QWidget | None,
+    title: str,
+    text: str,
+    *,
+    theme_settings: ThemeSettings | None = None,
+) -> QMessageBox.StandardButton:
+    return show_themed_message_box(
+        parent,
+        QMessageBox.Icon.Critical,
+        title,
+        text,
+        theme_settings=theme_settings,
+    )
 
 
 class PetWindow(QWidget):
@@ -941,7 +1019,7 @@ class PetWindow(QWidget):
         if self.worker_thread is not None:
             return
         if not self.screen_observation_enabled:
-            QMessageBox.information(self, "截图已关闭", "请先在设置中开启屏幕观察权限。")
+            show_themed_information(self, "截图已关闭", "请先在设置中开启屏幕观察权限。")
             return
 
         debug_log("PetWindow", "开始手动框选截图")
@@ -951,7 +1029,7 @@ class PetWindow(QWidget):
         try:
             desktop_pixmap, virtual_geometry = self._capture_virtual_desktop_pixmap()
         except RuntimeError as exc:
-            QMessageBox.warning(self, "截图失败", str(exc))
+            show_themed_warning(self, "截图失败", str(exc))
             debug_log("PetWindow", "手动框选截图启动失败", {"error": str(exc)})
             return
 
@@ -974,7 +1052,7 @@ class PetWindow(QWidget):
         try:
             observation = build_screen_observation_from_pixmap(pixmap)
         except RuntimeError as exc:
-            QMessageBox.warning(self, "截图失败", str(exc))
+            show_themed_warning(self, "截图失败", str(exc))
             debug_log("PetWindow", "手动框选截图编码失败", {"error": str(exc)})
             return
 
@@ -1058,7 +1136,7 @@ class PetWindow(QWidget):
             self._end_interaction("ignored")
             return
         if manual_observation is not None and not self.screen_observation_enabled:
-            QMessageBox.information(self, "截图已关闭", "屏幕观察权限已关闭，本次截图不会发送。")
+            show_themed_information(self, "截图已关闭", "屏幕观察权限已关闭，本次截图不会发送。")
             self._clear_manual_screen_observation()
             self._end_interaction("ignored")
             return
@@ -1783,7 +1861,7 @@ class PetWindow(QWidget):
             self.messages.pop()
         self._record_history("error", message)
         self.subtitle_controller.cancel_reply_flow("……通信に失敗した。設定を確認して。")
-        QMessageBox.warning(self, "请求失败", message)
+        show_themed_warning(self, "请求失败", message)
         self._end_interaction("error")
 
     @Slot()
@@ -1939,7 +2017,7 @@ class PetWindow(QWidget):
         )
         if mode == "history_clear":
             if result.processed_entries > 0 and result.returned == 0:
-                QMessageBox.warning(
+                show_themed_warning(
                     self,
                     "整理失败",
                     "记忆整理没有写入任何结果，已保留聊天历史。请检查日志后再重试。",
@@ -1949,11 +2027,11 @@ class PetWindow(QWidget):
                 self.history_store.clear()
                 self.memory_curation_state.mark_history_cleared()
             except OSError as exc:
-                QMessageBox.warning(self, "清空失败", f"记忆已整理，但清空历史失败：{exc}")
+                show_themed_warning(self, "清空失败", f"记忆已整理，但清空历史失败：{exc}")
             else:
                 if self.history_window is not None:
                     self.history_window.refresh()
-                QMessageBox.information(self, "整理完成", result.summary())
+                show_themed_information(self, "整理完成", result.summary())
             return
 
         self.memory_curation_state.mark_processed(
@@ -1973,7 +2051,7 @@ class PetWindow(QWidget):
             },
         )
         if self.memory_curation_mode == "history_clear":
-            QMessageBox.warning(self, "整理失败", f"历史没有清空，原因：{message}")
+            show_themed_warning(self, "整理失败", f"历史没有清空，原因：{message}")
 
     @Slot()
     def _cleanup_memory_curation_worker(self) -> None:
@@ -2180,6 +2258,7 @@ class PetWindow(QWidget):
             self._show_memory_ready_message(message)
 
     def _show_memory_status_message(self, status: str, message: str) -> None:
+        _ = status
         self.memory_status_message_active = True
         self.memory_status_last_message = message
         if (
@@ -2188,13 +2267,6 @@ class PetWindow(QWidget):
             and not self.reply_history_review_active
         ):
             self.subtitle_controller.show_text_immediately(message)
-        if hasattr(self, "tray_icon") and self.tray_icon.isVisible():
-            icon = (
-                QSystemTrayIcon.MessageIcon.Critical
-                if status == "failed"
-                else QSystemTrayIcon.MessageIcon.Information
-            )
-            self.tray_icon.showMessage("Sakura 长期记忆", message, icon, MEMORY_STATUS_DISPLAY_MS)
 
     @Slot()
     def _show_pending_memory_status_after_startup(self) -> None:
@@ -2209,13 +2281,7 @@ class PetWindow(QWidget):
         self.subtitle_controller.show_text_immediately(self.memory_status_last_message)
 
     def _show_memory_ready_message(self, message: str) -> None:
-        if hasattr(self, "tray_icon") and self.tray_icon.isVisible():
-            self.tray_icon.showMessage(
-                "Sakura 长期记忆",
-                message,
-                QSystemTrayIcon.MessageIcon.Information,
-                MEMORY_STATUS_DISPLAY_MS,
-            )
+        _ = message
         if not self.memory_status_message_active:
             return
         self.memory_status_message_active = False
@@ -2293,12 +2359,12 @@ class PetWindow(QWidget):
 
     def _save_history_to_memory_and_clear(self) -> None:
         if self.memory_curation_thread is not None:
-            QMessageBox.information(self, "整理中", "记忆整理已经在进行中，请稍后再试。")
+            show_themed_information(self, "整理中", "记忆整理已经在进行中，请稍后再试。")
             if self.history_window is not None:
                 self.history_window.set_memory_save_busy(False)
             return
         if self.worker_thread is not None:
-            QMessageBox.information(self, "正在回复", "当前聊天还没处理完，稍后再整理历史。")
+            show_themed_information(self, "正在回复", "当前聊天还没处理完，稍后再整理历史。")
             if self.history_window is not None:
                 self.history_window.set_memory_save_busy(False)
             return
@@ -2325,7 +2391,7 @@ class PetWindow(QWidget):
                 character_profile=self.character_profile,
             )
         except (OSError, TTSConfigError) as exc:
-            QMessageBox.warning(self, "配置读取失败", f"TTS 配置读取失败，将使用默认值打开设置：{exc}")
+            show_themed_warning(self, "配置读取失败", f"TTS 配置读取失败，将使用默认值打开设置：{exc}")
             tts_settings = self._default_tts_settings()
 
         dialog = SettingsDialog(
@@ -2388,7 +2454,7 @@ class PetWindow(QWidget):
         try:
             selected_profile = dialog_character_registry.get(dialog.result_character_id)
         except CharacterConfigError as exc:
-            QMessageBox.critical(self, "角色配置无效", str(exc))
+            show_themed_critical(self, "角色配置无效", str(exc))
             return
 
         new_tts_provider = self._create_tts_provider_from_settings(dialog.result_tts_settings)
@@ -2421,7 +2487,7 @@ class PetWindow(QWidget):
                 },
             )
         except OSError as exc:
-            QMessageBox.critical(self, "保存失败", f"无法保存设置：{exc}")
+            show_themed_critical(self, "保存失败", f"无法保存设置：{exc}")
             return
 
         if api_changed:
@@ -2462,7 +2528,7 @@ class PetWindow(QWidget):
             message += "\n\nWindows MCP 开关需要重启 Sakura 后才会生效。"
         if getattr(dialog, "result_plugin_config_changed", False):
             message += "\n\n插件启用状态需要重启 Sakura 后才会生效。"
-        QMessageBox.information(self, "保存成功", message)
+        show_themed_information(self, "保存成功", message)
 
     @Slot(bool)
     def _toggle_chinese_subtitles(self, checked: bool) -> None:
@@ -2480,7 +2546,7 @@ class PetWindow(QWidget):
         except OSError as exc:
             self.subtitle_language = previous_language
             self._apply_speech_font()
-            QMessageBox.warning(self, "保存失败", f"无法保存字幕设置：{exc}")
+            show_themed_warning(self, "保存失败", f"无法保存字幕设置：{exc}")
             return
 
         self._apply_speech_font()
@@ -2515,7 +2581,7 @@ class PetWindow(QWidget):
                 },
             )
         except OSError as exc:
-            QMessageBox.warning(self, "保存失败", f"无法保存自主看屏幕设置：{exc}")
+            show_themed_warning(self, "保存失败", f"无法保存自主看屏幕设置：{exc}")
         if hasattr(self, "tray_icon"):
             self.tray_icon.setContextMenu(self._build_menu())
 
@@ -2537,7 +2603,7 @@ class PetWindow(QWidget):
             self._save_system_config_values("ui", {"always_on_top_enabled": checked})
         except OSError as exc:
             self.always_on_top_enabled = previous_enabled
-            QMessageBox.warning(self, "保存失败", f"无法保存置顶设置：{exc}")
+            show_themed_warning(self, "保存失败", f"无法保存置顶设置：{exc}")
             return
 
         self._apply_window_flags()
@@ -2567,7 +2633,7 @@ class PetWindow(QWidget):
             return provider
         except TTSConfigError as exc:
             debug_log("PetWindow", "TTS 配置无效", {"error": str(exc)})
-            QMessageBox.critical(self, "TTS 配置无效", f"无法启用 TTS，当前语音配置保持不变：{exc}")
+            show_themed_critical(self, "TTS 配置无效", f"无法启用 TTS，当前语音配置保持不变：{exc}")
             return None
 
     def _retire_tts_provider(self, provider: TTSProvider) -> None:

--- a/app/ui/theme.py
+++ b/app/ui/theme.py
@@ -537,6 +537,43 @@ QPushButton:disabled {{
 """
 
 
+def build_message_box_stylesheet(settings: ThemeSettings) -> str:
+    theme = settings.normalized()
+    return f"""
+QMessageBox {{
+    background: {theme.page_background_color};
+    color: {theme.text_color};
+    font-family: "Microsoft YaHei", "Yu Gothic UI", sans-serif;
+    font-size: 14px;
+}}
+QMessageBox QLabel {{
+    color: {theme.text_color};
+    font-size: 14px;
+    line-height: 1.35;
+}}
+QMessageBox QPushButton {{
+    background: {theme.primary_color};
+    border: 1px solid {rgba(theme.accent_color, 140)};
+    border-radius: 8px;
+    color: white;
+    min-width: 76px;
+    padding: 7px 14px;
+    font-weight: 600;
+}}
+QMessageBox QPushButton:hover {{
+    background: {theme.primary_hover_color};
+}}
+QMessageBox QPushButton:pressed {{
+    background: {theme.accent_color};
+}}
+QMessageBox QPushButton:disabled {{
+    background: {rgba(theme.primary_color, 107)};
+    border: 1px solid {rgba(theme.border_color, 115)};
+    color: rgba(255, 255, 255, 0.76);
+}}
+"""
+
+
 def build_history_window_stylesheet(settings: ThemeSettings) -> str:
     theme = settings.normalized()
     return f"""

--- a/tests/integration/test_agent_core.py
+++ b/tests/integration/test_agent_core.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import sys
 import threading
 import time
+from types import SimpleNamespace
 import uuid
 
 import pytest
@@ -398,6 +399,88 @@ def test_memory_store_reload_keeps_old_runtime_until_new_runtime_is_ready() -> N
         if store._memory is not old_runtime:
             break
         time.sleep(0.05)
+    assert store._memory == {"settings": new_settings}
+
+
+def test_memory_store_reload_existing_runtime_replaces_only_llm() -> None:
+    old_settings = ApiSettings("https://old.example.com/v1", "old-key", "old-model")
+    new_settings = ApiSettings("https://new.example.com/v1", "new-key", "new-model")
+
+    class HotReloadMemoryStore(MemoryStore):
+        def __init__(self) -> None:
+            super().__init__(
+                base_dir=_runtime_root_path("memory_reload_llm_only"),
+                api_settings=old_settings,
+            )
+            self.create_memory_calls = 0
+            self.create_llm_calls = 0
+
+        def _create_memory_client(self, api_settings=None):  # type: ignore[no-untyped-def]
+            self.create_memory_calls += 1
+            return {"settings": api_settings}
+
+        def _create_memory_llm(self, api_settings):  # type: ignore[no-untyped-def]
+            self.create_llm_calls += 1
+            return {"settings": api_settings}, {"settings": api_settings}
+
+    store = HotReloadMemoryStore()
+    old_config = {"settings": old_settings}
+    old_llm = {"settings": old_settings}
+    runtime = SimpleNamespace(config=SimpleNamespace(llm=old_config), llm=old_llm)
+    store._memory = runtime
+
+    store.reload_api_settings(new_settings, wait=True)
+
+    assert store._memory is runtime
+    assert store.create_memory_calls == 0
+    assert store.create_llm_calls == 1
+    assert runtime.config.llm == {"settings": new_settings}
+    assert runtime.llm == {"settings": new_settings}
+    assert store._reload_error == ""
+
+
+def test_memory_store_reload_llm_failure_keeps_old_runtime_llm() -> None:
+    old_settings = ApiSettings("https://old.example.com/v1", "old-key", "old-model")
+    new_settings = ApiSettings("https://new.example.com/v1", "new-key", "new-model")
+
+    class FailingLlmReloadMemoryStore(MemoryStore):
+        def _create_memory_llm(self, api_settings):  # type: ignore[no-untyped-def]
+            raise RuntimeError("llm failed")
+
+    store = FailingLlmReloadMemoryStore(
+        base_dir=_runtime_root_path("memory_reload_llm_failure"),
+        api_settings=old_settings,
+    )
+    old_config = {"settings": old_settings}
+    old_llm = {"settings": old_settings}
+    runtime = SimpleNamespace(config=SimpleNamespace(llm=old_config), llm=old_llm)
+    store._memory = runtime
+
+    store.reload_api_settings(new_settings, wait=True)
+
+    assert store._memory is runtime
+    assert runtime.config.llm is old_config
+    assert runtime.llm is old_llm
+    assert store._reload_error == "llm failed"
+
+
+def test_memory_store_reload_without_runtime_still_creates_memory_client() -> None:
+    new_settings = ApiSettings("https://new.example.com/v1", "new-key", "new-model")
+
+    class ColdReloadMemoryStore(MemoryStore):
+        def __init__(self) -> None:
+            super().__init__(base_dir=_runtime_root_path("memory_reload_cold"))
+            self.create_memory_calls = 0
+
+        def _create_memory_client(self, api_settings=None):  # type: ignore[no-untyped-def]
+            self.create_memory_calls += 1
+            return {"settings": api_settings}
+
+    store = ColdReloadMemoryStore()
+
+    store.reload_api_settings(new_settings, wait=True)
+
+    assert store.create_memory_calls == 1
     assert store._memory == {"settings": new_settings}
 
 

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -15,7 +15,12 @@ from app.config.settings_service import DebugLogSettings
 from app.llm.api_client import ApiSettings
 from app.llm.chat_reply import ChatSegment
 from app.ui.portrait_utils import portrait_kind_key, should_crossfade_portrait
-from app.ui.theme import DEFAULT_THEME_SETTINGS, ThemeSettings, build_pet_window_stylesheet
+from app.ui.theme import (
+    DEFAULT_THEME_SETTINGS,
+    ThemeSettings,
+    build_message_box_stylesheet,
+    build_pet_window_stylesheet,
+)
 from app.agent.proactive_care import ProactiveCareSettings
 from app.agent.screen_observation import ScreenObservation
 from app.voice.tts import GPTSoVITSTTSSettings
@@ -151,6 +156,75 @@ def test_pet_window_status_tray_icon_is_not_empty() -> None:
 
     assert not icon.isNull()
     app.processEvents()
+
+
+def test_memory_status_does_not_use_tray_balloon(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    import app.ui.pet_window as pet_window_module
+    from app.ui.pet_window import PetWindow
+
+    class TrayIconStub:
+        def __init__(self) -> None:
+            self.messages: list[tuple[object, ...]] = []
+
+        def isVisible(self) -> bool:
+            return True
+
+        def showMessage(self, *args) -> None:  # type: ignore[no-untyped-def]
+            self.messages.append(args)
+
+    class SubtitleControllerStub:
+        def __init__(self) -> None:
+            self.messages: list[str] = []
+
+        def show_text_immediately(self, message: str) -> None:
+            self.messages.append(message)
+
+    single_shots: list[tuple[int, object]] = []
+    monkeypatch.setattr(
+        pet_window_module.QTimer,
+        "singleShot",
+        lambda delay, callback: single_shots.append((delay, callback)),
+    )
+    window = type("WindowStub", (), {})()
+    window.memory_status_message_active = False
+    window.memory_status_last_message = ""
+    window.startup_initializing = False
+    window.active_interaction_id = None
+    window.reply_history_review_active = False
+    window.subtitle_controller = SubtitleControllerStub()
+    window.tray_icon = TrayIconStub()
+    window._restore_memory_status_speech = lambda: None
+
+    for status in ("loading", "reloading", "failed"):
+        PetWindow._show_memory_status_message(window, status, f"{status} message")
+    PetWindow._show_memory_ready_message(window, "ready message")
+
+    assert window.tray_icon.messages == []
+    assert window.subtitle_controller.messages == [
+        "loading message",
+        "reloading message",
+        "failed message",
+    ]
+    assert single_shots == [(pet_window_module.MEMORY_STATUS_DISPLAY_MS, window._restore_memory_status_speech)]
+
+
+def test_message_box_stylesheet_contains_configured_theme_colors() -> None:
+    theme = ThemeSettings(
+        primary_color="#112233",
+        primary_hover_color="#223344",
+        accent_color="#334455",
+        text_color="#445566",
+        page_background_color="#ddeeff",
+        border_color="#556677",
+    )
+
+    stylesheet = build_message_box_stylesheet(theme)
+
+    assert "#112233" in stylesheet
+    assert "#223344" in stylesheet
+    assert "#334455" in stylesheet
+    assert "#445566" in stylesheet
+    assert "#ddeeff" in stylesheet
 
 
 def test_pet_window_hide_and_show_to_tray_tracks_hidden_state() -> None:
@@ -2603,7 +2677,7 @@ def test_show_settings_does_not_save_or_reload_api_when_unchanged(monkeypatch) -
         MemoryStoreStub(),
     )
     monkeypatch.setattr(pet_window_module, "SettingsDialog", DialogStub)
-    monkeypatch.setattr(pet_window_module.QMessageBox, "information", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(pet_window_module, "show_themed_information", lambda *_args, **_kwargs: None)
 
     window.show_settings()
 
@@ -2676,7 +2750,7 @@ def test_show_settings_saves_and_applies_subtitle_display_speed(monkeypatch) -> 
         MemoryStoreStub(),
     )
     monkeypatch.setattr(pet_window_module, "SettingsDialog", DialogStub)
-    monkeypatch.setattr(pet_window_module.QMessageBox, "information", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(pet_window_module, "show_themed_information", lambda *_args, **_kwargs: None)
 
     window.show_settings()
 
@@ -2722,8 +2796,12 @@ def test_history_clear_keeps_history_when_memory_curation_returns_nothing(monkey
     window.memory_curation_state = MemoryCurationStateStub()
     window.history_window = None
 
-    monkeypatch.setattr(pet_window_module.QMessageBox, "warning", lambda _parent, title, text: warnings.append((title, text)))
-    monkeypatch.setattr(pet_window_module.QMessageBox, "information", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        pet_window_module,
+        "show_themed_warning",
+        lambda _parent, title, text: warnings.append((title, text)),
+    )
+    monkeypatch.setattr(pet_window_module, "show_themed_information", lambda *_args, **_kwargs: None)
 
     window._handle_memory_curation_finished(
         MemoryCurationResult(ignored=3, processed_entries=3, returned=0)
@@ -2803,9 +2881,9 @@ def test_show_settings_reloads_memory_in_background_when_api_changes(monkeypatch
     )
     monkeypatch.setattr(pet_window_module, "SettingsDialog", DialogStub)
     monkeypatch.setattr(
-        pet_window_module.QMessageBox,
-        "information",
-        lambda *_args, **_kwargs: messages.append(str(_args[2])),
+        pet_window_module,
+        "show_themed_information",
+        lambda _parent, _title, text, **_kwargs: messages.append(str(text)),
     )
 
     window.show_settings()
@@ -2895,7 +2973,7 @@ def test_show_settings_uses_dialog_refreshed_character_registry(monkeypatch) -> 
         MemoryStoreStub(),
     )
     monkeypatch.setattr(pet_window_module, "SettingsDialog", DialogStub)
-    monkeypatch.setattr(pet_window_module.QMessageBox, "information", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(pet_window_module, "show_themed_information", lambda *_args, **_kwargs: None)
 
     window.show_settings()
 


### PR DESCRIPTION
## 变更
- 长期记忆 API 热重载时只替换 mem0 LLM，避免重建本地 Qdrant 客户端导致 Windows 文件锁冲突
- 移除长期记忆状态的 Windows 托盘气泡通知，保留应用内提示
- 为 PetWindow 弹窗接入当前 Sakura 主题样式

## 验证
- .\\runtime\\python.exe -m pytest tests\\integration\\test_agent_core.py
- .\\runtime\\python.exe -m pytest tests\\ui\\test_pet_window.py
- .\\runtime\\python.exe -m pytest tests\\unit\\test_settings_service.py