### PR TITLE
fix: 修复历史清空保存记忆卡住问题

### DIFF
--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -343,6 +343,7 @@ class PetWindow(QWidget):
         self.memory_curation_mode = ""
         self.memory_curation_target_history_count = 0
         self.memory_curation_consumed_turns = 0
+        self.pending_history_clear_after_curation = False
         self.drag_offset: QPoint | None = None
         self.portrait_scale_percent = self._load_portrait_scale_percent()
         (
@@ -1997,6 +1998,8 @@ class PetWindow(QWidget):
             return
         if not self.memory_curation_settings.enabled:
             return
+        if self.pending_history_clear_after_curation:
+            return
         state = self.memory_curation_state.snapshot()
         if state.get("backfill_completed"):
             return
@@ -2121,9 +2124,32 @@ class PetWindow(QWidget):
         self.memory_curation_mode = ""
         self.memory_curation_target_history_count = 0
         self.memory_curation_consumed_turns = 0
+        if self.pending_history_clear_after_curation:
+            self.pending_history_clear_after_curation = False
+            if self._start_pending_history_clear_after_curation():
+                return
         if self.history_window is not None:
             self.history_window.set_memory_save_busy(False)
         QTimer.singleShot(0, self._maybe_start_auto_memory_curation)
+
+    def _start_pending_history_clear_after_curation(self) -> bool:
+        if not self._memory_curation_can_start():
+            return False
+        entries = self.history_store.load()
+        if not entries:
+            if self.history_window is not None:
+                self.history_window.refresh()
+            return False
+        if not self._memory_store_ready_for_history_clear():
+            self._show_memory_not_ready_for_history_clear()
+            return False
+        self._start_memory_curation(
+            entries,
+            mode="history_clear",
+            target_history_count=len(entries),
+            consumed_turns=self.memory_curation_state.pending_turns(),
+        )
+        return self.memory_curation_thread is not None
 
     @Slot(object)
     def apply_deferred_services(self, services: "DeferredStartupServices") -> None:
@@ -2453,6 +2479,14 @@ class PetWindow(QWidget):
 
     def _save_history_to_memory_and_clear(self) -> None:
         if self.memory_curation_thread is not None:
+            if self.memory_curation_mode in {"auto", "backfill"}:
+                self.pending_history_clear_after_curation = True
+                show_themed_information(
+                    self,
+                    "整理中",
+                    "当前正在自动整理记忆，结束后会继续清空并保存历史。",
+                )
+                return
             show_themed_information(self, "整理中", "记忆整理已经在进行中，请稍后再试。")
             if self.history_window is not None:
                 self.history_window.set_memory_save_busy(False)
@@ -2468,12 +2502,34 @@ class PetWindow(QWidget):
                 self.history_window.set_memory_save_busy(False)
                 self.history_window.refresh()
             return
+        if not self._memory_store_ready_for_history_clear():
+            self._show_memory_not_ready_for_history_clear()
+            if self.history_window is not None:
+                self.history_window.set_memory_save_busy(False)
+            return
         self._start_memory_curation(
             entries,
             mode="history_clear",
             target_history_count=len(entries),
             consumed_turns=self.memory_curation_state.pending_turns(),
         )
+
+    def _memory_store_ready_for_history_clear(self) -> bool:
+        is_ready = getattr(self.memory_store, "is_ready", None)
+        if not callable(is_ready):
+            return True
+        try:
+            return bool(is_ready())
+        except Exception as exc:  # noqa: BLE001
+            debug_log("Memory", "检查长期记忆就绪状态失败", {"error": str(exc)})
+            return False
+
+    def _show_memory_not_ready_for_history_clear(self) -> None:
+        message = getattr(self, "memory_status_last_message", "") or (
+            "长期记忆系统还在初始化。首次启动或覆盖更新后，"
+            "可能需要准备本地嵌入模型，请稍等就绪后再试。"
+        )
+        show_themed_information(self, "记忆初始化中", message)
 
     @Slot()
     def show_settings(self) -> None:

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -238,6 +238,51 @@ def show_themed_critical(
     )
 
 
+class TTSReadyWarmupWorker(QObject):
+    """后台启动并检测 TTS 服务，避免首次朗读承担冷启动。"""
+
+    succeeded = Signal(str)
+    failed = Signal(str)
+    finished = Signal()
+
+    def __init__(self, provider: TTSProvider) -> None:
+        super().__init__()
+        self.provider = provider
+
+    @Slot()
+    def run(self) -> None:
+        try:
+            ensure_ready = getattr(self.provider, "ensure_ready", None)
+            if not callable(ensure_ready):
+                return
+            debug_log("TTS", "开始后台预热 TTS 服务", {"provider": type(self.provider).__name__})
+            ok, message = ensure_ready()
+            if ok:
+                debug_log(
+                    "TTS",
+                    "后台预热 TTS 服务完成",
+                    {"provider": type(self.provider).__name__, "message": message},
+                )
+                self.succeeded.emit(message)
+            else:
+                debug_log(
+                    "TTS",
+                    "后台预热 TTS 服务失败",
+                    {"provider": type(self.provider).__name__, "message": message},
+                )
+                self.failed.emit(message)
+        except Exception as exc:  # noqa: BLE001
+            message = f"TTS 服务预热失败：{exc}"
+            debug_log(
+                "TTS",
+                "后台预热 TTS 服务异常",
+                {"provider": type(self.provider).__name__, "error": str(exc)},
+            )
+            self.failed.emit(message)
+        finally:
+            self.finished.emit()
+
+
 class PetWindow(QWidget):
     memory_status_changed = Signal(str, str)
 
@@ -251,6 +296,8 @@ class PetWindow(QWidget):
         self.startup_initializing = context.startup_initializing
         self.deferred_startup_thread: QThread | None = None
         self.deferred_startup_worker: QObject | None = None
+        self.tts_ready_warmup_thread: QThread | None = None
+        self.tts_ready_warmup_worker: QObject | None = None
         self.settings_service = context.settings_service
         self.character_registry = context.character_registry
         self.character_profile = context.character_profile
@@ -462,6 +509,7 @@ class PetWindow(QWidget):
         self.speech_timer = self.subtitle_controller.speech_timer
         if not self.startup_initializing:
             QTimer.singleShot(0, self._warm_up_current_tts_playback)
+            QTimer.singleShot(0, self._start_current_tts_ready_warmup)
 
         bubble_header = QHBoxLayout()
         bubble_header.setContentsMargins(0, 0, 0, 0)
@@ -2093,6 +2141,7 @@ class PetWindow(QWidget):
         self.voice_playback_controller.set_provider(services.tts_provider)
         self._connect_tts_error_signal(services.tts_provider)
         self._warm_up_tts_playback(services.tts_provider)
+        self._start_tts_ready_warmup(services.tts_provider)
         self.tool_registry = services.tool_registry
         self.free_access_enabled = self.tool_registry.free_access_enabled
         self.agent_runtime.tools = services.tool_registry
@@ -2213,6 +2262,42 @@ class PetWindow(QWidget):
                     "error": str(exc),
                 },
             )
+
+    def _start_current_tts_ready_warmup(self) -> None:
+        self._start_tts_ready_warmup(self.tts_provider)
+
+    def _start_tts_ready_warmup(self, provider: TTSProvider) -> None:
+        if isinstance(provider, NullTTSProvider):
+            debug_log("TTS", "TTS 已关闭，跳过服务预热")
+            return
+        ensure_ready = getattr(provider, "ensure_ready", None)
+        if not callable(ensure_ready):
+            return
+        if self.tts_ready_warmup_thread is not None:
+            debug_log("TTS", "TTS 服务预热已在进行，跳过重复请求")
+            return
+
+        thread = QThread(self)
+        worker = TTSReadyWarmupWorker(provider)
+        worker.moveToThread(thread)
+        thread.started.connect(worker.run)
+        worker.failed.connect(self._handle_tts_ready_warmup_failed)
+        worker.finished.connect(thread.quit)
+        thread.finished.connect(worker.deleteLater)
+        thread.finished.connect(thread.deleteLater)
+        thread.finished.connect(self._cleanup_tts_ready_warmup_worker)
+        self.tts_ready_warmup_thread = thread
+        self.tts_ready_warmup_worker = worker
+        thread.start()
+
+    @Slot(str)
+    def _handle_tts_ready_warmup_failed(self, message: str) -> None:
+        self._show_tts_error(message)
+
+    @Slot()
+    def _cleanup_tts_ready_warmup_worker(self) -> None:
+        self.tts_ready_warmup_thread = None
+        self.tts_ready_warmup_worker = None
 
     def _apply_startup_initializing_state(self) -> None:
         self.input_edit.setPlaceholderText(STARTUP_INITIALIZING_TEXT)
@@ -2537,6 +2622,9 @@ class PetWindow(QWidget):
         if callable(connect_tts_error_signal):
             connect_tts_error_signal(new_tts_provider)
         self._warm_up_tts_playback(new_tts_provider)
+        start_tts_ready_warmup = getattr(self, "_start_tts_ready_warmup", None)
+        if callable(start_tts_ready_warmup):
+            start_tts_ready_warmup(new_tts_provider)
         self._apply_character(selected_profile)
         if hasattr(self, "tray_icon"):
             self.tray_icon.setContextMenu(self._build_menu())

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -3255,6 +3255,178 @@ def test_history_clear_keeps_history_when_memory_curation_returns_nothing(monkey
     assert warnings == [("整理失败", "记忆整理没有写入任何结果，已保留聊天历史。请检查日志后再重试。")]
 
 
+def test_history_clear_queues_while_auto_memory_curation_is_running(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    import app.ui.pet_window as pet_window_module
+    from app.ui.pet_window import PetWindow
+
+    messages: list[tuple[str, str]] = []
+
+    class HistoryWindowStub:
+        def __init__(self) -> None:
+            self.busy_calls: list[bool] = []
+
+        def set_memory_save_busy(self, busy: bool) -> None:
+            self.busy_calls.append(busy)
+
+    class WindowStub:
+        _save_history_to_memory_and_clear = PetWindow._save_history_to_memory_and_clear
+
+        def __init__(self) -> None:
+            self.memory_curation_thread = object()
+            self.memory_curation_mode = "backfill"
+            self.pending_history_clear_after_curation = False
+            self.history_window = HistoryWindowStub()
+            self.worker_thread = None
+
+    monkeypatch.setattr(
+        pet_window_module,
+        "show_themed_information",
+        lambda _parent, title, text, **_kwargs: messages.append((title, text)),
+    )
+
+    window = WindowStub()
+    window._save_history_to_memory_and_clear()
+
+    assert window.pending_history_clear_after_curation is True
+    assert window.history_window.busy_calls == []
+    assert messages == [("整理中", "当前正在自动整理记忆，结束后会继续清空并保存历史。")]
+
+
+def test_queued_history_clear_starts_after_auto_curation_cleanup(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    import app.ui.pet_window as pet_window_module
+    from app.ui.pet_window import PetWindow
+
+    timer_calls: list[tuple[object, object]] = []
+    monkeypatch.setattr(
+        pet_window_module.QTimer,
+        "singleShot",
+        lambda delay, callback: timer_calls.append((delay, callback)),
+    )
+
+    class DisposableStub:
+        def deleteLater(self) -> None:
+            pass
+
+    class HistoryStoreStub:
+        def load(self) -> list[object]:
+            return [object()]
+
+    class MemoryStoreStub:
+        def is_ready(self) -> bool:
+            return True
+
+    class MemoryCurationStateStub:
+        def pending_turns(self) -> int:
+            return 2
+
+    class HistoryWindowStub:
+        def __init__(self) -> None:
+            self.busy_calls: list[bool] = []
+
+        def set_memory_save_busy(self, busy: bool) -> None:
+            self.busy_calls.append(busy)
+
+    class WindowStub:
+        _cleanup_memory_curation_worker = PetWindow._cleanup_memory_curation_worker
+        _start_pending_history_clear_after_curation = PetWindow._start_pending_history_clear_after_curation
+        _memory_store_ready_for_history_clear = PetWindow._memory_store_ready_for_history_clear
+
+        def __init__(self) -> None:
+            self.memory_curation_worker = DisposableStub()
+            self.memory_curation_thread = DisposableStub()
+            self.memory_curation_mode = "backfill"
+            self.memory_curation_target_history_count = 5
+            self.memory_curation_consumed_turns = 0
+            self.pending_history_clear_after_curation = True
+            self.history_window = HistoryWindowStub()
+            self.history_store = HistoryStoreStub()
+            self.memory_store = MemoryStoreStub()
+            self.memory_curation_state = MemoryCurationStateStub()
+            self.start_calls: list[dict[str, object]] = []
+
+        def _memory_curation_can_start(self) -> bool:
+            return True
+
+        def _start_memory_curation(self, entries, *, mode, target_history_count, consumed_turns):  # type: ignore[no-untyped-def]
+            self.start_calls.append(
+                {
+                    "entry_count": len(entries),
+                    "mode": mode,
+                    "target_history_count": target_history_count,
+                    "consumed_turns": consumed_turns,
+                }
+            )
+            self.memory_curation_thread = object()
+
+    window = WindowStub()
+    window._cleanup_memory_curation_worker()
+
+    assert window.pending_history_clear_after_curation is False
+    assert window.start_calls == [
+        {
+            "entry_count": 1,
+            "mode": "history_clear",
+            "target_history_count": 1,
+            "consumed_turns": 2,
+        }
+    ]
+    assert window.history_window.busy_calls == []
+    assert timer_calls == []
+
+
+def test_history_clear_reports_when_memory_store_is_not_ready(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    import app.ui.pet_window as pet_window_module
+    from app.ui.pet_window import PetWindow
+
+    messages: list[tuple[str, str]] = []
+
+    class HistoryStoreStub:
+        def load(self) -> list[object]:
+            return [object()]
+
+    class MemoryStoreStub:
+        def is_ready(self) -> bool:
+            return False
+
+    class HistoryWindowStub:
+        def __init__(self) -> None:
+            self.busy_calls: list[bool] = []
+
+        def set_memory_save_busy(self, busy: bool) -> None:
+            self.busy_calls.append(busy)
+
+    class WindowStub:
+        _save_history_to_memory_and_clear = PetWindow._save_history_to_memory_and_clear
+        _memory_store_ready_for_history_clear = PetWindow._memory_store_ready_for_history_clear
+        _show_memory_not_ready_for_history_clear = PetWindow._show_memory_not_ready_for_history_clear
+
+        def __init__(self) -> None:
+            self.memory_curation_thread = None
+            self.memory_curation_mode = ""
+            self.worker_thread = None
+            self.history_store = HistoryStoreStub()
+            self.memory_store = MemoryStoreStub()
+            self.history_window = HistoryWindowStub()
+            self.memory_status_last_message = "长期记忆系统正在初始化，首次启动可能需要下载本地嵌入模型，请稍等。"
+            self.start_calls = 0
+
+        def _start_memory_curation(self, *_args, **_kwargs) -> None:
+            self.start_calls += 1
+
+    monkeypatch.setattr(
+        pet_window_module,
+        "show_themed_information",
+        lambda _parent, title, text, **_kwargs: messages.append((title, text)),
+    )
+
+    window = WindowStub()
+    window._save_history_to_memory_and_clear()
+
+    assert window.start_calls == 0
+    assert window.history_window.busy_calls == [False]
+    assert messages == [("记忆初始化中", "长期记忆系统正在初始化，首次启动可能需要下载本地嵌入模型，请稍等。")]
+
+
 def test_show_settings_reloads_memory_in_background_when_api_changes(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     import app.ui.pet_window as pet_window_module
     from app.ui.pet_window import PetWindow

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -5608,6 +5608,49 @@ def _minimal_tts_settings() -> GPTSoVITSTTSSettings:
     )
 
 
+def test_tts_ready_warmup_worker_calls_ensure_ready_success() -> None:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    pytest.importorskip("PySide6.QtCore")
+    from app.ui.pet_window import TTSReadyWarmupWorker
+
+    events: list[tuple[str, str]] = []
+
+    class FakeProvider:
+        def ensure_ready(self) -> tuple[bool, str]:
+            events.append(("called", ""))
+            return True, "ready"
+
+    worker = TTSReadyWarmupWorker(FakeProvider())  # type: ignore[arg-type]
+    worker.succeeded.connect(lambda message: events.append(("succeeded", message)))
+    worker.failed.connect(lambda message: events.append(("failed", message)))
+    worker.finished.connect(lambda: events.append(("finished", "")))
+
+    worker.run()
+
+    assert events == [("called", ""), ("succeeded", "ready"), ("finished", "")]
+
+
+def test_tts_ready_warmup_worker_reports_failure() -> None:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    pytest.importorskip("PySide6.QtCore")
+    from app.ui.pet_window import TTSReadyWarmupWorker
+
+    events: list[tuple[str, str]] = []
+
+    class FakeProvider:
+        def ensure_ready(self) -> tuple[bool, str]:
+            return False, "启动失败"
+
+    worker = TTSReadyWarmupWorker(FakeProvider())  # type: ignore[arg-type]
+    worker.succeeded.connect(lambda message: events.append(("succeeded", message)))
+    worker.failed.connect(lambda message: events.append(("failed", message)))
+    worker.finished.connect(lambda: events.append(("finished", "")))
+
+    worker.run()
+
+    assert events == [("failed", "启动失败"), ("finished", "")]
+
+
 def test_tts_test_worker_keeps_provider_after_success(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
     pytest.importorskip("PySide6.QtCore")


### PR DESCRIPTION
## 变更
- 启动后后台预热 TTS 服务，减少首次朗读冷启动卡顿。
- 修复历史记录“清除并保存至记忆”在自动整理占用或记忆初始化未完成时看起来无响应的问题。
- 增加历史清空保存记忆、TTS 预热、舞台高度与 API 模型检测相关回归测试。

## 验证
- `python -m pytest tests/ui/test_pet_window.py -k "history_clear or tts_ready_warmup or stage_size or api_model_probe"`
- `python -m pytest tests/unit/test_memory_curator.py`
- `python -m pytest tests/integration/test_agent_core.py -k "memory_store_uses_local_embedding_cache or memory_store_passes_project_embedding_cache_folder or memory_store_ignores_incomplete_local_embedding_cache or reload"`

## 备注
- 本 PR 不包含当前工作区未提交的 `pytest.ini` / `tests/conftest.py` 改动。