### PR TITLE
fix: 修复长期记忆初始化反馈、角色语音包导出校验与 CI 配置

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -14,7 +14,7 @@ jobs:
     outputs:
       TAG: ${{ steps.gen.outputs.TAG }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Generate package tag
         id: gen
@@ -41,7 +41,7 @@ jobs:
       BUNDLE_ARCHIVE: sakura-${{ needs.metadata.outputs.TAG }}-${{ matrix.platform }}.zip
       RUNTIME_ARCHIVE: runtime-${{ matrix.platform }}.zip
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download Python 3.12 embeddable runtime
         shell: bash
@@ -77,11 +77,11 @@ jobs:
         run: Compress-Archive -Path runtime -DestinationPath "$env:RUNTIME_ARCHIVE" -Force
 
       - name: Upload package artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sakura-${{ needs.metadata.outputs.TAG }}-${{ matrix.platform }}
           path: |
             ${{ env.BUNDLE_ARCHIVE }}
             ${{ env.RUNTIME_ARCHIVE }}
           if-no-files-found: error
-          retention-days: 14
+          retention-days: 5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: Release
 
 on:
-  schedule:
-    - cron: "0 9 1,15 * *"
   workflow_dispatch:
 
 jobs:
@@ -12,7 +10,7 @@ jobs:
       TAG: ${{ steps.gen.outputs.TAG }}
       PRERELEASE: ${{ steps.gen.outputs.PRERELEASE }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Generate tag
         id: gen
@@ -34,9 +32,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -79,7 +77,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
@@ -103,7 +101,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Python 3.12 (Windows download embeddable)
         if: matrix.platform == 'windows-x64'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,10 +22,10 @@ jobs:
         python-version: ["3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -73,10 +73,10 @@ jobs:
         python-version: ["3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/app/agent/memory.py
+++ b/app/agent/memory.py
@@ -17,15 +17,17 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-os.environ.setdefault("MEM0_TELEMETRY", "False")
-
 MEM0_VENDOR_ROOT = Path(__file__).resolve().parents[2] / "third_party" / "mem0"
 DEFAULT_MEMORY_SCOPE = "sakura"
 DEFAULT_COLLECTION_NAME = "sakura_memories"
 DEFAULT_EMBEDDING_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
 DEFAULT_EMBEDDING_DIMS = 384
 DEFAULT_MEMORY_LIMIT = 20
+DEFAULT_HUGGINGFACE_ENDPOINT = "https://hf-mirror.com"
 _MEM0_CREATE_LOCK = threading.Lock()
+os.environ.setdefault("MEM0_TELEMETRY", "False")
+if not (os.environ.get("HF_ENDPOINT") or "").strip():
+    os.environ["HF_ENDPOINT"] = DEFAULT_HUGGINGFACE_ENDPOINT
 DEFAULT_MEMORY_LANGUAGE_INSTRUCTIONS = (
     "Sakura 的长期记忆必须使用简体中文记录。"
     "无论用户或助手消息使用什么语言，都要把可记忆事实翻译、归纳为自然的简体中文；"
@@ -154,6 +156,11 @@ class MemoryStore:
         """返回首次初始化是否可能需要下载本地嵌入模型。"""
 
         return not _embedding_model_cached(DEFAULT_EMBEDDING_MODEL, self.base_dir)
+
+    def embedding_model_endpoint(self) -> str:
+        """返回当前嵌入模型下载端点，便于 UI 提示用户。"""
+
+        return _huggingface_endpoint()
 
     def preload(self, *, wait: bool = False) -> None:
         """提前启动 mem0 加载，避免首次打开设置或聊天时才初始化。"""
@@ -343,7 +350,12 @@ class MemoryStore:
     ) -> dict[str, Any]:
         query = _optional_text(arguments, "query") or _optional_text(arguments, "keyword")
         limit = _positive_int(arguments.get("limit") or arguments.get("top_k"), DEFAULT_MEMORY_LIMIT)
-        mem = self._get_memory(wait=wait)
+        try:
+            mem = self._get_memory(wait=wait)
+        except RuntimeError as exc:
+            if wait:
+                raise
+            return self._failed_response(str(exc))
         if mem is None:
             return self._loading_response()
         raw = (
@@ -368,7 +380,12 @@ class MemoryStore:
     ) -> dict[str, Any]:
         _ = allow_sensitive
         content = _required_text(arguments, "content")
-        mem = self._get_memory(wait=wait)
+        try:
+            mem = self._get_memory(wait=wait)
+        except RuntimeError as exc:
+            if wait:
+                raise
+            return self._failed_response(str(exc))
         if mem is None:
             return self._loading_response()
         metadata = _memory_metadata(arguments)
@@ -404,7 +421,12 @@ class MemoryStore:
 
     def forget_memory(self, arguments: dict[str, Any], *, wait: bool = True) -> dict[str, Any]:
         memory_id = _required_text(arguments, "id")
-        mem = self._get_memory(wait=wait)
+        try:
+            mem = self._get_memory(wait=wait)
+        except RuntimeError as exc:
+            if wait:
+                raise
+            return self._failed_response(str(exc))
         if mem is None:
             return self._loading_response()
         previous = _normalize_memory_record(mem.get(memory_id))
@@ -463,7 +485,7 @@ class MemoryStore:
         status_event = (
             self._set_status_locked(
                 "loading",
-                "长期记忆系统正在初始化，首次启动可能需要下载本地嵌入模型，请稍等。",
+                "长期记忆系统正在初始化，首次启动会从 HuggingFace 镜像下载本地嵌入模型，请稍等。",
             )
             if report_dependency_loading
             else None
@@ -474,12 +496,16 @@ class MemoryStore:
                 mem = self._create_memory_client(api_settings)
             except Exception as exc:
                 logger.exception("mem0 初始化失败")
+                error_message = _format_memory_load_error(
+                    exc,
+                    embedding_download=report_dependency_loading,
+                )
                 with self._lock:
                     if generation == self._reload_generation:
-                        self._load_error = str(exc)
+                        self._load_error = error_message
                         self._loading = False
                 if report_dependency_loading:
-                    self._publish_status("failed", f"长期记忆系统初始化失败：{exc}")
+                    self._publish_status("failed", error_message)
                 return
             with self._lock:
                 if generation != self._reload_generation or self.api_settings != api_settings:
@@ -575,6 +601,17 @@ class MemoryStore:
             "memories": [],
         }
 
+    def _failed_response(self, error: str) -> dict[str, Any]:
+        return {
+            "status": "failed",
+            "message": (
+                "长期记忆系统暂时不可用。请告诉主人普通聊天仍可继续，"
+                "不要重复调用记忆工具。"
+            ),
+            "error": error,
+            "memories": [],
+        }
+
 
 def _resolve_base_dir(base_dir: Path | None) -> Path:
     if base_dir is None:
@@ -591,12 +628,12 @@ def _normalize_scope_id(scope_id: str | None) -> str:
 
 
 def _local_embedding_model_kwargs(model_name: str, base_dir: Path | None = None) -> dict[str, Any]:
-    """本地已有 HuggingFace 缓存时禁止联网探测，避免设置页反复卡顿。"""
+    """优先复用本地模型；缺失时下载到项目缓存并使用 HuggingFace 镜像。"""
 
     cache_folder = _embedding_model_cache_folder(model_name, base_dir)
-    if cache_folder is None:
-        return {}
-    return {"cache_folder": str(cache_folder), "local_files_only": True}
+    if cache_folder is not None:
+        return {"cache_folder": str(cache_folder), "local_files_only": True}
+    return {"cache_folder": str(_project_embedding_cache_folder(base_dir))}
 
 
 def _embedding_model_cached(model_name: str, base_dir: Path | None = None) -> bool:
@@ -643,6 +680,29 @@ def _embedding_model_cache_candidates(base_dir: Path | None = None) -> list[Path
     default_hf_home = Path(hf_home) if hf_home else Path.home() / ".cache" / "huggingface"
     add_candidate(default_hf_home / "hub")
     return cache_candidates
+
+
+def _project_embedding_cache_folder(base_dir: Path | None = None) -> Path:
+    """返回 Sakura 自己管理的 HuggingFace hub 缓存目录。"""
+
+    root = _resolve_base_dir(base_dir)
+    return root / "runtime" / "hf-cache" / "hub"
+
+
+def _huggingface_endpoint() -> str:
+    return (os.environ.get("HF_ENDPOINT") or DEFAULT_HUGGINGFACE_ENDPOINT).strip()
+
+
+def _format_memory_load_error(exc: Exception, *, embedding_download: bool) -> str:
+    raw_message = str(exc).strip() or exc.__class__.__name__
+    if not embedding_download:
+        return f"长期记忆系统初始化失败：{raw_message}"
+    endpoint = _huggingface_endpoint()
+    return (
+        "长期记忆系统初始化失败：本地嵌入模型下载失败，可能是网络无法访问 HuggingFace "
+        f"镜像（当前端点：{endpoint}）。请检查网络或代理后重试；普通聊天仍可继续。"
+        f"\n\n原始错误：{raw_message}"
+    )
 
 
 def _hub_snapshot_has_model_weights(snapshot_dir: Path) -> bool:

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -343,6 +343,7 @@ class PetWindow(QWidget):
         self.memory_curation_mode = ""
         self.memory_curation_target_history_count = 0
         self.memory_curation_consumed_turns = 0
+        self.pending_history_clear_after_curation = False
         self.drag_offset: QPoint | None = None
         self.portrait_scale_percent = self._load_portrait_scale_percent()
         (
@@ -1997,6 +1998,8 @@ class PetWindow(QWidget):
             return
         if not self.memory_curation_settings.enabled:
             return
+        if self.pending_history_clear_after_curation:
+            return
         state = self.memory_curation_state.snapshot()
         if state.get("backfill_completed"):
             return
@@ -2121,9 +2124,32 @@ class PetWindow(QWidget):
         self.memory_curation_mode = ""
         self.memory_curation_target_history_count = 0
         self.memory_curation_consumed_turns = 0
+        if self.pending_history_clear_after_curation:
+            self.pending_history_clear_after_curation = False
+            if self._start_pending_history_clear_after_curation():
+                return
         if self.history_window is not None:
             self.history_window.set_memory_save_busy(False)
         QTimer.singleShot(0, self._maybe_start_auto_memory_curation)
+
+    def _start_pending_history_clear_after_curation(self) -> bool:
+        if not self._memory_curation_can_start():
+            return False
+        entries = self.history_store.load()
+        if not entries:
+            if self.history_window is not None:
+                self.history_window.refresh()
+            return False
+        if not self._memory_store_ready_for_history_clear():
+            self._show_memory_not_ready_for_history_clear()
+            return False
+        self._start_memory_curation(
+            entries,
+            mode="history_clear",
+            target_history_count=len(entries),
+            consumed_turns=self.memory_curation_state.pending_turns(),
+        )
+        return self.memory_curation_thread is not None
 
     @Slot(object)
     def apply_deferred_services(self, services: "DeferredStartupServices") -> None:
@@ -2453,6 +2479,14 @@ class PetWindow(QWidget):
 
     def _save_history_to_memory_and_clear(self) -> None:
         if self.memory_curation_thread is not None:
+            if self.memory_curation_mode in {"auto", "backfill"}:
+                self.pending_history_clear_after_curation = True
+                show_themed_information(
+                    self,
+                    "整理中",
+                    "当前正在自动整理记忆，结束后会继续清空并保存历史。",
+                )
+                return
             show_themed_information(self, "整理中", "记忆整理已经在进行中，请稍后再试。")
             if self.history_window is not None:
                 self.history_window.set_memory_save_busy(False)
@@ -2468,12 +2502,34 @@ class PetWindow(QWidget):
                 self.history_window.set_memory_save_busy(False)
                 self.history_window.refresh()
             return
+        if not self._memory_store_ready_for_history_clear():
+            self._show_memory_not_ready_for_history_clear()
+            if self.history_window is not None:
+                self.history_window.set_memory_save_busy(False)
+            return
         self._start_memory_curation(
             entries,
             mode="history_clear",
             target_history_count=len(entries),
             consumed_turns=self.memory_curation_state.pending_turns(),
         )
+
+    def _memory_store_ready_for_history_clear(self) -> bool:
+        is_ready = getattr(self.memory_store, "is_ready", None)
+        if not callable(is_ready):
+            return True
+        try:
+            return bool(is_ready())
+        except Exception as exc:  # noqa: BLE001
+            debug_log("Memory", "检查长期记忆就绪状态失败", {"error": str(exc)})
+            return False
+
+    def _show_memory_not_ready_for_history_clear(self) -> None:
+        message = getattr(self, "memory_status_last_message", "") or (
+            "长期记忆系统还在初始化。首次启动或覆盖更新后，"
+            "可能需要准备本地嵌入模型，请稍等就绪后再试。"
+        )
+        show_themed_information(self, "记忆初始化中", message)
 
     @Slot()
     def show_settings(self) -> None:

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -238,6 +238,51 @@ def show_themed_critical(
     )
 
 
+class TTSReadyWarmupWorker(QObject):
+    """后台启动并检测 TTS 服务，避免首次朗读承担冷启动。"""
+
+    succeeded = Signal(str)
+    failed = Signal(str)
+    finished = Signal()
+
+    def __init__(self, provider: TTSProvider) -> None:
+        super().__init__()
+        self.provider = provider
+
+    @Slot()
+    def run(self) -> None:
+        try:
+            ensure_ready = getattr(self.provider, "ensure_ready", None)
+            if not callable(ensure_ready):
+                return
+            debug_log("TTS", "开始后台预热 TTS 服务", {"provider": type(self.provider).__name__})
+            ok, message = ensure_ready()
+            if ok:
+                debug_log(
+                    "TTS",
+                    "后台预热 TTS 服务完成",
+                    {"provider": type(self.provider).__name__, "message": message},
+                )
+                self.succeeded.emit(message)
+            else:
+                debug_log(
+                    "TTS",
+                    "后台预热 TTS 服务失败",
+                    {"provider": type(self.provider).__name__, "message": message},
+                )
+                self.failed.emit(message)
+        except Exception as exc:  # noqa: BLE001
+            message = f"TTS 服务预热失败：{exc}"
+            debug_log(
+                "TTS",
+                "后台预热 TTS 服务异常",
+                {"provider": type(self.provider).__name__, "error": str(exc)},
+            )
+            self.failed.emit(message)
+        finally:
+            self.finished.emit()
+
+
 class PetWindow(QWidget):
     memory_status_changed = Signal(str, str)
 
@@ -251,6 +296,8 @@ class PetWindow(QWidget):
         self.startup_initializing = context.startup_initializing
         self.deferred_startup_thread: QThread | None = None
         self.deferred_startup_worker: QObject | None = None
+        self.tts_ready_warmup_thread: QThread | None = None
+        self.tts_ready_warmup_worker: QObject | None = None
         self.settings_service = context.settings_service
         self.character_registry = context.character_registry
         self.character_profile = context.character_profile
@@ -462,6 +509,7 @@ class PetWindow(QWidget):
         self.speech_timer = self.subtitle_controller.speech_timer
         if not self.startup_initializing:
             QTimer.singleShot(0, self._warm_up_current_tts_playback)
+            QTimer.singleShot(0, self._start_current_tts_ready_warmup)
 
         bubble_header = QHBoxLayout()
         bubble_header.setContentsMargins(0, 0, 0, 0)
@@ -2093,6 +2141,7 @@ class PetWindow(QWidget):
         self.voice_playback_controller.set_provider(services.tts_provider)
         self._connect_tts_error_signal(services.tts_provider)
         self._warm_up_tts_playback(services.tts_provider)
+        self._start_tts_ready_warmup(services.tts_provider)
         self.tool_registry = services.tool_registry
         self.free_access_enabled = self.tool_registry.free_access_enabled
         self.agent_runtime.tools = services.tool_registry
@@ -2213,6 +2262,42 @@ class PetWindow(QWidget):
                     "error": str(exc),
                 },
             )
+
+    def _start_current_tts_ready_warmup(self) -> None:
+        self._start_tts_ready_warmup(self.tts_provider)
+
+    def _start_tts_ready_warmup(self, provider: TTSProvider) -> None:
+        if isinstance(provider, NullTTSProvider):
+            debug_log("TTS", "TTS 已关闭，跳过服务预热")
+            return
+        ensure_ready = getattr(provider, "ensure_ready", None)
+        if not callable(ensure_ready):
+            return
+        if self.tts_ready_warmup_thread is not None:
+            debug_log("TTS", "TTS 服务预热已在进行，跳过重复请求")
+            return
+
+        thread = QThread(self)
+        worker = TTSReadyWarmupWorker(provider)
+        worker.moveToThread(thread)
+        thread.started.connect(worker.run)
+        worker.failed.connect(self._handle_tts_ready_warmup_failed)
+        worker.finished.connect(thread.quit)
+        thread.finished.connect(worker.deleteLater)
+        thread.finished.connect(thread.deleteLater)
+        thread.finished.connect(self._cleanup_tts_ready_warmup_worker)
+        self.tts_ready_warmup_thread = thread
+        self.tts_ready_warmup_worker = worker
+        thread.start()
+
+    @Slot(str)
+    def _handle_tts_ready_warmup_failed(self, message: str) -> None:
+        self._show_tts_error(message)
+
+    @Slot()
+    def _cleanup_tts_ready_warmup_worker(self) -> None:
+        self.tts_ready_warmup_thread = None
+        self.tts_ready_warmup_worker = None
 
     def _apply_startup_initializing_state(self) -> None:
         self.input_edit.setPlaceholderText(STARTUP_INITIALIZING_TEXT)
@@ -2537,6 +2622,9 @@ class PetWindow(QWidget):
         if callable(connect_tts_error_signal):
             connect_tts_error_signal(new_tts_provider)
         self._warm_up_tts_playback(new_tts_provider)
+        start_tts_ready_warmup = getattr(self, "_start_tts_ready_warmup", None)
+        if callable(start_tts_ready_warmup):
+            start_tts_ready_warmup(new_tts_provider)
         self._apply_character(selected_profile)
         if hasattr(self, "tray_icon"):
             self.tray_icon.setContextMenu(self._build_menu())

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -368,6 +368,7 @@ class PetWindow(QWidget):
         self.active_event: AgentEvent | None = None
         self.memory_status_message_active = False
         self.memory_status_last_message = ""
+        self.memory_failure_dialog_last_message = ""
         self.last_user_activity_at = time.perf_counter()
         self.last_proactive_care_at: float | None = None
         self.last_proactive_screen_context_at: float | None = None
@@ -2378,15 +2379,22 @@ class PetWindow(QWidget):
             self._show_memory_ready_message(message)
 
     def _show_memory_status_message(self, status: str, message: str) -> None:
-        _ = status
         self.memory_status_message_active = True
         self.memory_status_last_message = message
+        if status == "failed":
+            self._show_memory_failure_dialog(message)
         if (
             not self.startup_initializing
             and not self.active_interaction_id
             and not self.reply_history_review_active
         ):
             self.subtitle_controller.show_text_immediately(message)
+
+    def _show_memory_failure_dialog(self, message: str) -> None:
+        if getattr(self, "memory_failure_dialog_last_message", "") == message:
+            return
+        self.memory_failure_dialog_last_message = message
+        show_themed_warning(self, "记忆模型下载失败", message)
 
     @Slot()
     def _show_pending_memory_status_after_startup(self) -> None:

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -315,6 +315,8 @@ class CharacterArchiveExportWorker(QObject):
     @Slot()
     def run(self) -> None:
         try:
+            if self.export_kind in ("full", "voice") and not _has_exportable_voice_model(self.profile):
+                raise CharacterArchiveError("当前角色没有完整语音模型，请导出单角色包。")
             if self.export_kind == "voice":
                 export_character_voice_archive(self.profile, self.output_path)
             else:
@@ -329,6 +331,19 @@ class CharacterArchiveExportWorker(QObject):
             self.succeeded.emit(str(self.output_path))
         finally:
             self.finished.emit()
+
+
+def _has_exportable_voice_model(profile: CharacterProfile | None) -> bool:
+    """判断角色是否带有可随包导出的完整语音模型。"""
+
+    if profile is None or profile.voice is None:
+        return False
+    return (
+        profile.voice.gpt_model_path is not None
+        and profile.voice.gpt_model_path.is_file()
+        and profile.voice.sovits_model_path is not None
+        and profile.voice.sovits_model_path.is_file()
+    )
 
 
 class SettingsDialog(QDialog):
@@ -2415,8 +2430,15 @@ class SettingsDialog(QDialog):
         if profile is None:
             QMessageBox.warning(self, "导出失败", "当前没有可导出的角色。")
             return
-        if export_kind == "voice" and profile.voice is None:
-            QMessageBox.warning(self, "导出失败", "当前角色没有可导出的语音包。")
+        if export_kind in ("full", "voice") and not _has_exportable_voice_model(profile):
+            if export_kind == "full":
+                QMessageBox.warning(
+                    self,
+                    "导出失败",
+                    "当前角色没有完整语音模型，请使用“导出单角色包 (.char)”导出角色人格和立绘。",
+                )
+            else:
+                QMessageBox.warning(self, "导出失败", "当前角色没有可导出的语音模型。")
             return
         if export_kind == "voice":
             title = "导出 Sakura TTS 模型包"
@@ -2515,14 +2537,22 @@ class SettingsDialog(QDialog):
         if busy is None:
             busy = self._character_export_thread is not None
         has_profile = profile is not None
-        has_voice = has_profile and profile.voice is not None
-        for action in (self.character_export_full_action, self.character_export_card_action):
-            action.setEnabled(not busy and has_profile)
-        self.character_export_voice_action.setEnabled(not busy and has_voice)
-        if has_voice:
+        has_voice_model = _has_exportable_voice_model(profile)
+        self.character_export_full_action.setEnabled(not busy and has_voice_model)
+        self.character_export_card_action.setEnabled(not busy and has_profile)
+        self.character_export_voice_action.setEnabled(not busy and has_voice_model)
+        if not has_profile:
+            self.character_export_full_action.setToolTip("当前没有可导出的角色。")
+            self.character_export_card_action.setToolTip("当前没有可导出的角色。")
+            self.character_export_voice_action.setToolTip("当前没有可导出的角色。")
+        elif has_voice_model:
+            self.character_export_full_action.setToolTip("导出当前角色的人格、立绘与语音模型。")
+            self.character_export_card_action.setToolTip("导出当前角色的人格与立绘，不包含语音模型。")
             self.character_export_voice_action.setToolTip("导出当前角色的 .voice TTS 模型包。")
         else:
-            self.character_export_voice_action.setToolTip("当前角色没有可导出的语音包。")
+            self.character_export_full_action.setToolTip("当前角色没有完整语音模型，只能导出单角色包。")
+            self.character_export_card_action.setToolTip("导出当前角色的人格与立绘，不包含语音模型。")
+            self.character_export_voice_action.setToolTip("当前角色没有可导出的语音模型。")
 
     def _validated_api_settings(self) -> ApiSettings | None:
         base_url = self.base_url_edit.text().strip().rstrip("/")

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -116,7 +116,7 @@ from sdk.types import SettingsPanelContribution, ToolsTabContribution
 
 
 MEMORY_READING_TEXT = "正在读取长期记忆..."
-MEMORY_DEPENDENCY_LOADING_TEXT = "长期记忆系统正在初始化，首次启动可能需要下载本地嵌入模型，请稍等。"
+MEMORY_DEPENDENCY_LOADING_TEXT = "长期记忆系统正在初始化，首次启动会从 HuggingFace 镜像下载本地嵌入模型，请稍等。"
 
 
 class ApiConnectionTestWorker(QObject):

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,8 @@ testpaths = tests
 addopts = -p no:cacheprovider
 timeout = 60
 timeout_method = thread
+filterwarnings =
+    ignore:SOCKS support in urllib3 requires.*:urllib3.exceptions.DependencyWarning:urllib3.contrib.socks
 env =
     QT_QPA_PLATFORM=offscreen
     PYTEST_QT_API=pyside6

--- a/tests/integration/test_agent_core.py
+++ b/tests/integration/test_agent_core.py
@@ -371,6 +371,18 @@ def test_memory_store_preload_only_creates_runtime_once() -> None:
     assert store.is_ready()
 
 
+def test_memory_store_returns_failed_response_for_nonblocking_memory_tools() -> None:
+    store = MemoryStore(base_dir=_runtime_root_path("memory_failed_nonblocking"))
+    store._load_error = "Cannot send a request, as the client has been closed."
+
+    result = store.search_memory({"query": "偏好"}, wait=False)
+
+    assert result["status"] == "failed"
+    assert "普通聊天仍可继续" in result["message"]
+    assert result["memories"] == []
+    assert "client has been closed" in result["error"]
+
+
 def test_memory_store_reload_keeps_old_runtime_until_new_runtime_is_ready() -> None:
     old_settings = ApiSettings("https://old.example.com/v1", "old-key", "old-model")
     new_settings = ApiSettings("https://new.example.com/v1", "new-key", "new-model")
@@ -580,7 +592,9 @@ def test_memory_store_ignores_incomplete_local_embedding_cache(monkeypatch) -> N
 
     config = store.build_mem0_config()
 
-    assert config["embedder"]["config"]["model_kwargs"] == {}
+    assert config["embedder"]["config"]["model_kwargs"] == {
+        "cache_folder": str(root / "runtime" / "hf-cache" / "hub"),
+    }
 
 
 def test_memory_store_create_update_search_and_delete() -> None:

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -3255,6 +3255,178 @@ def test_history_clear_keeps_history_when_memory_curation_returns_nothing(monkey
     assert warnings == [("整理失败", "记忆整理没有写入任何结果，已保留聊天历史。请检查日志后再重试。")]
 
 
+def test_history_clear_queues_while_auto_memory_curation_is_running(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    import app.ui.pet_window as pet_window_module
+    from app.ui.pet_window import PetWindow
+
+    messages: list[tuple[str, str]] = []
+
+    class HistoryWindowStub:
+        def __init__(self) -> None:
+            self.busy_calls: list[bool] = []
+
+        def set_memory_save_busy(self, busy: bool) -> None:
+            self.busy_calls.append(busy)
+
+    class WindowStub:
+        _save_history_to_memory_and_clear = PetWindow._save_history_to_memory_and_clear
+
+        def __init__(self) -> None:
+            self.memory_curation_thread = object()
+            self.memory_curation_mode = "backfill"
+            self.pending_history_clear_after_curation = False
+            self.history_window = HistoryWindowStub()
+            self.worker_thread = None
+
+    monkeypatch.setattr(
+        pet_window_module,
+        "show_themed_information",
+        lambda _parent, title, text, **_kwargs: messages.append((title, text)),
+    )
+
+    window = WindowStub()
+    window._save_history_to_memory_and_clear()
+
+    assert window.pending_history_clear_after_curation is True
+    assert window.history_window.busy_calls == []
+    assert messages == [("整理中", "当前正在自动整理记忆，结束后会继续清空并保存历史。")]
+
+
+def test_queued_history_clear_starts_after_auto_curation_cleanup(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    import app.ui.pet_window as pet_window_module
+    from app.ui.pet_window import PetWindow
+
+    timer_calls: list[tuple[object, object]] = []
+    monkeypatch.setattr(
+        pet_window_module.QTimer,
+        "singleShot",
+        lambda delay, callback: timer_calls.append((delay, callback)),
+    )
+
+    class DisposableStub:
+        def deleteLater(self) -> None:
+            pass
+
+    class HistoryStoreStub:
+        def load(self) -> list[object]:
+            return [object()]
+
+    class MemoryStoreStub:
+        def is_ready(self) -> bool:
+            return True
+
+    class MemoryCurationStateStub:
+        def pending_turns(self) -> int:
+            return 2
+
+    class HistoryWindowStub:
+        def __init__(self) -> None:
+            self.busy_calls: list[bool] = []
+
+        def set_memory_save_busy(self, busy: bool) -> None:
+            self.busy_calls.append(busy)
+
+    class WindowStub:
+        _cleanup_memory_curation_worker = PetWindow._cleanup_memory_curation_worker
+        _start_pending_history_clear_after_curation = PetWindow._start_pending_history_clear_after_curation
+        _memory_store_ready_for_history_clear = PetWindow._memory_store_ready_for_history_clear
+
+        def __init__(self) -> None:
+            self.memory_curation_worker = DisposableStub()
+            self.memory_curation_thread = DisposableStub()
+            self.memory_curation_mode = "backfill"
+            self.memory_curation_target_history_count = 5
+            self.memory_curation_consumed_turns = 0
+            self.pending_history_clear_after_curation = True
+            self.history_window = HistoryWindowStub()
+            self.history_store = HistoryStoreStub()
+            self.memory_store = MemoryStoreStub()
+            self.memory_curation_state = MemoryCurationStateStub()
+            self.start_calls: list[dict[str, object]] = []
+
+        def _memory_curation_can_start(self) -> bool:
+            return True
+
+        def _start_memory_curation(self, entries, *, mode, target_history_count, consumed_turns):  # type: ignore[no-untyped-def]
+            self.start_calls.append(
+                {
+                    "entry_count": len(entries),
+                    "mode": mode,
+                    "target_history_count": target_history_count,
+                    "consumed_turns": consumed_turns,
+                }
+            )
+            self.memory_curation_thread = object()
+
+    window = WindowStub()
+    window._cleanup_memory_curation_worker()
+
+    assert window.pending_history_clear_after_curation is False
+    assert window.start_calls == [
+        {
+            "entry_count": 1,
+            "mode": "history_clear",
+            "target_history_count": 1,
+            "consumed_turns": 2,
+        }
+    ]
+    assert window.history_window.busy_calls == []
+    assert timer_calls == []
+
+
+def test_history_clear_reports_when_memory_store_is_not_ready(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    import app.ui.pet_window as pet_window_module
+    from app.ui.pet_window import PetWindow
+
+    messages: list[tuple[str, str]] = []
+
+    class HistoryStoreStub:
+        def load(self) -> list[object]:
+            return [object()]
+
+    class MemoryStoreStub:
+        def is_ready(self) -> bool:
+            return False
+
+    class HistoryWindowStub:
+        def __init__(self) -> None:
+            self.busy_calls: list[bool] = []
+
+        def set_memory_save_busy(self, busy: bool) -> None:
+            self.busy_calls.append(busy)
+
+    class WindowStub:
+        _save_history_to_memory_and_clear = PetWindow._save_history_to_memory_and_clear
+        _memory_store_ready_for_history_clear = PetWindow._memory_store_ready_for_history_clear
+        _show_memory_not_ready_for_history_clear = PetWindow._show_memory_not_ready_for_history_clear
+
+        def __init__(self) -> None:
+            self.memory_curation_thread = None
+            self.memory_curation_mode = ""
+            self.worker_thread = None
+            self.history_store = HistoryStoreStub()
+            self.memory_store = MemoryStoreStub()
+            self.history_window = HistoryWindowStub()
+            self.memory_status_last_message = "长期记忆系统正在初始化，首次启动可能需要下载本地嵌入模型，请稍等。"
+            self.start_calls = 0
+
+        def _start_memory_curation(self, *_args, **_kwargs) -> None:
+            self.start_calls += 1
+
+    monkeypatch.setattr(
+        pet_window_module,
+        "show_themed_information",
+        lambda _parent, title, text, **_kwargs: messages.append((title, text)),
+    )
+
+    window = WindowStub()
+    window._save_history_to_memory_and_clear()
+
+    assert window.start_calls == 0
+    assert window.history_window.busy_calls == [False]
+    assert messages == [("记忆初始化中", "长期记忆系统正在初始化，首次启动可能需要下载本地嵌入模型，请稍等。")]
+
+
 def test_show_settings_reloads_memory_in_background_when_api_changes(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     import app.ui.pet_window as pet_window_module
     from app.ui.pet_window import PetWindow

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -2268,6 +2268,7 @@ def test_settings_dialog_export_button_uses_menu_actions(monkeypatch) -> None:  
     root = case_root / "runtime"
     profile = _build_settings_dialog_character(root, "sakura", "Sakura")
     _build_settings_dialog_character(root, "nanami", "Nanami", with_voice=False)
+    _build_settings_dialog_character(root, "yuki", "Yuki", with_voice_models=False)
 
     QApplication = qtwidgets.QApplication
     app = QApplication.instance() or QApplication([])
@@ -2299,6 +2300,8 @@ def test_settings_dialog_export_button_uses_menu_actions(monkeypatch) -> None:  
         "导出单角色包 (.char)",
         "导出语音包 (.voice)",
     ]
+    assert dialog.character_export_full_action.isEnabled()
+    assert dialog.character_export_card_action.isEnabled()
     assert dialog.character_export_voice_action.isEnabled()
 
     dialog.character_export_full_action.trigger()
@@ -2314,8 +2317,20 @@ def test_settings_dialog_export_button_uses_menu_actions(monkeypatch) -> None:  
     nanami_index = dialog.character_combo.findData("nanami")
     assert nanami_index >= 0
     dialog.character_combo.setCurrentIndex(nanami_index)
+    assert not dialog.character_export_full_action.isEnabled()
+    assert dialog.character_export_card_action.isEnabled()
     assert not dialog.character_export_voice_action.isEnabled()
-    assert "没有可导出的语音包" in dialog.character_export_voice_action.toolTip()
+    assert "没有完整语音模型" in dialog.character_export_full_action.toolTip()
+    assert "没有可导出的语音模型" in dialog.character_export_voice_action.toolTip()
+
+    yuki_index = dialog.character_combo.findData("yuki")
+    assert yuki_index >= 0
+    dialog.character_combo.setCurrentIndex(yuki_index)
+    assert not dialog.character_export_full_action.isEnabled()
+    assert dialog.character_export_card_action.isEnabled()
+    assert not dialog.character_export_voice_action.isEnabled()
+    assert "没有完整语音模型" in dialog.character_export_full_action.toolTip()
+    assert "没有可导出的语音模型" in dialog.character_export_voice_action.toolTip()
 
     dialog.deleteLater()
     app.processEvents()
@@ -5661,6 +5676,7 @@ def _build_settings_dialog_character(
     theme: dict[str, object] | None = None,
     *,
     with_voice: bool = True,
+    with_voice_models: bool = True,
 ):
     from app.config.character_loader import CharacterRegistry
 
@@ -5680,20 +5696,26 @@ def _build_settings_dialog_character(
     if with_voice:
         (character_dir / "voice" / "models").mkdir(parents=True, exist_ok=True)
         (character_dir / "voice" / "refs" / "tone_refs").mkdir(parents=True, exist_ok=True)
-        (character_dir / "voice" / "models" / "gpt.ckpt").write_bytes(b"gpt")
-        (character_dir / "voice" / "models" / "sovits.pth").write_bytes(b"sovits")
         (character_dir / "voice" / "refs" / "tone_refs" / "neutral.wav").write_bytes(b"wav")
         (character_dir / "voice" / "refs" / "ref.txt").write_text(
             "voice/refs/tone_refs/neutral.wav|JA|テスト|中性\n",
             encoding="utf-8",
         )
-        character_data["voice"] = {
-            "gpt_model": "voice/models/gpt.ckpt",
-            "sovits_model": "voice/models/sovits.pth",
+        voice_data = {
             "tone_refs": "voice/refs/ref.txt",
             "ref_lang": "ja",
             "text_lang": "ja",
         }
+        if with_voice_models:
+            (character_dir / "voice" / "models" / "gpt.ckpt").write_bytes(b"gpt")
+            (character_dir / "voice" / "models" / "sovits.pth").write_bytes(b"sovits")
+            voice_data.update(
+                {
+                    "gpt_model": "voice/models/gpt.ckpt",
+                    "sovits_model": "voice/models/sovits.pth",
+                }
+            )
+        character_data["voice"] = voice_data
     if theme is not None:
         character_data["theme"] = theme
     (character_dir / "character.json").write_text(

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -5608,6 +5608,49 @@ def _minimal_tts_settings() -> GPTSoVITSTTSSettings:
     )
 
 
+def test_tts_ready_warmup_worker_calls_ensure_ready_success() -> None:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    pytest.importorskip("PySide6.QtCore")
+    from app.ui.pet_window import TTSReadyWarmupWorker
+
+    events: list[tuple[str, str]] = []
+
+    class FakeProvider:
+        def ensure_ready(self) -> tuple[bool, str]:
+            events.append(("called", ""))
+            return True, "ready"
+
+    worker = TTSReadyWarmupWorker(FakeProvider())  # type: ignore[arg-type]
+    worker.succeeded.connect(lambda message: events.append(("succeeded", message)))
+    worker.failed.connect(lambda message: events.append(("failed", message)))
+    worker.finished.connect(lambda: events.append(("finished", "")))
+
+    worker.run()
+
+    assert events == [("called", ""), ("succeeded", "ready"), ("finished", "")]
+
+
+def test_tts_ready_warmup_worker_reports_failure() -> None:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    pytest.importorskip("PySide6.QtCore")
+    from app.ui.pet_window import TTSReadyWarmupWorker
+
+    events: list[tuple[str, str]] = []
+
+    class FakeProvider:
+        def ensure_ready(self) -> tuple[bool, str]:
+            return False, "启动失败"
+
+    worker = TTSReadyWarmupWorker(FakeProvider())  # type: ignore[arg-type]
+    worker.succeeded.connect(lambda message: events.append(("succeeded", message)))
+    worker.failed.connect(lambda message: events.append(("failed", message)))
+    worker.finished.connect(lambda: events.append(("finished", "")))
+
+    worker.run()
+
+    assert events == [("failed", "启动失败"), ("finished", "")]
+
+
 def test_tts_test_worker_keeps_provider_after_success(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
     pytest.importorskip("PySide6.QtCore")

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -182,20 +182,28 @@ def test_memory_status_does_not_use_tray_balloon(monkeypatch) -> None:  # type: 
             self.messages.append(message)
 
     single_shots: list[tuple[int, object]] = []
+    warnings: list[tuple[str, str]] = []
     monkeypatch.setattr(
         pet_window_module.QTimer,
         "singleShot",
         lambda delay, callback: single_shots.append((delay, callback)),
     )
+    monkeypatch.setattr(
+        pet_window_module,
+        "show_themed_warning",
+        lambda _parent, title, text, **_kwargs: warnings.append((title, text)),
+    )
     window = type("WindowStub", (), {})()
     window.memory_status_message_active = False
     window.memory_status_last_message = ""
+    window.memory_failure_dialog_last_message = ""
     window.startup_initializing = False
     window.active_interaction_id = None
     window.reply_history_review_active = False
     window.subtitle_controller = SubtitleControllerStub()
     window.tray_icon = TrayIconStub()
     window._restore_memory_status_speech = lambda: None
+    window._show_memory_failure_dialog = lambda message: PetWindow._show_memory_failure_dialog(window, message)
 
     for status in ("loading", "reloading", "failed"):
         PetWindow._show_memory_status_message(window, status, f"{status} message")
@@ -207,6 +215,7 @@ def test_memory_status_does_not_use_tray_balloon(monkeypatch) -> None:  # type: 
         "reloading message",
         "failed message",
     ]
+    assert warnings == [("记忆模型下载失败", "failed message")]
     assert single_shots == [(pet_window_module.MEMORY_STATUS_DISPLAY_MS, window._restore_memory_status_speech)]
 
 
@@ -2540,7 +2549,7 @@ def test_settings_dialog_shows_memory_dependency_download_hint() -> None:
         memory_store=memory_store,  # type: ignore[arg-type]
     )
 
-    expected = "长期记忆系统正在初始化，首次启动可能需要下载本地嵌入模型，请稍等。"
+    expected = "长期记忆系统正在初始化，首次启动会从 HuggingFace 镜像下载本地嵌入模型，请稍等。"
     assert dialog.memory_status_label.text() == expected
     assert dialog.memory_table.item(0, 1).text() == expected
     assert _process_events_until(app, lambda: memory_store.list_calls == 1)
@@ -3407,7 +3416,7 @@ def test_history_clear_reports_when_memory_store_is_not_ready(monkeypatch) -> No
             self.history_store = HistoryStoreStub()
             self.memory_store = MemoryStoreStub()
             self.history_window = HistoryWindowStub()
-            self.memory_status_last_message = "长期记忆系统正在初始化，首次启动可能需要下载本地嵌入模型，请稍等。"
+            self.memory_status_last_message = "长期记忆系统正在初始化，首次启动会从 HuggingFace 镜像下载本地嵌入模型，请稍等。"
             self.start_calls = 0
 
         def _start_memory_curation(self, *_args, **_kwargs) -> None:
@@ -3424,7 +3433,7 @@ def test_history_clear_reports_when_memory_store_is_not_ready(monkeypatch) -> No
 
     assert window.start_calls == 0
     assert window.history_window.busy_calls == [False]
-    assert messages == [("记忆初始化中", "长期记忆系统正在初始化，首次启动可能需要下载本地嵌入模型，请稍等。")]
+    assert messages == [("记忆初始化中", "长期记忆系统正在初始化，首次启动会从 HuggingFace 镜像下载本地嵌入模型，请稍等。")]
 
 
 def test_show_settings_reloads_memory_in_background_when_api_changes(monkeypatch) -> None:  # type: ignore[no-untyped-def]

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -9,7 +9,9 @@
 
 from __future__ import annotations
 
+import shutil
 import tempfile
+import uuid
 from pathlib import Path
 
 import pytest
@@ -21,6 +23,16 @@ from app.config.defaults import (
 )
 from app.config.migrations import _parse_dotenv, _coerce_type, migrate_env_to_yaml
 from app.config.models import ApiSettings, DebugLogSettings
+
+
+_TEST_TEMP_ROOT = Path(__file__).resolve().parents[2] / "temp" / "test_config"
+
+
+def _make_test_dir(name: str) -> Path:
+    """创建继承仓库 ACL 的唯一测试目录，避免 tempfile 在 Windows 沙箱中丢权限。"""
+    path = _TEST_TEMP_ROOT / f"{name}_{uuid.uuid4().hex}"
+    path.mkdir(parents=True)
+    return path
 
 
 class TestApiSettings:
@@ -106,8 +118,8 @@ class TestMigration:
     """.env → YAML 迁移"""
 
     def test_migrate_basic(self) -> None:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            base = Path(tmpdir)
+        base = _make_test_dir("migrate_basic")
+        try:
             config_dir = base / "data" / "config"
             config_dir.mkdir(parents=True)
 
@@ -124,10 +136,12 @@ class TestMigration:
             result = migrate_env_to_yaml(env_path, api_yaml, system_yaml)
             assert "BASE_URL" in result["migrated"]
             assert "API_KEY" in result["migrated"]
+        finally:
+            shutil.rmtree(base, ignore_errors=True)
 
     def test_migrate_missing_env(self) -> None:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            base = Path(tmpdir)
+        base = _make_test_dir("migrate_missing_env")
+        try:
             config_dir = base / "data" / "config"
             config_dir.mkdir(parents=True)
             api_yaml = config_dir / "api.yaml"
@@ -136,3 +150,5 @@ class TestMigration:
             system_yaml.write_text("{}\n")
             result = migrate_env_to_yaml(base / "missing.env", api_yaml, system_yaml)
             assert result["errors"]
+        finally:
+            shutil.rmtree(base, ignore_errors=True)


### PR DESCRIPTION
## 变更内容

- 改善长期记忆初始化失败反馈
  - 首次缺少本地嵌入模型时，使用 HuggingFace 镜像端点下载，并将缓存写入项目 `runtime/hf-cache/hub`。
  - 初始化失败时返回更明确的错误信息，提示普通聊天仍可继续。
  - 非阻塞记忆工具在初始化失败后返回 `status: failed`，避免模型反复调用记忆工具。
  - UI 在记忆模型下载失败时弹出主题化警告，并同步更新初始化提示文案。

- 校验角色导出语音模型完整性
  - 完整角色包和 `.voice` 语音包导出前要求同时存在 GPT 与 SoVITS 模型文件。
  - 缺少完整语音模型时，仅允许导出单角色包。
  - 后台导出 Worker 再次校验，避免 UI 状态变化导致导出半残语音包。

- 稳定 Windows 测试环境
  - 配置迁移测试改用仓库内临时目录，避免 Windows 沙箱下 `tempfile` ACL 权限问题。
  - 忽略 urllib3 SOCKS 依赖警告，减少无关测试噪音。

- 更新 GitHub Actions 配置
  - 升级 `actions/checkout`、`actions/setup-python`、`actions/upload-artifact` 版本。
  - 缩短 package artifact 保留时间。
  - Release workflow 改为仅手动触发，取消定时发布。

## 验证

已运行：

```powershell
.\runtime\python.exe -m pytest tests\integration\test_agent_core.py tests\ui\test_pet_window.py tests\unit\test_config.py tests\unit\test_character_archive.py