### PR TITLE
fix: 修复 Windows 混合 DPI 跨屏拖拽异常

### DIFF
--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -639,7 +639,7 @@ class PetWindow(QWidget):
             self._schedule_native_topmost_sync()
 
     def event(self, event) -> bool:  # type: ignore[override]
-        if event.type() == QEvent.Type.ScreenChangeInternal:
+        if _is_screen_change_event(event):
             self._schedule_screen_change_relayout()
         return super().event(event)
 
@@ -3401,6 +3401,14 @@ def _stage_size_for_portrait_scale_percent(portrait_scale_percent: int) -> tuple
         DEFAULT_STAGE_WIDTH,
         max(MIN_STAGE_HEIGHT, round(DEFAULT_STAGE_HEIGHT * scale)),
     )
+
+
+def _is_screen_change_event(event: object) -> bool:
+    """兼容旧版 Qt：缺少 ScreenChangeInternal 枚举时直接忽略。"""
+
+    screen_change_type = getattr(QEvent.Type, "ScreenChangeInternal", None)
+    event_type = getattr(event, "type", None)
+    return screen_change_type is not None and callable(event_type) and event_type() == screen_change_type
 
 
 def _configure_reply_history_panel(panel: QFrame) -> None:

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -344,7 +344,7 @@ class PetWindow(QWidget):
         self.memory_curation_target_history_count = 0
         self.memory_curation_consumed_turns = 0
         self.pending_history_clear_after_curation = False
-        self.drag_offset: QPoint | None = None
+        self.drag_anchor: QPoint | None = None
         self.portrait_scale_percent = self._load_portrait_scale_percent()
         (
             self.subtitle_typing_interval_ms,
@@ -638,6 +638,11 @@ class PetWindow(QWidget):
         }:
             self._schedule_native_topmost_sync()
 
+    def event(self, event) -> bool:  # type: ignore[override]
+        if event.type() == QEvent.Type.ScreenChangeInternal:
+            self._schedule_screen_change_relayout()
+        return super().event(event)
+
     def eventFilter(self, watched, event) -> bool:  # type: ignore[no-untyped-def]
         application = QApplication.instance()
         if application is not None and watched is application:
@@ -664,7 +669,7 @@ class PetWindow(QWidget):
             self.speech_label,
         } and isinstance(event, QMouseEvent):
             if event.type() == QEvent.Type.MouseButtonPress:
-                return self._handle_mouse_press(event)
+                return self._handle_mouse_press(event, watched)
             if event.type() == QEvent.Type.MouseMove:
                 return self._handle_mouse_move(event)
             if event.type() == QEvent.Type.MouseButtonRelease:
@@ -723,9 +728,9 @@ class PetWindow(QWidget):
     def close_plugins(self) -> None:
         self.plugin_manager.shutdown_all()
 
-    def _handle_mouse_press(self, event: QMouseEvent) -> bool:
+    def _handle_mouse_press(self, event: QMouseEvent, source_widget: QWidget | None = None) -> bool:
         if event.button() == Qt.MouseButton.LeftButton:
-            self.drag_offset = event.globalPosition().toPoint() - self.frameGeometry().topLeft()
+            self.drag_anchor = self._drag_anchor_from_event(event, source_widget)
             event.accept()
             return True
         if event.button() == Qt.MouseButton.RightButton:
@@ -734,15 +739,15 @@ class PetWindow(QWidget):
         return False
 
     def _handle_mouse_move(self, event: QMouseEvent) -> bool:
-        if event.buttons() & Qt.MouseButton.LeftButton and self.drag_offset is not None:
-            self.move(event.globalPosition().toPoint() - self.drag_offset)
+        if event.buttons() & Qt.MouseButton.LeftButton and self.drag_anchor is not None:
+            self.move(event.globalPosition().toPoint() - self.drag_anchor)
             event.accept()
             return True
         return False
 
     def _handle_mouse_release(self, event: QMouseEvent) -> bool:
         if event.button() == Qt.MouseButton.LeftButton:
-            self.drag_offset = None
+            self.drag_anchor = None
             event.accept()
             return True
         if event.button() == Qt.MouseButton.RightButton:
@@ -750,6 +755,28 @@ class PetWindow(QWidget):
             event.accept()
             return True
         return False
+
+    def _drag_anchor_from_event(
+        self,
+        event: QMouseEvent,
+        source_widget: QWidget | None = None,
+    ) -> QPoint:
+        position = event.position().toPoint()
+        if source_widget is None or source_widget is self:
+            return position
+
+        map_to = getattr(source_widget, "mapTo", None)
+        if callable(map_to):
+            return map_to(self, position)
+        return position
+
+    def _schedule_screen_change_relayout(self) -> None:
+        QTimer.singleShot(0, self._restore_geometry_after_screen_change)
+
+    def _restore_geometry_after_screen_change(self) -> None:
+        self.resize(*self.stage_size)
+        self._layout_stage()
+        self._schedule_native_topmost_sync()
 
     def _apply_reply_segment(self, segment: ChatSegment) -> None:
         self.portrait_controller.apply_for_segment(segment)

--- a/main.py
+++ b/main.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import sys
+import ctypes
 from dataclasses import replace
 from pathlib import Path
 
-from PySide6.QtCore import QObject, QThread, QTimer, Signal, Slot
+from PySide6.QtCore import QObject, QThread, QTimer, Qt, Signal, Slot
+from PySide6.QtGui import QGuiApplication
 from PySide6.QtWidgets import QApplication, QDialog, QLabel, QMessageBox, QProgressBar, QPushButton, QVBoxLayout
 
 from app.core.app_context import AppContext
@@ -33,6 +35,59 @@ from app.voice.tts_bundle import (
 
 
 BASE_DIR = Path(__file__).resolve().parent
+
+
+def _configure_windows_high_dpi() -> None:
+    """在 QApplication 创建前配置 Windows 混合 DPI 行为。"""
+
+    if sys.platform != "win32":
+        return
+
+    awareness = _set_windows_process_dpi_awareness()
+    try:
+        QGuiApplication.setHighDpiScaleFactorRoundingPolicy(
+            Qt.HighDpiScaleFactorRoundingPolicy.PassThrough
+        )
+    except Exception as exc:  # noqa: BLE001
+        debug_log("Startup", "配置 Qt HighDPI 舍入策略失败", {"error": str(exc)})
+    debug_log("Startup", "Windows HighDPI 配置完成", {"awareness": awareness})
+
+
+def _set_windows_process_dpi_awareness() -> str:
+    """优先启用 Per-Monitor V2，失败时降级到旧版 DPI 感知模式。"""
+
+    errors: list[str] = []
+    try:
+        set_context = ctypes.windll.user32.SetProcessDpiAwarenessContext
+        set_context.argtypes = [ctypes.c_void_p]
+        set_context.restype = ctypes.c_bool
+        if set_context(ctypes.c_void_p(-4)):
+            return "per_monitor_v2"
+        errors.append("SetProcessDpiAwarenessContext")
+    except Exception as exc:  # noqa: BLE001
+        errors.append(f"SetProcessDpiAwarenessContext: {exc}")
+
+    try:
+        set_awareness = ctypes.windll.shcore.SetProcessDpiAwareness
+        set_awareness.argtypes = [ctypes.c_int]
+        set_awareness.restype = ctypes.c_long
+        if set_awareness(2) == 0:
+            return "per_monitor"
+        errors.append("SetProcessDpiAwareness")
+    except Exception as exc:  # noqa: BLE001
+        errors.append(f"SetProcessDpiAwareness: {exc}")
+
+    try:
+        set_system_aware = ctypes.windll.user32.SetProcessDPIAware
+        set_system_aware.restype = ctypes.c_bool
+        if set_system_aware():
+            return "system"
+        errors.append("SetProcessDPIAware")
+    except Exception as exc:  # noqa: BLE001
+        errors.append(f"SetProcessDPIAware: {exc}")
+
+    debug_log("Startup", "Windows DPI 感知配置未生效", {"errors": errors})
+    return "unchanged"
 
 
 class DeferredStartupWorker(QObject):
@@ -163,6 +218,7 @@ class TTSBundleMigrationDialog(QDialog):
 
 
 def main() -> int:
+    _configure_windows_high_dpi()
     app = QApplication(sys.argv)
     app.setApplicationName("Sakura Desktop Pet")
     app.setQuitOnLastWindowClosed(False)

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -541,6 +541,23 @@ def test_pet_window_screen_change_restores_stage_geometry(monkeypatch) -> None: 
     app.processEvents()
 
 
+def test_screen_change_event_check_tolerates_missing_qt_enum(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    import app.ui.pet_window as pet_window_module
+    from app.ui.pet_window import _is_screen_change_event
+
+    class FakeQEvent:
+        class Type:
+            pass
+
+    class EventStub:
+        def type(self) -> object:
+            return object()
+
+    monkeypatch.setattr(pet_window_module, "QEvent", FakeQEvent)
+
+    assert not _is_screen_change_event(EventStub())
+
+
 def test_reply_history_controls_use_capsule_sizing() -> None:
     os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
     qtwidgets = pytest.importorskip("PySide6.QtWidgets")

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -367,6 +367,180 @@ def test_pet_window_context_menu_opens_on_right_release_not_press() -> None:
     assert window.context_menu_positions == [release_event.position().toPoint()]
 
 
+def test_pet_window_drag_uses_window_local_anchor_not_frame_geometry() -> None:
+    qtcore = pytest.importorskip("PySide6.QtCore")
+    from app.ui.pet_window import PetWindow
+
+    class MouseEventStub:
+        def __init__(
+            self,
+            *,
+            position: tuple[int, int],
+            global_position: tuple[int, int],
+            button=None,  # type: ignore[no-untyped-def]
+            buttons=None,  # type: ignore[no-untyped-def]
+        ) -> None:
+            self.accepted = False
+            self._position = qtcore.QPointF(*position)
+            self._global_position = qtcore.QPointF(*global_position)
+            self._button = button or qtcore.Qt.MouseButton.LeftButton
+            self._buttons = buttons or qtcore.Qt.MouseButton.LeftButton
+
+        def button(self):  # type: ignore[no-untyped-def]
+            return self._button
+
+        def buttons(self):  # type: ignore[no-untyped-def]
+            return self._buttons
+
+        def position(self):  # type: ignore[no-untyped-def]
+            return self._position
+
+        def globalPosition(self):  # type: ignore[no-untyped-def]
+            return self._global_position
+
+        def accept(self) -> None:
+            self.accepted = True
+
+    class MinimalWindow:
+        _handle_mouse_press = PetWindow._handle_mouse_press
+        _handle_mouse_move = PetWindow._handle_mouse_move
+        _handle_mouse_release = PetWindow._handle_mouse_release
+        _drag_anchor_from_event = PetWindow._drag_anchor_from_event
+
+        def __init__(self) -> None:
+            self.drag_anchor = None
+            self.move_positions: list[object] = []
+
+        def frameGeometry(self):  # type: ignore[no-untyped-def]
+            raise AssertionError("拖拽不应依赖 frameGeometry")
+
+        def move(self, position) -> None:  # type: ignore[no-untyped-def]
+            self.move_positions.append(position)
+
+    window = MinimalWindow()
+    press_event = MouseEventStub(position=(40, 60), global_position=(240, 160))
+    move_event = MouseEventStub(position=(45, 65), global_position=(300, 220))
+    release_event = MouseEventStub(position=(45, 65), global_position=(300, 220))
+
+    assert window._handle_mouse_press(press_event) is True
+    assert window.drag_anchor == qtcore.QPoint(40, 60)
+    assert press_event.accepted
+
+    assert window._handle_mouse_move(move_event) is True
+    assert window.move_positions == [qtcore.QPoint(260, 160)]
+    assert move_event.accepted
+
+    assert window._handle_mouse_release(release_event) is True
+    assert window.drag_anchor is None
+    assert release_event.accepted
+
+
+def test_pet_window_drag_maps_child_widget_anchor_to_window_coordinates() -> None:
+    qtcore = pytest.importorskip("PySide6.QtCore")
+    from app.ui.pet_window import PetWindow
+
+    class MouseEventStub:
+        accepted = False
+
+        def __init__(self, position: tuple[int, int], global_position: tuple[int, int]) -> None:
+            self._position = qtcore.QPointF(*position)
+            self._global_position = qtcore.QPointF(*global_position)
+
+        def button(self):  # type: ignore[no-untyped-def]
+            return qtcore.Qt.MouseButton.LeftButton
+
+        def buttons(self):  # type: ignore[no-untyped-def]
+            return qtcore.Qt.MouseButton.LeftButton
+
+        def position(self):  # type: ignore[no-untyped-def]
+            return self._position
+
+        def globalPosition(self):  # type: ignore[no-untyped-def]
+            return self._global_position
+
+        def accept(self) -> None:
+            self.accepted = True
+
+    class ChildWidgetStub:
+        def mapTo(self, _window, position):  # type: ignore[no-untyped-def]
+            return position + qtcore.QPoint(100, 80)
+
+    class MinimalWindow:
+        _handle_mouse_press = PetWindow._handle_mouse_press
+        _handle_mouse_move = PetWindow._handle_mouse_move
+        _drag_anchor_from_event = PetWindow._drag_anchor_from_event
+
+        def __init__(self) -> None:
+            self.drag_anchor = None
+            self.move_positions: list[object] = []
+
+        def move(self, position) -> None:  # type: ignore[no-untyped-def]
+            self.move_positions.append(position)
+
+    window = MinimalWindow()
+    child = ChildWidgetStub()
+    press_event = MouseEventStub(position=(10, 15), global_position=(300, 200))
+    move_event = MouseEventStub(position=(15, 20), global_position=(350, 260))
+
+    assert window._handle_mouse_press(press_event, child) is True
+    assert window.drag_anchor == qtcore.QPoint(110, 95)
+
+    assert window._handle_mouse_move(move_event) is True
+    assert window.move_positions == [qtcore.QPoint(240, 165)]
+
+
+def test_pet_window_screen_change_restores_stage_geometry(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    qtcore = pytest.importorskip("PySide6.QtCore")
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    if not hasattr(qtcore.QEvent.Type, "ScreenChangeInternal"):
+        pytest.skip("当前 Qt 版本不提供 ScreenChangeInternal。")
+    if not hasattr(qtwidgets, "QApplication") or not hasattr(qtwidgets, "QWidget"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+
+    import app.ui.pet_window as pet_window_module
+    from app.ui.pet_window import PetWindow
+
+    QApplication = qtwidgets.QApplication
+    QWidget = qtwidgets.QWidget
+    app = QApplication.instance() or QApplication([])
+    scheduled_callbacks: list[tuple[int, object]] = []
+    monkeypatch.setattr(
+        pet_window_module.QTimer,
+        "singleShot",
+        lambda delay, callback: scheduled_callbacks.append((delay, callback)),
+    )
+
+    class MinimalScreenChangeWindow(PetWindow):
+        def __init__(self) -> None:
+            QWidget.__init__(self)
+            self.stage_size = (321, 234)
+            self.layout_count = 0
+            self.topmost_sync_count = 0
+
+        def _layout_stage(self) -> None:
+            self.layout_count += 1
+
+        def _schedule_native_topmost_sync(self) -> None:
+            self.topmost_sync_count += 1
+
+    window = MinimalScreenChangeWindow()
+    window.resize(111, 222)
+    window.layout_count = 0
+
+    window.event(qtcore.QEvent(qtcore.QEvent.Type.ScreenChangeInternal))
+    assert len(scheduled_callbacks) == 1
+    assert scheduled_callbacks[0][0] == 0
+
+    scheduled_callbacks[0][1]()
+
+    assert window.size() == qtcore.QSize(321, 234)
+    assert window.layout_count >= 1
+    assert window.topmost_sync_count == 1
+
+    window.deleteLater()
+    app.processEvents()
+
+
 def test_reply_history_controls_use_capsule_sizing() -> None:
     os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
     qtwidgets = pytest.importorskip("PySide6.QtWidgets")


### PR DESCRIPTION
## 变更内容
- 启动前配置 Windows DPI awareness，优先使用 Per-Monitor V2，并设置 Qt HighDPI rounding policy 为 PassThrough。
- 将桌宠拖拽逻辑改为窗口本地锚点，避免跨屏混合缩放时依赖 frameGeometry 导致位置跳动。
- 监听跨屏事件后恢复舞台逻辑尺寸并重新布局，降低 DPI 切换后 UI 裁切或错位风险。
- 新增 UI 回归测试覆盖拖拽锚点、子控件坐标映射和跨屏恢复。

## 验证
- `./runtime/python.exe -m pytest tests/ui/test_pet_window.py -q -k "drag or screen_change or context_menu"`：5 passed
- `./runtime/python.exe -m pytest tests/ui/test_pet_window.py -q`：140 passed
- `./runtime/python.exe -m pytest tests/unit -q`：257 passed, 3 skipped
- `./runtime/python.exe -m py_compile main.py app/ui/pet_window.py tests/ui/test_pet_window.py`：通过

## 说明
- 自动化测试无法真实模拟 Windows 双屏不同缩放，仍建议在 100% + 150% 等混合 DPI 双屏环境下手动拖动验证一次。