### PR TITLE
fix: defer memory failure dialog until window is visible

### DIFF
--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -367,8 +367,10 @@ class PetWindow(QWidget):
         self.active_event_type = ""
         self.active_event: AgentEvent | None = None
         self.memory_status_message_active = False
+        self.memory_status_last_status = ""
         self.memory_status_last_message = ""
         self.memory_failure_dialog_last_message = ""
+        self.memory_failure_dialog_pending_message = ""
         self.last_user_activity_at = time.perf_counter()
         self.last_proactive_care_at: float | None = None
         self.last_proactive_screen_context_at: float | None = None
@@ -625,6 +627,8 @@ class PetWindow(QWidget):
         super().showEvent(event)
         self._refresh_tray_menu()
         self._schedule_native_topmost_sync()
+        if getattr(self, "memory_failure_dialog_pending_message", ""):
+            QTimer.singleShot(0, self._show_pending_memory_failure_dialog)
 
     def hideEvent(self, event) -> None:  # type: ignore[no-untyped-def]
         super().hideEvent(event)
@@ -2408,6 +2412,7 @@ class PetWindow(QWidget):
 
     def _show_memory_status_message(self, status: str, message: str) -> None:
         self.memory_status_message_active = True
+        self.memory_status_last_status = status
         self.memory_status_last_message = message
         if status == "failed":
             self._show_memory_failure_dialog(message)
@@ -2421,6 +2426,23 @@ class PetWindow(QWidget):
     def _show_memory_failure_dialog(self, message: str) -> None:
         if getattr(self, "memory_failure_dialog_last_message", "") == message:
             return
+        if self._should_defer_memory_failure_dialog():
+            self.memory_failure_dialog_pending_message = message
+            return
+        self._display_memory_failure_dialog(message)
+
+    def _should_defer_memory_failure_dialog(self) -> bool:
+        if getattr(self, "startup_initializing", False):
+            return True
+        is_visible = getattr(self, "isVisible", None)
+        if callable(is_visible):
+            return not bool(is_visible())
+        return False
+
+    def _display_memory_failure_dialog(self, message: str) -> None:
+        if getattr(self, "memory_failure_dialog_last_message", "") == message:
+            return
+        self.memory_failure_dialog_pending_message = ""
         self.memory_failure_dialog_last_message = message
         show_themed_warning(self, "记忆模型下载失败", message)
 
@@ -2435,9 +2457,25 @@ class PetWindow(QWidget):
         ):
             return
         self.subtitle_controller.show_text_immediately(self.memory_status_last_message)
+        self._show_pending_memory_failure_dialog()
+
+    @Slot()
+    def _show_pending_memory_failure_dialog(self) -> None:
+        message = getattr(self, "memory_failure_dialog_pending_message", "")
+        if (
+            not message
+            or getattr(self, "startup_initializing", False)
+            or getattr(self, "memory_status_last_status", "") != "failed"
+        ):
+            return
+        if self._should_defer_memory_failure_dialog():
+            return
+        self._display_memory_failure_dialog(message)
 
     def _show_memory_ready_message(self, message: str) -> None:
         _ = message
+        self.memory_status_last_status = "ready"
+        self.memory_failure_dialog_pending_message = ""
         if not self.memory_status_message_active:
             return
         self.memory_status_message_active = False

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -195,14 +195,23 @@ def test_memory_status_does_not_use_tray_balloon(monkeypatch) -> None:  # type: 
     )
     window = type("WindowStub", (), {})()
     window.memory_status_message_active = False
+    window.memory_status_last_status = ""
     window.memory_status_last_message = ""
     window.memory_failure_dialog_last_message = ""
+    window.memory_failure_dialog_pending_message = ""
     window.startup_initializing = False
     window.active_interaction_id = None
     window.reply_history_review_active = False
     window.subtitle_controller = SubtitleControllerStub()
     window.tray_icon = TrayIconStub()
+    window.isVisible = lambda: True
     window._restore_memory_status_speech = lambda: None
+    window._should_defer_memory_failure_dialog = (
+        lambda: PetWindow._should_defer_memory_failure_dialog(window)
+    )
+    window._display_memory_failure_dialog = (
+        lambda message: PetWindow._display_memory_failure_dialog(window, message)
+    )
     window._show_memory_failure_dialog = lambda message: PetWindow._show_memory_failure_dialog(window, message)
 
     for status in ("loading", "reloading", "failed"):
@@ -217,6 +226,61 @@ def test_memory_status_does_not_use_tray_balloon(monkeypatch) -> None:  # type: 
     ]
     assert warnings == [("记忆模型下载失败", "failed message")]
     assert single_shots == [(pet_window_module.MEMORY_STATUS_DISPLAY_MS, window._restore_memory_status_speech)]
+
+
+def test_memory_failure_dialog_is_deferred_until_startup_window_is_visible(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    import app.ui.pet_window as pet_window_module
+    from app.ui.pet_window import PetWindow
+
+    class SubtitleControllerStub:
+        def __init__(self) -> None:
+            self.messages: list[str] = []
+
+        def show_text_immediately(self, message: str) -> None:
+            self.messages.append(message)
+
+    warnings: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        pet_window_module,
+        "show_themed_warning",
+        lambda _parent, title, text, **_kwargs: warnings.append((title, text)),
+    )
+    window = type("WindowStub", (), {})()
+    window.memory_status_message_active = False
+    window.memory_status_last_status = ""
+    window.memory_status_last_message = ""
+    window.memory_failure_dialog_last_message = ""
+    window.memory_failure_dialog_pending_message = ""
+    window.startup_initializing = True
+    window.active_interaction_id = None
+    window.reply_history_review_active = False
+    window.subtitle_controller = SubtitleControllerStub()
+    visible = {"value": False}
+    window.isVisible = lambda: visible["value"]
+    window._should_defer_memory_failure_dialog = (
+        lambda: PetWindow._should_defer_memory_failure_dialog(window)
+    )
+    window._display_memory_failure_dialog = (
+        lambda message: PetWindow._display_memory_failure_dialog(window, message)
+    )
+    window._show_memory_failure_dialog = lambda message: PetWindow._show_memory_failure_dialog(window, message)
+    window._show_pending_memory_failure_dialog = (
+        lambda: PetWindow._show_pending_memory_failure_dialog(window)
+    )
+
+    PetWindow._show_memory_status_message(window, "failed", "download failed")
+
+    assert warnings == []
+    assert window.subtitle_controller.messages == []
+    assert window.memory_failure_dialog_pending_message == "download failed"
+
+    window.startup_initializing = False
+    visible["value"] = True
+    PetWindow._show_pending_memory_status_after_startup(window)
+
+    assert window.subtitle_controller.messages == ["download failed"]
+    assert warnings == [("记忆模型下载失败", "download failed")]
+    assert window.memory_failure_dialog_pending_message == ""
 
 
 def test_message_box_stylesheet_contains_configured_theme_colors() -> None:


### PR DESCRIPTION
b站评论区有用户反馈长期记忆系统初始化失败后出现闪退，针对该问题试做修复：
memory preload starts before PetWindow.show()
failed status can be replayed while PetWindow.__init__ is still running
showing modal QMessageBox.exec() during construction can make startup appear to crash, so defer it until window is visible/startup is done
修改了qt的ui时序