### PR TITLE
feat: 为 API 设置页加入模型列表检测

### DIFF
--- a/app/llm/api_client.py
+++ b/app/llm/api_client.py
@@ -101,6 +101,34 @@ class OpenAICompatibleClient:
 
         return str(content).strip() or "OK"
 
+    def list_models(self) -> list[str]:
+        """读取 OpenAI 兼容 /models 接口，返回可选择的模型 id 列表。"""
+        self._ensure_model_list_config()
+        url = f"{self.settings.base_url}/models"
+        request = urllib.request.Request(
+            url=url,
+            method="GET",
+            headers={
+                "Authorization": f"Bearer {self.settings.api_key}",
+            },
+        )
+        debug_log(
+            "API",
+            "准备检测模型列表",
+            {
+                "url": url,
+                "timeout_seconds": self.settings.timeout_seconds,
+            },
+        )
+        response_body = self._send_with_retries(request)
+
+        try:
+            data: dict[str, Any] = json.loads(response_body)
+        except json.JSONDecodeError as exc:
+            raise ApiRequestError(f"API 返回格式无法解析：{response_body}") from exc
+
+        return _parse_model_ids(data)
+
     def chat(
         self,
         system_prompt: str,
@@ -282,6 +310,12 @@ class OpenAICompatibleClient:
         if not self.settings.model:
             raise ApiConfigError("缺少 MODEL。")
 
+    def _ensure_model_list_config(self) -> None:
+        if not self.settings.api_key:
+            raise ApiConfigError("缺少 API_KEY。请在设置中填写 API Key。")
+        if not self.settings.base_url:
+            raise ApiConfigError("缺少 BASE_URL。")
+
     def _post_chat_completions(self, payload: dict[str, Any]) -> dict[str, Any]:
         """调用 OpenAI 兼容的 chat/completions 接口并返回 JSON 数据。"""
         body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
@@ -410,6 +444,22 @@ def _build_segmented_reply_instruction(
     reply_portraits: list[str] | None = None,
 ) -> str:
     return build_segmented_reply_instruction(reply_tones, reply_portraits)
+
+
+def _parse_model_ids(data: dict[str, Any]) -> list[str]:
+    """解析 /models 响应中的模型 id，过滤坏数据并稳定排序。"""
+    raw_models = data.get("data")
+    if not isinstance(raw_models, list):
+        raise ApiRequestError(f"API 模型列表格式无法解析：{json.dumps(data, ensure_ascii=False)}")
+
+    model_ids: set[str] = set()
+    for item in raw_models:
+        if not isinstance(item, dict):
+            continue
+        model_id = item.get("id")
+        if isinstance(model_id, str) and model_id.strip():
+            model_ids.add(model_id.strip())
+    return sorted(model_ids, key=str.casefold)
 
 
 def _build_chat_completion_payload(

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -8,12 +8,13 @@ from pathlib import Path
 from typing import Literal
 from urllib.parse import urlparse
 
-from PySide6.QtCore import QObject, Qt, QThread, QTimer, Signal, Slot
+from PySide6.QtCore import QObject, QStringListModel, Qt, QThread, QTimer, Signal, Slot
 from PySide6.QtGui import QAction, QBrush, QColor
 from PySide6.QtWidgets import (
     QAbstractItemView,
     QCheckBox,
     QComboBox,
+    QCompleter,
     QDialog,
     QDialogButtonBox,
     QColorDialog,
@@ -137,6 +138,61 @@ class ApiConnectionTestWorker(QObject):
             self.succeeded.emit(message)
         finally:
             self.finished.emit()
+
+
+class ApiModelListProbeWorker(QObject):
+    succeeded = Signal(list)
+    failed = Signal(str)
+    finished = Signal()
+
+    def __init__(self, settings: ApiSettings) -> None:
+        super().__init__()
+        self.settings = settings
+
+    @Slot()
+    def run(self) -> None:
+        try:
+            models = OpenAICompatibleClient(self.settings).list_models()
+        except Exception as exc:  # UI 边界统一转成可读错误。
+            self.failed.emit(str(exc))
+        else:
+            self.succeeded.emit(models)
+        finally:
+            self.finished.emit()
+
+
+class ModelComboBox(QComboBox):
+    """可编辑模型选择框，保留 QLineEdit 风格的 text/setText 兼容接口。"""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._model_names: list[str] = []
+        self._completion_model = QStringListModel(self)
+        completer = QCompleter(self._completion_model, self)
+        completer.setCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
+        completer.setFilterMode(Qt.MatchFlag.MatchContains)
+        self.setEditable(True)
+        self.setInsertPolicy(QComboBox.InsertPolicy.NoInsert)
+        self.setCompleter(completer)
+
+    def setText(self, text: str) -> None:
+        self.setEditText(text)
+
+    def text(self) -> str:
+        return self.currentText()
+
+    def set_model_names(self, model_names: list[str]) -> None:
+        current_text = self.currentText().strip()
+        self._model_names = list(model_names)
+        self.blockSignals(True)
+        self.clear()
+        self.addItems(self._model_names)
+        self._completion_model.setStringList(self._model_names)
+        if current_text:
+            self.setEditText(current_text)
+        elif self._model_names:
+            self.setCurrentIndex(0)
+        self.blockSignals(False)
 
 
 class TTSTestWorker(QObject):
@@ -342,6 +398,8 @@ class SettingsDialog(QDialog):
         self.result_plugin_config_changed = False
         self._api_test_thread: QThread | None = None
         self._api_test_worker: ApiConnectionTestWorker | None = None
+        self._api_model_probe_thread: QThread | None = None
+        self._api_model_probe_worker: ApiModelListProbeWorker | None = None
         self._tts_test_thread: QThread | None = None
         self._tts_test_worker: TTSTestWorker | None = None
         self._pending_api_accept_values: dict[str, object] | None = None
@@ -642,7 +700,8 @@ class SettingsDialog(QDialog):
         self.api_key_edit.setEchoMode(QLineEdit.EchoMode.Password)
         self.api_key_edit.setPlaceholderText("请输入 API Key")
 
-        self.model_edit = QLineEdit(settings.model, tab)
+        self.model_edit = ModelComboBox(tab)
+        self.model_edit.setText(settings.model)
         self.model_edit.setPlaceholderText("gpt-4.1-mini")
 
         self.api_timeout_spin = QSpinBox(tab)
@@ -650,8 +709,18 @@ class SettingsDialog(QDialog):
         self.api_timeout_spin.setSuffix(" 秒")
         self.api_timeout_spin.setValue(settings.timeout_seconds)
 
+        self.api_model_probe_button = QPushButton("检测模型", tab)
+        self.api_model_probe_button.clicked.connect(self._probe_api_models)
+
         self.api_test_button = QPushButton("测试 API", tab)
         self.api_test_button.clicked.connect(self._test_api_settings)
+
+        api_actions = QWidget(tab)
+        api_actions_layout = QHBoxLayout(api_actions)
+        api_actions_layout.setContentsMargins(0, 0, 0, 0)
+        api_actions_layout.setSpacing(8)
+        api_actions_layout.addWidget(self.api_model_probe_button)
+        api_actions_layout.addWidget(self.api_test_button)
 
         form_layout = QFormLayout()
         form_layout.setContentsMargins(16, 18, 16, 16)
@@ -660,7 +729,7 @@ class SettingsDialog(QDialog):
         form_layout.addRow("API Key", self.api_key_edit)
         form_layout.addRow("模型", self.model_edit)
         form_layout.addRow("超时", self.api_timeout_spin)
-        form_layout.addRow("", self.api_test_button)
+        form_layout.addRow("", api_actions)
         tab.setLayout(form_layout)
         return tab
 
@@ -1799,6 +1868,9 @@ class SettingsDialog(QDialog):
         if self._api_test_thread is not None:
             QMessageBox.information(self, "测试中", "API 测试仍在进行，请等待完成后再保存设置。")
             return
+        if self._api_model_probe_thread is not None:
+            QMessageBox.information(self, "检测中", "模型列表仍在检测，请等待完成后再保存设置。")
+            return
         if self._tts_test_thread is not None:
             QMessageBox.information(self, "检测中", "TTS 服务检测仍在进行，请等待完成后再保存设置。")
             return
@@ -1952,6 +2024,9 @@ class SettingsDialog(QDialog):
         if self._api_test_thread is not None:
             QMessageBox.information(self, "测试中", "API 测试仍在进行，请等待完成后再关闭设置。")
             return
+        if self._api_model_probe_thread is not None:
+            QMessageBox.information(self, "检测中", "模型列表仍在检测，请等待完成后再关闭设置。")
+            return
         if self._tts_test_thread is not None:
             QMessageBox.information(self, "检测中", "TTS 服务检测仍在进行，请等待完成后再关闭设置。")
             return
@@ -1966,6 +2041,10 @@ class SettingsDialog(QDialog):
     def closeEvent(self, event):  # type: ignore[no-untyped-def]
         if self._api_test_thread is not None:
             QMessageBox.information(self, "测试中", "API 测试仍在进行，请等待完成后再关闭设置。")
+            event.ignore()
+            return
+        if self._api_model_probe_thread is not None:
+            QMessageBox.information(self, "检测中", "模型列表仍在检测，请等待完成后再关闭设置。")
             event.ignore()
             return
         if self._tts_test_thread is not None:
@@ -1984,7 +2063,7 @@ class SettingsDialog(QDialog):
 
     def _test_api_settings(self) -> None:
         settings = self._validated_api_settings()
-        if settings is None or self._api_test_thread is not None:
+        if settings is None or self._api_test_thread is not None or self._api_model_probe_thread is not None:
             return
 
         self._start_api_settings_test(settings)
@@ -1994,7 +2073,7 @@ class SettingsDialog(QDialog):
         settings: ApiSettings,
         accept_values: dict[str, object] | None = None,
     ) -> None:
-        if self._api_test_thread is not None:
+        if self._api_test_thread is not None or self._api_model_probe_thread is not None:
             return
 
         self._pending_api_accept_values = dict(accept_values) if accept_values is not None else None
@@ -2039,6 +2118,7 @@ class SettingsDialog(QDialog):
     def _set_api_test_busy(self, busy: bool) -> None:
         self.api_test_button.setEnabled(not busy)
         self.api_test_button.setText("测试中..." if busy else "测试 API")
+        self.api_model_probe_button.setEnabled(not busy)
         if not hasattr(self, "button_box"):
             return
         save_button = self.button_box.button(QDialogButtonBox.StandardButton.Save)
@@ -2049,6 +2129,65 @@ class SettingsDialog(QDialog):
                 self._save_button_text = save_button.text()
             save_button.setText("测试 API...")
         elif self._tts_test_thread is not None:
+            return
+        elif self._save_button_text is not None:
+            save_button.setText(self._save_button_text)
+            self._save_button_text = None
+
+    def _probe_api_models(self) -> None:
+        settings = self._validated_api_model_probe_settings()
+        if settings is None or self._api_model_probe_thread is not None or self._api_test_thread is not None:
+            return
+
+        self._set_api_model_probe_busy(True)
+        thread = QThread()
+        worker = ApiModelListProbeWorker(settings)
+        worker.moveToThread(thread)
+        thread.started.connect(worker.run)
+        worker.succeeded.connect(self._handle_api_model_probe_success)
+        worker.failed.connect(self._handle_api_model_probe_failed)
+        worker.finished.connect(thread.quit)
+        worker.finished.connect(worker.deleteLater)
+        thread.finished.connect(thread.deleteLater)
+        thread.finished.connect(self._reset_api_model_probe_state)
+
+        self._api_model_probe_thread = thread
+        self._api_model_probe_worker = worker
+        thread.start()
+
+    @Slot(list)
+    def _handle_api_model_probe_success(self, model_names: list[str]) -> None:
+        if not model_names:
+            QMessageBox.warning(self, "探测失败", "模型列表为空，请检查服务是否暴露 /models 接口。")
+            return
+        self.model_edit.set_model_names(model_names)
+        QMessageBox.information(self, "探测成功", f"已发现 {len(model_names)} 个模型。")
+
+    @Slot(str)
+    def _handle_api_model_probe_failed(self, message: str) -> None:
+        QMessageBox.warning(self, "探测失败", message)
+
+    @Slot()
+    def _reset_api_model_probe_state(self) -> None:
+        self._api_model_probe_thread = None
+        self._api_model_probe_worker = None
+        self._set_api_model_probe_busy(False)
+
+    def _set_api_model_probe_busy(self, busy: bool) -> None:
+        self.api_model_probe_button.setEnabled(not busy)
+        self.api_model_probe_button.setText("检测中..." if busy else "检测模型")
+        self.api_test_button.setEnabled(not busy)
+        if not hasattr(self, "button_box"):
+            return
+        save_button = self.button_box.button(QDialogButtonBox.StandardButton.Save)
+        if save_button is None:
+            return
+        if busy:
+            if self._save_button_text is None:
+                self._save_button_text = save_button.text()
+            save_button.setText("检测模型...")
+            save_button.setEnabled(False)
+        elif self._api_test_thread is not None or self._tts_test_thread is not None:
             return
         elif self._save_button_text is not None:
             save_button.setText(self._save_button_text)
@@ -2395,6 +2534,24 @@ class SettingsDialog(QDialog):
             base_url=base_url,
             api_key=api_key,
             model=model,
+            timeout_seconds=self.api_timeout_spin.value(),
+        )
+
+    def _validated_api_model_probe_settings(self) -> ApiSettings | None:
+        base_url = self.base_url_edit.text().strip().rstrip("/")
+        api_key = self.api_key_edit.text().strip()
+
+        if not _is_http_url(base_url):
+            QMessageBox.warning(self, "配置无效", "Base URL 必须是有效的 http 或 https 地址。")
+            return None
+        if not api_key:
+            QMessageBox.warning(self, "配置无效", "API Key 不能为空。")
+            return None
+
+        return ApiSettings(
+            base_url=base_url,
+            api_key=api_key,
+            model=self.model_edit.text().strip(),
             timeout_seconds=self.api_timeout_spin.value(),
         )
 

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -2136,9 +2136,13 @@ class SettingsDialog(QDialog):
 
     def _probe_api_models(self) -> None:
         settings = self._validated_api_model_probe_settings()
-        if settings is None or self._api_model_probe_thread is not None or self._api_test_thread is not None:
+        if (
+            settings is None
+            or self._api_model_probe_thread is not None
+            or self._api_test_thread is not None
+            or self._tts_test_thread is not None
+        ):
             return
-
         self._set_api_model_probe_busy(True)
         thread = QThread()
         worker = ApiModelListProbeWorker(settings)

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -2063,7 +2063,12 @@ class SettingsDialog(QDialog):
 
     def _test_api_settings(self) -> None:
         settings = self._validated_api_settings()
-        if settings is None or self._api_test_thread is not None or self._api_model_probe_thread is not None:
+        if (
+            settings is None
+            or self._api_test_thread is not None
+            or self._api_model_probe_thread is not None
+            or self._tts_test_thread is not None
+        ):
             return
 
         self._start_api_settings_test(settings)

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -1681,6 +1681,121 @@ def test_settings_dialog_tests_api_when_api_changes(monkeypatch) -> None:  # typ
     app.processEvents()
 
 
+def test_settings_dialog_model_combo_saves_manual_input(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    if not hasattr(qtwidgets, "QApplication"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+
+    dialog, app = _build_api_settings_dialog("api_manual_model")
+    dialog.model_edit.setText("manual-model")
+    monkeypatch.setattr(dialog, "_start_api_settings_test", lambda settings, accept_values=None: dialog._continue_accept_after_api_test(accept_values))
+
+    dialog.accept()
+
+    assert dialog.result_api_settings is not None
+    assert dialog.result_api_settings.model == "manual-model"
+    dialog.deleteLater()
+    app.processEvents()
+
+
+def test_settings_dialog_model_probe_populates_candidates_and_selects_first(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    if not hasattr(qtwidgets, "QApplication"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+
+    import app.ui.settings_dialog as settings_dialog_module
+
+    dialog, app = _build_api_settings_dialog("api_model_probe_empty", model="")
+    infos: list[str] = []
+    monkeypatch.setattr(
+        settings_dialog_module.QMessageBox,
+        "information",
+        lambda _parent, _title, message: infos.append(message),
+    )
+
+    dialog._handle_api_model_probe_success(["z-model", "a-model"])
+
+    assert dialog.model_edit.currentText() == "z-model"
+    assert [dialog.model_edit.itemText(index) for index in range(dialog.model_edit.count())] == ["z-model", "a-model"]
+    assert infos and "2" in infos[0]
+    dialog.deleteLater()
+    app.processEvents()
+
+
+def test_settings_dialog_model_probe_keeps_current_input(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    if not hasattr(qtwidgets, "QApplication"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+
+    import app.ui.settings_dialog as settings_dialog_module
+
+    dialog, app = _build_api_settings_dialog("api_model_probe_keep_input", model="custom-model")
+    monkeypatch.setattr(settings_dialog_module.QMessageBox, "information", lambda *_args: None)
+
+    dialog._handle_api_model_probe_success(["a-model", "b-model"])
+
+    assert dialog.model_edit.currentText() == "custom-model"
+    assert dialog.model_edit.completer().completionModel().rowCount() == 2
+    dialog.deleteLater()
+    app.processEvents()
+
+
+def test_settings_dialog_model_probe_failure_keeps_current_model(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    if not hasattr(qtwidgets, "QApplication"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+
+    import app.ui.settings_dialog as settings_dialog_module
+
+    dialog, app = _build_api_settings_dialog("api_model_probe_failure", model="current-model")
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        settings_dialog_module.QMessageBox,
+        "warning",
+        lambda _parent, _title, message: warnings.append(message),
+    )
+
+    dialog._handle_api_model_probe_failed("无法连接")
+
+    assert warnings == ["无法连接"]
+    assert dialog.model_edit.currentText() == "current-model"
+    assert dialog.result_api_settings is None
+    dialog.deleteLater()
+    app.processEvents()
+
+
+def test_settings_dialog_model_probe_busy_state_disables_actions() -> None:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    if not hasattr(qtwidgets, "QApplication"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+
+    from PySide6.QtWidgets import QDialogButtonBox
+
+    dialog, app = _build_api_settings_dialog("api_model_probe_busy")
+    save_button = dialog.button_box.button(QDialogButtonBox.StandardButton.Save)
+
+    dialog._set_api_model_probe_busy(True)
+
+    assert not dialog.api_model_probe_button.isEnabled()
+    assert not dialog.api_test_button.isEnabled()
+    assert save_button is not None
+    assert not save_button.isEnabled()
+    assert save_button.text() == "检测模型..."
+
+    dialog._set_api_model_probe_busy(False)
+
+    assert dialog.api_model_probe_button.isEnabled()
+    assert dialog.api_test_button.isEnabled()
+    assert save_button.isEnabled()
+    dialog.deleteLater()
+    app.processEvents()
+
+
 def test_settings_dialog_api_test_failure_blocks_save(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
     qtwidgets = pytest.importorskip("PySide6.QtWidgets")
@@ -5421,6 +5536,28 @@ def _settings_dialog_character_kwargs(root: Path) -> dict[str, object]:
         "character_registry": CharacterRegistry(root),
         "current_character": profile,
     }
+
+
+def _build_api_settings_dialog(name: str, *, model: str = "test-model"):
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    from app.ui.settings_dialog import SettingsDialog
+
+    QApplication = qtwidgets.QApplication
+    app = QApplication.instance() or QApplication([])
+    root = _ui_runtime_root(name)
+    dialog = SettingsDialog(
+        api_settings=ApiSettings(
+            base_url="https://api.example.com/v1",
+            api_key="test-key",
+            model=model,
+        ),
+        tts_settings=_minimal_tts_settings(),
+        base_dir=root,
+        **_settings_dialog_character_kwargs(root),
+        proactive_care_settings=ProactiveCareSettings(screen_context_enabled=True),
+        mcp_settings=MCPRuntimeSettings(windows_enabled=False),
+    )
+    return dialog, app
 
 
 def _minimal_tts_settings() -> GPTSoVITSTTSSettings:

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from app.llm.api_client import (
+    ApiConfigError,
     ApiRequestError,
     ApiSettings,
     OpenAICompatibleClient,
@@ -326,6 +327,122 @@ def test_segmented_reply_instruction_requests_portrait_field() -> None:
 
     assert '"portrait":"站立待机"' in instruction
     assert "portrait 只能从这些类别中选择：站立待机、伸手命令" in instruction
+
+
+def test_list_models_requests_models_endpoint(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    captured: dict[str, Any] = {}
+    client = OpenAICompatibleClient(
+        ApiSettings(
+            base_url="https://api.example.com/v1",
+            api_key="key",
+            model="",
+            timeout_seconds=12,
+        )
+    )
+
+    class FakeResponse:
+        status = 200
+
+        def __enter__(self):  # type: ignore[no-untyped-def]
+            return self
+
+        def __exit__(self, *_args):  # type: ignore[no-untyped-def]
+            return None
+
+        def read(self) -> bytes:
+            return b'{"data":[{"id":"z-model"},{"id":"a-model"},{"id":"a-model"}]}'
+
+    def fake_urlopen(request, timeout):  # type: ignore[no-untyped-def]
+        captured["url"] = request.full_url
+        captured["method"] = request.get_method()
+        captured["auth"] = request.headers.get("Authorization")
+        captured["timeout"] = timeout
+        return FakeResponse()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    assert client.list_models() == ["a-model", "z-model"]
+    assert captured == {
+        "url": "https://api.example.com/v1/models",
+        "method": "GET",
+        "auth": "Bearer key",
+        "timeout": 12,
+    }
+
+
+def test_list_models_allows_empty_model_but_requires_key() -> None:
+    client = OpenAICompatibleClient(ApiSettings("https://api.example.com/v1", "", ""))
+
+    try:
+        client.list_models()
+    except ApiConfigError as exc:
+        assert "API_KEY" in str(exc)
+    else:
+        raise AssertionError("缺少 API Key 时应拒绝检测模型列表")
+
+
+def test_list_models_returns_empty_list(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    client = OpenAICompatibleClient(ApiSettings("https://api.example.com/v1", "key", ""))
+
+    monkeypatch.setattr(client, "_send_with_retries", lambda _request: '{"data":[]}')
+
+    assert client.list_models() == []
+
+
+def test_list_models_rejects_bad_response_shape(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    client = OpenAICompatibleClient(ApiSettings("https://api.example.com/v1", "key", ""))
+
+    monkeypatch.setattr(client, "_send_with_retries", lambda _request: '{"object":"list"}')
+
+    try:
+        client.list_models()
+    except ApiRequestError as exc:
+        assert "模型列表格式无法解析" in str(exc)
+    else:
+        raise AssertionError("模型列表格式错误时应抛出 ApiRequestError")
+
+
+def test_list_models_wraps_http_error(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    client = OpenAICompatibleClient(ApiSettings("https://api.example.com/v1", "key", "", timeout_seconds=1))
+
+    def fake_urlopen(_request, timeout):  # type: ignore[no-untyped-def]
+        import urllib.error
+
+        raise urllib.error.HTTPError(
+            "https://api.example.com/v1/models",
+            401,
+            "Unauthorized",
+            {},
+            None,
+        )
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    try:
+        client.list_models()
+    except ApiRequestError as exc:
+        assert "API HTTP 401" in str(exc)
+    else:
+        raise AssertionError("HTTP 错误应包装为 ApiRequestError")
+
+
+def test_list_models_wraps_url_error(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    client = OpenAICompatibleClient(ApiSettings("https://api.example.com/v1", "key", "", timeout_seconds=1))
+
+    def fake_urlopen(_request, timeout):  # type: ignore[no-untyped-def]
+        import urllib.error
+
+        raise urllib.error.URLError("offline")
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+
+    try:
+        client.list_models()
+    except ApiRequestError as exc:
+        assert "API 请求失败" in str(exc)
+    else:
+        raise AssertionError("URL 错误应包装为 ApiRequestError")
 
 
 def test_parse_chat_reply_keeps_segment_portrait() -> None:


### PR DESCRIPTION
## 更新内容
- 为 OpenAI 兼容客户端新增 /models 模型列表检测能力
- 将 API 设置页模型字段改为可编辑下拉框，并支持检测后候选过滤
- 补充 API 客户端与设置页 UI 测试

## 验证
- python -m pytest tests/unit/test_api_client.py
- python -m pytest tests/ui/test_pet_window.py -k "api or model"