### PR TITLE
fix: 修复手动记忆整理失败

### DIFF
--- a/app/agent/memory.py
+++ b/app/agent/memory.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import logging
 import os
+import sqlite3
 import sys
 import threading
 import time
+from contextlib import nullcontext
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, Iterable
 
 from app.storage.chat_history import ChatHistoryEntry
 
@@ -417,7 +419,8 @@ class MemoryStore:
         mem = self._get_memory()
         previous = _normalize_memory_record(mem.get(memory_id))
         mem.delete(memory_id)
-        return {"memory": previous or {"id": memory_id, "content": ""}}
+        cache_reset = self._reset_scope_curation_cache(mem, memory_ids=[memory_id])
+        return {"memory": previous or {"id": memory_id, "content": ""}, "curation_cache_reset": cache_reset}
 
     def forget_memory(self, arguments: dict[str, Any], *, wait: bool = True) -> dict[str, Any]:
         memory_id = _required_text(arguments, "id")
@@ -431,8 +434,17 @@ class MemoryStore:
             return self._loading_response()
         previous = _normalize_memory_record(mem.get(memory_id))
         mem.delete(memory_id)
+        cache_reset = self._reset_scope_curation_cache(mem, memory_ids=[memory_id])
         forgotten = previous or {"id": memory_id, "content": ""}
-        return {"forgotten": forgotten, "memory": forgotten}
+        return {"forgotten": forgotten, "memory": forgotten, "curation_cache_reset": cache_reset}
+
+    def reset_curation_cache(self, *, wait: bool = True) -> dict[str, int]:
+        """清理当前角色的 mem0 整理缓存，不影响 Sakura 自己的聊天历史文件。"""
+
+        mem = self._get_memory(wait=wait)
+        if mem is None:
+            return {"messages": 0, "history": 0}
+        return self._reset_scope_curation_cache(mem)
 
     def add_history_entries(self, entries: list[ChatHistoryEntry]) -> MemoryCurationCounts:
         messages = _entries_for_mem0(entries)
@@ -441,6 +453,56 @@ class MemoryStore:
         mem = self._get_memory()
         raw = mem.add(messages, user_id=self.scope_id, infer=True)
         return _count_mem0_events(raw, total=len(messages))
+
+    def _reset_scope_curation_cache(
+        self,
+        mem: Any,
+        *,
+        memory_ids: Iterable[str] | None = None,
+    ) -> dict[str, int]:
+        """清理 mem0 内部整理缓存，避免删除长期记忆后旧缓存继续参与抽取。"""
+
+        db = getattr(mem, "db", None)
+        connection = getattr(db, "connection", None)
+        if connection is None:
+            return {"messages": 0, "history": 0}
+
+        clean_memory_ids = [
+            memory_id
+            for memory_id in (str(item).strip() for item in (memory_ids or []))
+            if memory_id
+        ]
+        session_scope = _mem0_session_scope({"user_id": self.scope_id})
+        lock = getattr(db, "_lock", None)
+        context = lock if lock is not None else nullcontext()
+        deleted_messages = 0
+        deleted_history = 0
+
+        try:
+            with context:
+                connection.execute("BEGIN")
+                message_cursor = connection.execute(
+                    "DELETE FROM messages WHERE session_scope = ?",
+                    (session_scope,),
+                )
+                deleted_messages = max(0, int(message_cursor.rowcount or 0))
+                if clean_memory_ids:
+                    placeholders = ",".join("?" for _ in clean_memory_ids)
+                    history_cursor = connection.execute(
+                        f"DELETE FROM history WHERE memory_id IN ({placeholders})",
+                        clean_memory_ids,
+                    )
+                    deleted_history = max(0, int(history_cursor.rowcount or 0))
+                connection.execute("COMMIT")
+        except (sqlite3.Error, RuntimeError) as exc:
+            try:
+                connection.execute("ROLLBACK")
+            except sqlite3.Error:
+                pass
+            logger.warning("mem0 整理缓存清理失败：%s", exc)
+            return {"messages": 0, "history": 0}
+
+        return {"messages": deleted_messages, "history": deleted_history}
 
     def _get_memory(self, *, wait: bool = True) -> Any | None:
         with self._lock:
@@ -625,6 +687,15 @@ def _resolve_base_dir(base_dir: Path | None) -> Path:
 def _normalize_scope_id(scope_id: str | None) -> str:
     text = (scope_id or "").strip()
     return text if text and not any(ch.isspace() for ch in text) else DEFAULT_MEMORY_SCOPE
+
+
+def _mem0_session_scope(filters: dict[str, str]) -> str:
+    parts: list[str] = []
+    for key in sorted(("user_id", "agent_id", "run_id")):
+        value = filters.get(key)
+        if value:
+            parts.append(f"{key}={value}")
+    return "&".join(parts)
 
 
 def _local_embedding_model_kwargs(model_name: str, base_dir: Path | None = None) -> dict[str, Any]:

--- a/app/agent/memory_curator.py
+++ b/app/agent/memory_curator.py
@@ -12,6 +12,8 @@ from app.storage.chat_history import ChatHistoryEntry
 
 DEFAULT_AUTO_MEMORY_TRIGGER_TURNS = 8
 DEFAULT_AUTO_MEMORY_BACKFILL_LIMIT = 200
+MAX_CURATION_CHUNK_MESSAGES = 32
+MAX_CURATION_CHUNK_CHARS = 12000
 
 
 @dataclass(frozen=True)
@@ -119,37 +121,51 @@ class MemoryCurator:
         if not model_entries:
             return MemoryCurationResult(processed_entries=len(entries))
 
-        counts = self.memory_store.add_history_entries(entries)
-        result = MemoryCurationResult(
-            created=counts.created,
-            updated=counts.updated,
-            archived=counts.deleted,
-            ignored=counts.ignored,
+        created = 0
+        updated = 0
+        archived = 0
+        ignored = 0
+        returned = 0
+        unclassified = 0
+        event_counts: dict[str, int] = {}
+        for chunk in _chunk_entries_for_curation(entries):
+            counts = self.memory_store.add_history_entries(chunk)
+            chunk_created = counts.created
+            chunk_updated = counts.updated
+            chunk_archived = counts.deleted
+            chunk_ignored = counts.ignored
+            chunk_returned = counts.returned
+            chunk_unclassified = counts.unclassified
+            _merge_event_counts(event_counts, counts.event_counts)
+            if chunk_returned == 0 and self.api_client is not None:
+                fallback_created = self._curate_entries_with_fallback(_entries_for_model(chunk))
+                if fallback_created:
+                    event_counts["FALLBACK_ADD"] = event_counts.get("FALLBACK_ADD", 0) + fallback_created
+                    chunk_created += fallback_created
+                    chunk_returned += fallback_created
+                    chunk_ignored = max(0, chunk_ignored - fallback_created)
+            created += chunk_created
+            updated += chunk_updated
+            archived += chunk_archived
+            ignored += chunk_ignored
+            returned += chunk_returned
+            unclassified += chunk_unclassified
+        return MemoryCurationResult(
+            created=created,
+            updated=updated,
+            archived=archived,
+            ignored=ignored,
             processed_entries=len(entries),
-            returned=counts.returned,
-            unclassified=counts.unclassified,
-            event_counts=dict(counts.event_counts),
+            returned=returned,
+            unclassified=unclassified,
+            event_counts=event_counts,
         )
-        if result.returned == 0 and self.api_client is not None:
-            fallback_created = self._curate_entries_with_fallback(model_entries)
-            if fallback_created:
-                event_counts = dict(result.event_counts or {})
-                event_counts["FALLBACK_ADD"] = event_counts.get("FALLBACK_ADD", 0) + fallback_created
-                result = MemoryCurationResult(
-                    created=result.created + fallback_created,
-                    updated=result.updated,
-                    archived=result.archived,
-                    ignored=max(0, result.ignored - fallback_created),
-                    processed_entries=result.processed_entries,
-                    returned=result.returned + fallback_created,
-                    unclassified=result.unclassified,
-                    event_counts=event_counts,
-                )
-        return result
 
     def _curate_entries_with_fallback(self, entries: list[dict[str, str]]) -> int:
         """mem0 抽取为空时，用主模型兜底抽取明确长期事实。"""
 
+        if not entries:
+            return 0
         prompt = _fallback_extraction_prompt(entries)
         try:
             raw = self.api_client.complete_raw(
@@ -183,22 +199,66 @@ class MemoryCurator:
         return created
 
 
+def _merge_event_counts(target: dict[str, int], source: dict[str, int]) -> None:
+    for key, value in source.items():
+        target[key] = target.get(key, 0) + value
+
+
+def _chunk_entries_for_curation(entries: list[ChatHistoryEntry]) -> list[list[ChatHistoryEntry]]:
+    chunks: list[list[ChatHistoryEntry]] = []
+    current: list[ChatHistoryEntry] = []
+    current_messages = 0
+    current_chars = 0
+    for entry in entries:
+        model_entry = _entry_for_model(entry)
+        if model_entry is None:
+            continue
+        entry_chars = _model_entry_char_count(model_entry)
+        if current and (
+            current_messages >= MAX_CURATION_CHUNK_MESSAGES
+            or current_chars + entry_chars > MAX_CURATION_CHUNK_CHARS
+        ):
+            chunks.append(current)
+            current = []
+            current_messages = 0
+            current_chars = 0
+        current.append(entry)
+        current_messages += 1
+        current_chars += entry_chars
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def _entry_for_model(entry: ChatHistoryEntry) -> dict[str, str] | None:
+    if entry.role not in {"user", "assistant"}:
+        return None
+    content = entry.content.strip()
+    if not content:
+        return None
+    return {
+        "created_at": entry.created_at,
+        "role": entry.role,
+        "content": content,
+        "translation": entry.translation.strip(),
+    }
+
+
+def _model_entry_char_count(entry: dict[str, str]) -> int:
+    return (
+        len(entry.get("created_at", ""))
+        + len(entry.get("role", ""))
+        + len(entry.get("content", ""))
+        + len(entry.get("translation", ""))
+    )
+
+
 def _entries_for_model(entries: list[ChatHistoryEntry]) -> list[dict[str, str]]:
     result: list[dict[str, str]] = []
     for entry in entries:
-        if entry.role not in {"user", "assistant"}:
-            continue
-        content = entry.content.strip()
-        if not content:
-            continue
-        result.append(
-            {
-                "created_at": entry.created_at,
-                "role": entry.role,
-                "content": content,
-                "translation": entry.translation.strip(),
-            }
-        )
+        model_entry = _entry_for_model(entry)
+        if model_entry is not None:
+            result.append(model_entry)
     return result
 
 

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -2144,6 +2144,7 @@ class PetWindow(QWidget):
         if not self._memory_store_ready_for_history_clear():
             self._show_memory_not_ready_for_history_clear()
             return False
+        self._reset_memory_curation_cache_for_history_clear()
         self._start_memory_curation(
             entries,
             mode="history_clear",
@@ -2515,6 +2516,7 @@ class PetWindow(QWidget):
             if self.history_window is not None:
                 self.history_window.set_memory_save_busy(False)
             return
+        self._reset_memory_curation_cache_for_history_clear()
         self._start_memory_curation(
             entries,
             mode="history_clear",
@@ -2538,6 +2540,17 @@ class PetWindow(QWidget):
             "可能需要准备本地嵌入模型，请稍等就绪后再试。"
         )
         show_themed_information(self, "记忆初始化中", message)
+
+    def _reset_memory_curation_cache_for_history_clear(self) -> None:
+        reset_cache = getattr(self.memory_store, "reset_curation_cache", None)
+        if not callable(reset_cache):
+            return
+        try:
+            reset_counts = reset_cache()
+        except Exception as exc:  # noqa: BLE001
+            debug_log("Memory", "重置 mem0 整理缓存失败", {"error": str(exc)})
+            return
+        debug_log("Memory", "已重置 mem0 整理缓存", reset_counts)
 
     @Slot()
     def show_settings(self) -> None:

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -3354,6 +3354,9 @@ def test_queued_history_clear_starts_after_auto_curation_cleanup(monkeypatch) ->
         _cleanup_memory_curation_worker = PetWindow._cleanup_memory_curation_worker
         _start_pending_history_clear_after_curation = PetWindow._start_pending_history_clear_after_curation
         _memory_store_ready_for_history_clear = PetWindow._memory_store_ready_for_history_clear
+        _reset_memory_curation_cache_for_history_clear = (
+            PetWindow._reset_memory_curation_cache_for_history_clear
+        )
 
         def __init__(self) -> None:
             self.memory_curation_worker = DisposableStub()
@@ -3449,6 +3452,52 @@ def test_history_clear_reports_when_memory_store_is_not_ready(monkeypatch) -> No
     assert window.start_calls == 0
     assert window.history_window.busy_calls == [False]
     assert messages == [("记忆初始化中", "长期记忆系统正在初始化，首次启动会从 HuggingFace 镜像下载本地嵌入模型，请稍等。")]
+
+
+def test_history_clear_resets_mem0_curation_cache_before_start() -> None:  # type: ignore[no-untyped-def]
+    from app.ui.pet_window import PetWindow
+
+    events: list[str] = []
+
+    class HistoryStoreStub:
+        def load(self) -> list[object]:
+            return [object()]
+
+    class MemoryStoreStub:
+        def is_ready(self) -> bool:
+            return True
+
+        def reset_curation_cache(self) -> dict[str, int]:
+            events.append("reset")
+            return {"messages": 1, "history": 0}
+
+    class MemoryCurationStateStub:
+        def pending_turns(self) -> int:
+            return 2
+
+    class WindowStub:
+        _save_history_to_memory_and_clear = PetWindow._save_history_to_memory_and_clear
+        _memory_store_ready_for_history_clear = PetWindow._memory_store_ready_for_history_clear
+        _reset_memory_curation_cache_for_history_clear = (
+            PetWindow._reset_memory_curation_cache_for_history_clear
+        )
+
+        def __init__(self) -> None:
+            self.memory_curation_thread = None
+            self.memory_curation_mode = ""
+            self.worker_thread = None
+            self.history_store = HistoryStoreStub()
+            self.memory_store = MemoryStoreStub()
+            self.history_window = None
+            self.memory_curation_state = MemoryCurationStateStub()
+
+        def _start_memory_curation(self, *_args, **_kwargs) -> None:
+            events.append("start")
+
+    window = WindowStub()
+    window._save_history_to_memory_and_clear()
+
+    assert events == ["reset", "start"]
 
 
 def test_show_settings_reloads_memory_in_background_when_api_changes(monkeypatch) -> None:  # type: ignore[no-untyped-def]

--- a/tests/unit/test_memory_curator.py
+++ b/tests/unit/test_memory_curator.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sqlite3
+import threading
 from pathlib import Path
 import uuid
 
@@ -50,6 +52,45 @@ def test_memory_curator_falls_back_when_mem0_returns_no_results() -> None:
     assert fake.calls[1]["infer"] is False
     assert fake.calls[1]["messages"] == "用户妈妈的生日是6月4日。"
     assert fake.calls[1]["metadata"] == {"source": "curation_fallback"}
+
+
+def test_memory_curator_chunks_large_history_before_mem0() -> None:
+    fake = FakeMem0()
+    store = MemoryStore(
+        base_dir=_runtime_root("memory_curator_chunks"),
+        scope_id="sakura",
+        memory_client=fake,
+    )
+    curator = MemoryCurator(store)
+
+    result = curator.curate_entries([_entry("user", f"偏好 {index}") for index in range(35)])
+
+    assert result.created == 2
+    assert result.returned == 2
+    assert result.processed_entries == 35
+    assert [len(call["messages"]) for call in fake.calls] == [32, 3]
+
+
+def test_memory_delete_resets_mem0_curation_cache_for_current_scope() -> None:
+    fake = FakeMem0WithCurationCache()
+    store = MemoryStore(
+        base_dir=_runtime_root("memory_delete_cache"),
+        scope_id="sakura",
+        memory_client=fake,
+    )
+    fake.insert_message("user_id=sakura", "user", "旧上下文")
+    fake.insert_message("user_id=other", "user", "其它角色上下文")
+    fake.insert_history("memory-001", "ADD")
+    fake.insert_history("memory-other", "ADD")
+
+    result = store.forget_memory({"id": "memory-001"})
+
+    assert result["curation_cache_reset"] == {"messages": 1, "history": 1}
+    assert fake.deleted == ["memory-001"]
+    assert fake.count_messages("user_id=sakura") == 0
+    assert fake.count_messages("user_id=other") == 1
+    assert fake.count_history("memory-001") == 0
+    assert fake.count_history("memory-other") == 1
 
 
 def test_memory_curator_ignores_non_dialog_entries() -> None:
@@ -205,6 +246,99 @@ class EmptyMem0:
                 }
             ]
         }
+
+
+class FakeMem0WithCurationCache:
+    def __init__(self) -> None:
+        self.records: dict[str, dict[str, str]] = {
+            "memory-001": {"id": "memory-001", "memory": "第一条记忆"},
+        }
+        self.deleted: list[str] = []
+        self.db = FakeMem0Db()
+
+    def get(self, memory_id):  # type: ignore[no-untyped-def]
+        return self.records.get(memory_id)
+
+    def delete(self, memory_id):  # type: ignore[no-untyped-def]
+        self.deleted.append(memory_id)
+        self.records.pop(memory_id, None)
+
+    def insert_message(self, session_scope: str, role: str, content: str) -> None:
+        self.db.connection.execute(
+            "INSERT INTO messages (id, session_scope, role, content, name, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+            (str(uuid.uuid4()), session_scope, role, content, None, "2026-06-05T00:00:00+00:00"),
+        )
+        self.db.connection.commit()
+
+    def insert_history(self, memory_id: str, event: str) -> None:
+        self.db.connection.execute(
+            "INSERT INTO history (id, memory_id, old_memory, new_memory, event, created_at, updated_at, is_deleted, actor_id, role) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                str(uuid.uuid4()),
+                memory_id,
+                None,
+                "记忆",
+                event,
+                "2026-06-05T00:00:00+00:00",
+                None,
+                0,
+                None,
+                "user",
+            ),
+        )
+        self.db.connection.commit()
+
+    def count_messages(self, session_scope: str) -> int:
+        return int(
+            self.db.connection.execute(
+                "SELECT COUNT(*) FROM messages WHERE session_scope = ?",
+                (session_scope,),
+            ).fetchone()[0]
+        )
+
+    def count_history(self, memory_id: str) -> int:
+        return int(
+            self.db.connection.execute(
+                "SELECT COUNT(*) FROM history WHERE memory_id = ?",
+                (memory_id,),
+            ).fetchone()[0]
+        )
+
+
+class FakeMem0Db:
+    def __init__(self) -> None:
+        self.connection = sqlite3.connect(":memory:")
+        self._lock = threading.Lock()
+        self.connection.execute(
+            """
+            CREATE TABLE messages (
+                id TEXT PRIMARY KEY,
+                session_scope TEXT,
+                role TEXT,
+                content TEXT,
+                name TEXT,
+                created_at DATETIME
+            )
+            """
+        )
+        self.connection.execute(
+            """
+            CREATE TABLE history (
+                id TEXT PRIMARY KEY,
+                memory_id TEXT,
+                old_memory TEXT,
+                new_memory TEXT,
+                event TEXT,
+                created_at DATETIME,
+                updated_at DATETIME,
+                is_deleted INTEGER,
+                actor_id TEXT,
+                role TEXT
+            )
+            """
+        )
+        self.connection.commit()
 
 
 class FakeFallbackApiClient:


### PR DESCRIPTION
修复手动记忆整理大批量历史返回空的问题：分块整理历史、手动整理前重置 mem0 内部缓存，并补充相关测试。验证：pytest tests/unit/test_memory_curator.py -q；pytest tests/ui/test_pet_window.py -q；pytest tests/integration/test_agent_core.py -k memory -q；py_compile；git diff --check。