### PR TITLE
feat: add reopen context prompt

### DIFF
--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -51,6 +51,7 @@ from app.agent import (
     AgentResult,
     PendingToolAction,
 )
+from app.agent.builtin_tools import get_current_time
 from app.agent.memory_curator import (
     MemoryCurationResult,
 )
@@ -139,6 +140,7 @@ MEMORY_STATUS_STARTUP_DELAY_MS = 1_000
 SUBTITLE_LANGUAGE_JA = "ja"
 SUBTITLE_LANGUAGE_ZH = "zh"
 MANUAL_SCREENSHOT_DEFAULT_TEXT = "请根据我框选的截图继续对话。"
+REOPEN_CONTEXT_PROMPT_PREFIX = "系统事件：用户刚刚重新打开了 Sakura 桌宠。"
 _UI_ASSETS_DIR = Path(__file__).with_name("assets")
 _SCREENSHOT_ICON_PATH = _UI_ASSETS_DIR / "screenshot-select.svg"
 _SCREENSHOT_ATTACHED_ICON_PATH = _UI_ASSETS_DIR / "screenshot-attached.svg"
@@ -158,6 +160,38 @@ DEFAULT_STAGE_HEIGHT = 640
 # 立绘缩放时碰撞箱高度下限：底部 UI 区（气泡 128 + 输入框 52 + 间距 94 = 274px）
 # 加上立绘顶部约 146px 可见区，合计 ~420px。
 MIN_STAGE_HEIGHT = 420
+
+
+def _build_reopen_context_message(time_info: dict[str, str]) -> dict[str, str]:
+    datetime_text = str(time_info.get("datetime") or "").strip()
+    timezone = str(time_info.get("timezone") or "").strip()
+    local_time = datetime_text
+    if timezone:
+        local_time = f"{datetime_text}（{timezone}）"
+    content = (
+        f"{REOPEN_CONTEXT_PROMPT_PREFIX}\n"
+        f"本地时间：{local_time}。\n"
+        "这表示用户此前曾隐藏或离开桌宠，现在又回到对话。"
+        "回复时请自然地意识到用户是重新打开应用后继续交流，"
+        "不要表现得像一直无缝在线，也不要直接复述这条系统事件。"
+    )
+    return {"role": "system", "content": content}
+
+
+def _current_time_from_builtin_tool(tool_registry: Any) -> dict[str, str]:
+    execute = getattr(tool_registry, "execute", None)
+    if callable(execute):
+        result = execute("get_current_time", {})
+        if getattr(result, "success", False):
+            content = getattr(result, "content", None)
+            if isinstance(content, dict):
+                datetime_text = str(content.get("datetime") or "").strip()
+                if datetime_text:
+                    return {
+                        "datetime": datetime_text,
+                        "timezone": str(content.get("timezone") or "").strip(),
+                    }
+    return get_current_time()
 
 
 def _message_box_theme(parent: QWidget | None, theme_settings: ThemeSettings | None) -> ThemeSettings:
@@ -357,6 +391,7 @@ class PetWindow(QWidget):
         self.pending_screen_observation_messages: list[dict[str, Any]] | None = None
         self.pending_screen_observation_event: AgentEvent | None = None
         self.pending_screen_observation_event_reminder_id: str | None = None
+        self.pending_reopen_context_message: dict[str, Any] | None = None
         self.pending_visual_observation_jobs: list[VisualObservationJob] = []
         self.pending_event_visual_observation_jobs: list[VisualObservationJob] = []
         self.plugin_chat_ui_widget_instances: list[QWidget] = []
@@ -1255,6 +1290,12 @@ class PetWindow(QWidget):
         else:
             request_user_message: dict[str, Any] = {"role": "user", "content": text}
             recorded_user_text = text
+
+        consume_reopen_context = getattr(self, "_consume_pending_reopen_context_message", None)
+        if callable(consume_reopen_context):
+            reopen_context_message = consume_reopen_context()
+            if reopen_context_message is not None:
+                self.messages.append(reopen_context_message)
 
         request_messages = _add_visual_context_to_messages(
             [*self.messages, request_user_message],
@@ -2487,10 +2528,37 @@ class PetWindow(QWidget):
     @Slot()
     def _show_from_tray(self) -> None:
         self.hidden_to_tray = False
+        queue_reopen_context = getattr(self, "_queue_reopen_context_prompt", None)
+        if callable(queue_reopen_context):
+            queue_reopen_context()
         self.show()
         self.raise_()
         self.activateWindow()
         self._refresh_tray_menu()
+
+    def _queue_reopen_context_prompt(self) -> None:
+        if getattr(self, "startup_initializing", False):
+            return
+        self.pending_reopen_context_message = _build_reopen_context_message(
+            _current_time_from_builtin_tool(getattr(self, "tool_registry", None))
+        )
+        debug_log(
+            "PetWindow",
+            "已排队重新打开上下文提示",
+            self.pending_reopen_context_message,
+        )
+
+    def _consume_pending_reopen_context_message(self) -> dict[str, Any] | None:
+        message = getattr(self, "pending_reopen_context_message", None)
+        self.pending_reopen_context_message = None
+        if not isinstance(message, dict):
+            return None
+        if message.get("role") != "system":
+            return None
+        content = message.get("content")
+        if not isinstance(content, str) or not content.strip():
+            return None
+        return message
 
     def _handle_application_activated(self) -> None:
         if getattr(self, "hidden_to_tray", False):

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -275,6 +275,56 @@ def test_pet_window_hide_and_show_to_tray_tracks_hidden_state() -> None:
     assert window.events == ["hide", "refresh", "show", "raise", "activate", "refresh"]
 
 
+def test_pet_window_show_from_tray_queues_reopen_context_prompt() -> None:
+    from app.ui.pet_window import PetWindow
+
+    class ToolResult:
+        success = True
+        content = {"datetime": "2026-06-06T12:34:56+08:00", "timezone": "CST"}
+
+    class ToolRegistryStub:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, dict[str, object]]] = []
+
+        def execute(self, name: str, arguments: dict[str, object]) -> ToolResult:
+            self.calls.append((name, arguments))
+            return ToolResult()
+
+    class MinimalWindow:
+        _show_from_tray = PetWindow._show_from_tray
+        _queue_reopen_context_prompt = PetWindow._queue_reopen_context_prompt
+
+        def __init__(self) -> None:
+            self.hidden_to_tray = True
+            self.startup_initializing = False
+            self.tool_registry = ToolRegistryStub()
+            self.pending_reopen_context_message = None
+            self.events: list[str] = []
+
+        def show(self) -> None:
+            self.events.append("show")
+
+        def raise_(self) -> None:
+            self.events.append("raise")
+
+        def activateWindow(self) -> None:
+            self.events.append("activate")
+
+        def _refresh_tray_menu(self) -> None:
+            self.events.append("refresh")
+
+    window = MinimalWindow()
+
+    window._show_from_tray()
+
+    assert window.hidden_to_tray is False
+    assert window.events == ["show", "raise", "activate", "refresh"]
+    assert window.tool_registry.calls == [("get_current_time", {})]
+    assert window.pending_reopen_context_message["role"] == "system"
+    assert "用户刚刚重新打开了 Sakura 桌宠" in window.pending_reopen_context_message["content"]
+    assert "2026-06-06T12:34:56+08:00" in window.pending_reopen_context_message["content"]
+
+
 def test_pet_window_application_activation_restores_when_hidden_to_tray(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     import app.ui.pet_window as pet_window_module
     from app.ui.pet_window import PetWindow
@@ -4887,6 +4937,39 @@ def test_send_message_clears_pending_proactive_screenshot_batch(monkeypatch) -> 
     assert minimal_window.proactive_screen_context_batch_started_at is None
     assert minimal_window.last_proactive_screen_context_at is None
     assert minimal_window.proactive_screen_context_dropped_count == 0
+
+
+def test_send_message_injects_reopen_context_before_user_message() -> None:
+    from app.ui.pet_window import PetWindow
+
+    window, requests, history = _build_minimal_manual_screenshot_window("继续刚才的话题")
+    window.pending_manual_screen_observation = None
+    reopen_message = {
+        "role": "system",
+        "content": "系统事件：用户刚刚重新打开了 Sakura 桌宠。",
+    }
+    window.pending_reopen_context_message = reopen_message
+    window._consume_pending_reopen_context_message = (
+        PetWindow._consume_pending_reopen_context_message.__get__(
+            window,
+            type(window),
+        )
+    )
+
+    window.send_message("test")
+
+    assert requests == [
+        [
+            reopen_message,
+            {"role": "user", "content": "继续刚才的话题"},
+        ]
+    ]
+    assert window.messages == [
+        reopen_message,
+        {"role": "user", "content": "继续刚才的话题"},
+    ]
+    assert window.pending_reopen_context_message is None
+    assert history == [("user", "继续刚才的话题")]
 
 
 class _DummyTextInput:


### PR DESCRIPTION
## 背景

当前用户隐藏/重新显示桌宠后，应用会继续保留同一进程内的 `PetWindow.messages` 上下文。模型下一次回复时会像无缝接上上一轮对话，无法感知用户其实是“重新打开/回到”桌宠，体验上不够自然。

## 变更

- 在桌宠从隐藏状态重新显示时，排队一条“用户重新打开 Sakura 桌宠”的 system 上下文提示。
- 复用内置 `get_current_time` 工具获取本地时间，并将本地时间写入该提示。
- 用户下一次发送消息时，将该 system 提示插入到历史上下文和当前用户消息之间，让 LLM 能自然意识到用户是重新回到对话。
- 该提示只进入运行时上下文，不写入 `chat_history`，避免污染历史记录窗口。
- 启动初始化阶段不会生成该提示，避免首次启动被误判为重新打开。

## 测试

已通过：

```bash
.venv/bin/python -m pytest tests/ui/test_pet_window.py
git diff --check