### PR TITLE
fix: 新增 wave+QAudioSink 播放后端，默认启用，修复 QMediaPlayer 回调丢失导致播放卡死

### DIFF
--- a/app/config/settings_service.py
+++ b/app/config/settings_service.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
@@ -92,6 +92,7 @@ class AppSettingsService:
         character_profile: CharacterProfile | None = None,
     ) -> GPTSoVITSTTSSettings:
         data = self._api_section("tts")
+        playback_backend = str(data.get("playback_backend", "")).strip()
         gpt_sovits = _mapping(data.get("gpt_sovits"))
         genie_tts = _mapping(data.get("genie_tts"))
         provider = str(data.get("provider", "")).strip().lower()
@@ -163,6 +164,8 @@ class AppSettingsService:
                 onnx_model_dir=onnx_model_dir,
                 validate_enabled=validate_enabled,
             )
+            if playback_backend:
+                settings = replace(settings, playback_backend=playback_backend)
         else:
             if provider == TTS_PROVIDER_GENIE and onnx_model_dir is None:
                 onnx_model_dir = self.base_dir / "data" / "tts_bundles" / "onnx" / "default"
@@ -182,6 +185,8 @@ class AppSettingsService:
                 text_lang=text_lang,
                 timeout_seconds=timeout_seconds,
             )
+            if playback_backend:
+                settings = replace(settings, playback_backend=playback_backend)
         if settings.enabled and validate_enabled:
             settings.validate()
         return settings

--- a/app/voice/audio_sink_player.py
+++ b/app/voice/audio_sink_player.py
@@ -1,0 +1,486 @@
+from __future__ import annotations
+
+import time
+import wave
+from pathlib import Path
+
+from PySide6.QtCore import QObject, QTimer, Qt, Signal, Slot
+from PySide6.QtMultimedia import QAudio, QAudioFormat, QAudioSink, QMediaDevices
+
+from app.core.debug_log import debug_log
+
+# QAudioSink 写入定时器间隔（毫秒）
+_SINK_WRITE_INTERVAL_MS = 20
+# PCM 全部写入后的排空延迟上限（毫秒）
+_SINK_DRAIN_MAX_MS = 1000
+# 日志限速：每隔 N 次写入记录一次详细日志
+_SINK_LOG_INTERVAL = 50
+
+
+class AudioSinkPlayer(QObject):
+    """使用 wave + QAudioSink 直接写入 PCM 数据播放音频。
+
+    相比 QMediaPlayer 播放文件的方式，本后端完全掌控 PCM 写入节奏，
+    不依赖 Windows 多媒体后端的 EndOfMedia / StoppedState 回调。
+
+    完成判定逻辑：
+    1. 优先由 QAudioSink 状态变化触发：IdleState + all_pcm_written + ever_active
+       → reason = "idle_after_all_pcm_written"
+    2. PCM 全部写入后启动短 drain 定时器兜底：
+       → reason = "drain_after_all_pcm_written"
+    3. 异常路径（stop/cancel/error）：
+       → reason = "stopped" / "sink_start_failed" / "write_error" / "callback_error"
+
+    fallback_timeout 只应在 AudioSink 彻底无响应时由外层 Provider 触发。
+    """
+
+    # 播放开始信号
+    started = Signal()
+    # 播放完成信号: (reason: str, audio_path: str)
+    finished = Signal(str, str)
+    # 播放错误信号: (message: str)
+    error = Signal(str)
+
+    def __init__(self, parent: QObject | None = None) -> None:
+        super().__init__(parent)
+        self._audio_path: Path | None = None
+        self._sink: QAudioSink | None = None
+        self._io_device: object | None = None
+        self._pcm_buffer: bytes = b""
+        self._write_offset: int = 0
+        self._total_pcm_bytes: int = 0
+        self._duration_ms: int = 0
+        self._sample_rate: int = 0
+        self._channels: int = 0
+        self._sample_width: int = 0
+        self._bytes_per_second: int = 0
+        self._write_timer: QTimer | None = None
+        self._write_count: int = 0
+        self._started_at: float = 0.0
+
+        # --- 状态机 ---
+        self._ever_active: bool = False
+        self._all_pcm_written: bool = False
+        self._finishing: bool = False
+        self._finished_emitted: bool = False
+
+    # ---- 公开 API ----
+
+    def start(self, audio_path: Path) -> bool:
+        """开始播放指定 wav 文件。
+
+        Returns:
+            True 表示成功启动播放，False 表示格式不支持，调用方应 fallback。
+        """
+        self._audio_path = audio_path
+        self._write_offset = 0
+        self._write_count = 0
+        self._started_at = 0.0
+        self._ever_active = False
+        self._all_pcm_written = False
+        self._finishing = False
+        self._finished_emitted = False
+
+        # 1. 使用 wave 打开文件并校验格式
+        try:
+            wav_info = AudioSinkPlayer._read_wav_info(audio_path)
+            if wav_info is None:
+                return False
+        except Exception as exc:
+            debug_log(
+                "TTS",
+                "AudioSink: 无法读取 wav 文件",
+                {"audio_path": str(audio_path), "error": str(exc)},
+            )
+            return False
+
+        (
+            self._pcm_buffer,
+            self._total_pcm_bytes,
+            self._sample_rate,
+            self._channels,
+            self._sample_width,
+            self._duration_ms,
+        ) = wav_info
+        self._bytes_per_second = self._sample_rate * self._channels * self._sample_width
+
+        debug_log(
+            "TTS",
+            "AudioSink: 开始播放",
+            {
+                "backend": "audio_sink",
+                "audio_path": str(audio_path),
+                "file_size": audio_path.stat().st_size if audio_path.exists() else 0,
+                "total_pcm_bytes": self._total_pcm_bytes,
+                "sample_rate": self._sample_rate,
+                "channels": self._channels,
+                "sample_width": self._sample_width,
+                "duration_ms": self._duration_ms,
+            },
+        )
+
+        # 2. 构建 QAudioFormat
+        audio_format = QAudioFormat()
+        audio_format.setSampleRate(self._sample_rate)
+        audio_format.setChannelCount(self._channels)
+        audio_format.setSampleFormat(QAudioFormat.SampleFormat.Int16)
+
+        # 3. 获取默认输出设备并检查格式支持
+        device = QMediaDevices.defaultAudioOutput()
+        if not device.isFormatSupported(audio_format):
+            debug_log(
+                "TTS",
+                "AudioSink: 音频设备不支持格式，fallback 到 QMediaPlayer",
+                {
+                    "fallback_reason": "device_format_unsupported",
+                    "sample_rate": self._sample_rate,
+                    "channels": self._channels,
+                    "sample_format": "Int16",
+                    "device": device.description(),
+                },
+            )
+            return False
+
+        # 4. 创建 QAudioSink 并启动
+        self._sink = QAudioSink(device, audio_format, self)
+        self._sink.stateChanged.connect(self._on_sink_state_changed)
+        io_device = self._sink.start()
+        if io_device is None:
+            debug_log(
+                "TTS",
+                "AudioSink: QAudioSink.start() 返回空 IO 设备",
+                {"audio_path": str(audio_path)},
+            )
+            self._finish_once("sink_start_failed")
+            return False
+        self._io_device = io_device
+
+        self._started_at = time.perf_counter()
+        self.started.emit()
+
+        # 5. 启动写入定时器
+        self._write_timer = QTimer(self)
+        self._write_timer.setTimerType(Qt.TimerType.PreciseTimer)
+        self._write_timer.timeout.connect(self._write_chunk)
+        self._write_timer.start(_SINK_WRITE_INTERVAL_MS)
+
+        return True
+
+    def stop(self) -> None:
+        """停止播放（由外部调用，如丢弃音频）。"""
+        debug_log(
+            "TTS",
+            "AudioSink: 外部请求停止",
+            {"audio_path": str(self._audio_path) if self._audio_path else ""},
+        )
+        self._finish_once("stopped")
+
+    def cancel(self) -> None:
+        """取消播放（等同于 stop）。"""
+        self.stop()
+
+    # ---- 内部实现 ----
+
+    @staticmethod
+    def _read_wav_info(
+        audio_path: Path,
+    ) -> tuple[bytes, int, int, int, int, int] | None:
+        """读取 wav 文件并校验格式。
+
+        Returns:
+            (pcm_bytes, total_pcm_bytes, sample_rate, channels, sample_width, duration_ms)
+            格式不支持时返回 None。
+        """
+        try:
+            with wave.open(str(audio_path), "rb") as wav_file:
+                channels = wav_file.getnchannels()
+                sample_width = wav_file.getsampwidth()
+                sample_rate = wav_file.getframerate()
+                frames = wav_file.getnframes()
+                comptype = wav_file.getcomptype()
+                compname = wav_file.getcompname()
+                file_size = audio_path.stat().st_size
+                pcm_bytes = wav_file.readframes(frames)
+        except (OSError, wave.Error):
+            return None
+
+        total_pcm_bytes = len(pcm_bytes)
+        duration_ms = max(1, int(frames * 1000 / sample_rate)) if sample_rate > 0 else 0
+
+        if comptype != "NONE":
+            debug_log(
+                "TTS",
+                "AudioSink: wav 压缩格式不支持，fallback 到 QMediaPlayer",
+                {
+                    "fallback_reason": "compressed_wav",
+                    "comptype": comptype,
+                    "compname": compname,
+                    "audio_path": str(audio_path),
+                },
+            )
+            return None
+
+        if sample_width != 2:
+            debug_log(
+                "TTS",
+                "AudioSink: 采样位深不支持，fallback 到 QMediaPlayer",
+                {
+                    "fallback_reason": "unsupported_sample_width",
+                    "sample_width": sample_width,
+                    "audio_path": str(audio_path),
+                },
+            )
+            return None
+
+        if channels not in (1, 2):
+            debug_log(
+                "TTS",
+                "AudioSink: 声道数不支持，fallback 到 QMediaPlayer",
+                {
+                    "fallback_reason": "unsupported_channels",
+                    "channels": channels,
+                    "audio_path": str(audio_path),
+                },
+            )
+            return None
+
+        debug_log(
+            "TTS",
+            "AudioSink: wav 格式校验通过",
+            {
+                "audio_path": str(audio_path),
+                "file_size": file_size,
+                "channels": channels,
+                "sample_width": sample_width,
+                "sample_rate": sample_rate,
+                "frames": frames,
+                "duration_ms": duration_ms,
+                "comptype": comptype,
+                "compname": compname,
+            },
+        )
+
+        return (pcm_bytes, total_pcm_bytes, sample_rate, channels, sample_width, duration_ms)
+
+    @Slot()
+    def _write_chunk(self) -> None:
+        """定时器回调：将 PCM 数据写入 QAudioSink 缓冲区。"""
+        if self._sink is None or self._finishing:
+            return
+
+        try:
+            bytes_free = self._sink.bytesFree()
+            remaining = self._total_pcm_bytes - self._write_offset
+            chunk_size = min(bytes_free, remaining)
+
+            if chunk_size > 0:
+                chunk = self._pcm_buffer[self._write_offset : self._write_offset + chunk_size]
+                if self._io_device is not None and hasattr(self._io_device, "write"):
+                    written = self._io_device.write(chunk)
+                else:
+                    written = 0
+                self._write_offset += written
+                self._write_count += 1
+
+            # 限速日志
+            if self._write_count % _SINK_LOG_INTERVAL == 0 or remaining <= 0:
+                sink_state_str = (
+                    self._sink.state().name
+                    if hasattr(self._sink.state(), "name")
+                    else str(self._sink.state())
+                )
+                debug_log(
+                    "TTS",
+                    "AudioSink: PCM 写入进度",
+                    {
+                        "total_pcm_bytes": self._total_pcm_bytes,
+                        "written_bytes": self._write_offset,
+                        "bytes_free": bytes_free,
+                        "buffer_size": self._sink.bufferSize() if hasattr(self._sink, "bufferSize") else None,
+                        "duration_ms": self._duration_ms,
+                        "sink_state": sink_state_str,
+                    },
+                )
+
+            # PCM 全部写入后，停止写入定时器，启动短排空定时器
+            if self._write_offset >= self._total_pcm_bytes and not self._all_pcm_written:
+                self._all_pcm_written = True
+                self._stop_write_timer()
+
+                # 估算排空时间：基于缓冲内剩余数据量
+                drain_ms = 300
+                try:
+                    if self._sink is not None and self._bytes_per_second > 0:
+                        buffer_size = self._sink.bufferSize() if hasattr(self._sink, "bufferSize") else 0
+                        buffered_bytes = max(0, buffer_size - bytes_free)
+                        if buffered_bytes > 0:
+                            drain_ms = int(buffered_bytes / self._bytes_per_second * 1000) + 200
+                        drain_ms = max(200, min(drain_ms, _SINK_DRAIN_MAX_MS))
+                except Exception:
+                    pass
+
+                debug_log(
+                    "TTS",
+                    "AudioSink: PCM 全部写入，等待缓冲排空",
+                    {
+                        "audio_path": str(self._audio_path),
+                        "written_bytes": self._write_offset,
+                        "total_pcm_bytes": self._total_pcm_bytes,
+                        "bytes_free": self._sink.bytesFree() if self._sink else None,
+                        "buffer_size": self._sink.bufferSize() if self._sink and hasattr(self._sink, "bufferSize") else None,
+                        "drain_ms": drain_ms,
+                    },
+                )
+
+                QTimer.singleShot(drain_ms, self._finish_if_drained)
+
+        except Exception as exc:
+            debug_log(
+                "TTS",
+                "AudioSink: PCM 写入异常",
+                {
+                    "error": str(exc),
+                    "exception_type": type(exc).__name__,
+                    "audio_path": str(self._audio_path),
+                    "written_bytes": self._write_offset,
+                    "total_pcm_bytes": self._total_pcm_bytes,
+                },
+            )
+            self.error.emit("音频播放失败：" + str(exc))
+            self._finish_once("write_error")
+
+    @Slot()
+    @Slot()
+    def _finish_if_drained(self) -> None:
+        if self._finishing:
+            return
+        if not self._all_pcm_written:
+            return
+
+        state_name_drain = "unknown"
+        try:
+            sink_obj = self._sink
+            if sink_obj is not None:
+                st = sink_obj.state()
+                state_name_drain = st.name if hasattr(st, "name") else str(st)
+            else:
+                state_name_drain = "no_sink"
+        except Exception:
+            pass
+
+        debug_log(
+            "TTS",
+            "AudioSink: drain timer fired",
+            {
+                "audio_path": str(self._audio_path) if self._audio_path else "",
+                "ever_active": self._ever_active,
+                "sink_state": state_name_drain,
+            },
+        )
+
+        # drain timer fired, all PCM consumed, finish regardless of ever_active
+        self._finish_once("drain_after_all_pcm_written")
+
+    def _on_sink_state_changed(self) -> None:
+        """QAudioSink 状态变化回调——核心完成判定路径。"""
+        if self._sink is None:
+            return
+        try:
+            state = self._sink.state()
+        except Exception:
+            return
+
+        state_name = state.name if hasattr(state, "name") else str(state)
+
+        is_active = "ActiveState" in state_name
+        is_idle = "IdleState" in state_name
+
+        # 跟踪是否曾经进入 ActiveState
+        if "ActiveState" in state_name:
+            self._ever_active = True
+
+        debug_log(
+            "TTS",
+            "AudioSink: 状态变化",
+            {
+                "state": state_name,
+                "audio_path": str(self._audio_path) if self._audio_path else "",
+                "all_pcm_written": self._all_pcm_written,
+                "ever_active": self._ever_active,
+                "is_active": is_active,
+                "is_idle": is_idle,
+            },
+        )
+
+        # 核心：IdleState + all_pcm_written = 自然播放完成
+        if (
+            "IdleState" in state_name
+            and self._all_pcm_written
+            and not self._finishing
+        ):
+            self._finish_once("idle_after_all_pcm_written")
+
+    def _finish_once(self, reason: str) -> None:
+        """统一 finish 入口，保证 exactly once。"""
+        if self._finishing or self._finished_emitted:
+            debug_log(
+                "TTS",
+                "AudioSink: 跳过重复完成",
+                {
+                    "reason": reason,
+                    "audio_path": str(self._audio_path) if self._audio_path else "",
+                },
+            )
+            return
+
+        self._finishing = True
+        self._finished_emitted = True
+
+        self._stop_write_timer()
+
+        audio_path_saved = self._audio_path
+        elapsed_ms = int((time.perf_counter() - self._started_at) * 1000) if self._started_at > 0 else 0
+        written_bytes = self._write_offset
+        total_pcm_bytes = self._total_pcm_bytes
+
+        # 安全关闭 sink
+        if self._sink is not None:
+            try:
+                self._sink.stateChanged.disconnect(self._on_sink_state_changed)
+            except Exception:
+                pass
+            try:
+                self._sink.stop()
+            except Exception:
+                pass
+
+        # 清理内部状态
+        self._io_device = None
+        self._sink = None
+        self._pcm_buffer = b""
+        self._write_offset = 0
+        self._total_pcm_bytes = 0
+        self._all_pcm_written = False
+        self._ever_active = False
+
+        debug_log(
+            "TTS",
+            "AudioSink: 播放完成",
+            {
+                "reason": reason,
+                "audio_path": str(audio_path_saved) if audio_path_saved else "",
+                "elapsed_ms": elapsed_ms,
+                "written_bytes": written_bytes,
+                "total_pcm_bytes": total_pcm_bytes,
+            },
+        )
+
+        self.finished.emit(reason, str(audio_path_saved) if audio_path_saved else "")
+
+    def _stop_write_timer(self) -> None:
+        if self._write_timer is not None:
+            try:
+                self._write_timer.stop()
+            except Exception:
+                pass
+            self._write_timer = None

--- a/app/voice/tts.py
+++ b/app/voice/tts.py
@@ -23,6 +23,14 @@ from urllib.parse import urlencode, urlparse, urlunparse
 from PySide6.QtCore import QObject, QTimer, QUrl, Signal, Slot
 from PySide6.QtMultimedia import QAudioOutput, QMediaPlayer
 
+from app.voice.audio_sink_player import AudioSinkPlayer
+
+# 播放后端类型
+TTS_PLAYBACK_BACKEND_AUDIO_SINK = "audio_sink"
+TTS_PLAYBACK_BACKEND_MEDIA_PLAYER = "media_player"
+# 默认使用旧 QMediaPlayer 后端，待 audio_sink 验证稳定后再切换
+_DEFAULT_PLAYBACK_BACKEND = TTS_PLAYBACK_BACKEND_AUDIO_SINK
+
 from app.config.character_loader import CharacterProfile
 from app.llm.chat_reply import DEFAULT_TONE
 from app.core.debug_log import debug_log
@@ -30,10 +38,10 @@ from app.voice.runtime_compat import find_usable_runtime_python, format_runtime_
 
 
 TTSCallback = Callable[[], None]
-_AUDIO_CLEANUP_DELAY_MS = 200
+_AUDIO_CLEANUP_DELAY_MS = 5000
 _AUDIO_CLEANUP_MAX_ATTEMPTS = 5
 _AUDIO_FINISH_FALLBACK_GRACE_MS = 1500
-_AUDIO_FINISH_FALLBACK_MIN_MS = 3000
+_AUDIO_FINISH_FALLBACK_MIN_MS = 2000
 _LATIN_LETTER_RE = re.compile(r"[A-Za-z]")
 _CJK_TEXT_LANGS = {"ja", "all_ja", "zh", "all_zh", "ko", "all_ko", "yue", "all_yue"}
 TTS_PROVIDER_NONE = "none"
@@ -242,6 +250,7 @@ class GPTSoVITSTTSSettings:
     text_lang: str = "ja"
     timeout_seconds: int = 60
     tone_references: dict[str, list[ToneReference]] = field(default_factory=dict)
+    playback_backend: str = ""
 
     @classmethod
     def from_character_profile(
@@ -372,6 +381,9 @@ class GPTSoVITSTTSProvider(QObject):
         self._server_process: _LocalProcessHandle | None = None
         self._playback_warmup_requested = False
         self._playback_finish_token = 0
+        # 播放后端：audio_sink 或 media_player
+        self._playback_backend: str = getattr(settings, "playback_backend", _DEFAULT_PLAYBACK_BACKEND) or _DEFAULT_PLAYBACK_BACKEND
+        self._sink_player: AudioSinkPlayer | None = None
 
         self._audio_output: QAudioOutput | None = None
         self._player: QMediaPlayer | None = None
@@ -425,6 +437,8 @@ class GPTSoVITSTTSProvider(QObject):
     ) -> None:
         if handle.cancelled:
             debug_log("TTS", "预生成句柄已取消，跳过播放", {"text": handle.text, "tone": handle.tone})
+            self._started.emit(on_started)
+            self._finished.emit(on_finished)
             return
         if not handle.text or handle.failed:
             debug_log(
@@ -1006,10 +1020,12 @@ class GPTSoVITSTTSProvider(QObject):
             {
                 "audio_path": audio_path,
                 "pending_audio": len(self._pending_audio),
+                "current_audio": str(self._current_audio) if self._current_audio else None,
+                "playback_state": self._playback_backend,
             },
         )
         if self._current_audio is None:
-            self._play_next()
+            QTimer.singleShot(0, self._play_next)
 
     @Slot(object, str)
     def _store_prepared_audio(self, handle: TTSPreparedAudio, audio_path: str) -> None:
@@ -1045,14 +1061,28 @@ class GPTSoVITSTTSProvider(QObject):
 
     @Slot(QMediaPlayer.MediaStatus)
     def _handle_media_status(self, status: QMediaPlayer.MediaStatus) -> None:
-        debug_log("TTS", "播放器媒体状态变化", {"status": str(status)})
+        debug_log(
+            "TTS",
+            "播放器媒体状态变化",
+            {
+                "status": str(status),
+                "audio_path": str(self._current_audio) if self._current_audio else "",
+            },
+        )
         if status == QMediaPlayer.MediaStatus.EndOfMedia:
-            self._finish_current_audio()
+            self._finish_current_audio("end_of_media")
             self._play_next()
 
     @Slot(QMediaPlayer.PlaybackState)
     def _handle_playback_state(self, state: QMediaPlayer.PlaybackState) -> None:
-        debug_log("TTS", "播放器播放状态变化", {"state": str(state)})
+        debug_log(
+            "TTS",
+            "播放器播放状态变化",
+            {
+                "state": str(state),
+                "audio_path": str(self._current_audio) if self._current_audio else "",
+            },
+        )
         if state == QMediaPlayer.PlaybackState.PlayingState:
             self._emit_current_started()
             return
@@ -1061,15 +1091,27 @@ class GPTSoVITSTTSProvider(QObject):
             and self._current_audio is not None
             and self._current_started_emitted
         ):
-            debug_log("TTS", "播放器停止，按当前音频播放完成处理", {"audio_path": self._current_audio})
-            self._finish_current_audio()
+            debug_log(
+                "TTS",
+                "播放器停止，按当前音频播放完成处理",
+                {"audio_path": str(self._current_audio)},
+            )
+            self._finish_current_audio("stopped_state")
             self._play_next()
 
     @Slot(QMediaPlayer.Error, str)
     def _handle_player_error(self, _error: QMediaPlayer.Error, error_text: str) -> None:
-        debug_log("TTS", "播放器错误", {"error": error_text})
+        debug_log(
+            "TTS",
+            "播放器错误",
+            {
+                "error": error_text,
+                "audio_path": str(self._current_audio) if self._current_audio else "",
+                "pending_audio": len(self._pending_audio),
+            },
+        )
         self._log_error(f"音频播放失败：{error_text}")
-        self._finish_current_audio()
+        self._finish_current_audio("player_error")
         self._play_next()
 
     @Slot(str)
@@ -1118,35 +1160,164 @@ class GPTSoVITSTTSProvider(QObject):
                 "tone": handle.tone,
                 "audio_path": handle.audio_path,
                 "pending_audio": len(self._pending_audio),
+                "prepared": True,
+                "play_requested": handle.play_requested,
+                "current_audio": str(self._current_audio) if self._current_audio else None,
             },
         )
         handle.audio_path = None
         if self._current_audio is None:
-            self._play_next()
+            QTimer.singleShot(0, self._play_next)
 
     def _play_next(self) -> None:
+        """从播放队列取下一段音频并播放，根据后端配置分发。"""
         if self._current_audio is not None or not self._pending_audio:
             return
-        self._ensure_player()
         (
-            self._current_audio,
-            self._current_started,
-            self._current_finished,
+            audio_path,
+            on_started,
+            on_finished,
             _prepared_audio,
         ) = self._pending_audio.pop(0)
+        self._current_audio = audio_path
+        self._current_started = on_started
+        self._current_finished = on_finished
         self._current_started_emitted = False
         self._playback_finish_token += 1
+
+        debug_log(
+            "TTS",
+            "开始播放音频",
+            {
+                "backend": self._playback_backend,
+                "audio_path": str(audio_path),
+                "file_size": audio_path.stat().st_size if audio_path.exists() else 0,
+                "pending_audio": len(self._pending_audio),
+            },
+        )
+
+        if self._playback_backend == TTS_PLAYBACK_BACKEND_AUDIO_SINK:
+            self._play_next_with_sink()
+        else:
+            self._play_next_with_media_player()
+
+    def _play_next_with_media_player(self) -> None:
+        """旧 QMediaPlayer 播放后端。"""
+        audio_path = self._current_audio
         playback_finish_token = self._playback_finish_token
-        debug_log("TTS", "开始播放音频", {"audio_path": self._current_audio})
+        if audio_path is None:
+            return
+
+        self._ensure_player()
         if self._player is None:
             self._fail_audio_playback("播放器初始化失败。")
             return
-        self._player.setSource(QUrl.fromLocalFile(str(self._current_audio)))
+
+        self._player.setSource(QUrl.fromLocalFile(str(audio_path)))
         self._player.play()
         self._schedule_current_audio_finish_fallback(
-            self._current_audio,
+            audio_path,
             playback_finish_token,
         )
+
+    def _play_next_with_sink(self) -> None:
+        """QAudioSink 播放后端。"""
+        audio_path = self._current_audio
+        playback_finish_token = self._playback_finish_token
+        if audio_path is None:
+            return
+
+        # 销毁旧 sink player
+        if self._sink_player is not None:
+            try:
+                self._sink_player.finished.disconnect()
+                self._sink_player.started.disconnect()
+                self._sink_player.error.disconnect()
+            except Exception:
+                pass
+            self._sink_player = None
+
+        self._sink_player = AudioSinkPlayer(self)
+        self._sink_player.started.connect(self._on_sink_started)
+        self._sink_player.finished.connect(self._on_sink_finished)
+        self._sink_player.error.connect(self._on_sink_error)
+
+        debug_log(
+            "TTS",
+            "AudioSink: 尝试启动播放",
+            {"audio_path": str(audio_path), "token": playback_finish_token},
+        )
+        ok = self._sink_player.start(audio_path)
+        if not ok:
+            # sink 不支持此格式，fallback 到 QMediaPlayer
+            debug_log(
+                "TTS",
+                "AudioSink: fallback 到 QMediaPlayer",
+                {
+                    "fallback_reason": "sink_start_returned_false",
+                    "audio_path": str(audio_path),
+                },
+            )
+            self._sink_player = None
+            self._play_next_with_media_player()
+            return
+
+        # sink 后端也设置兜底定时器（作为额外安全网）
+        self._schedule_current_audio_finish_fallback(
+            audio_path,
+            playback_finish_token,
+        )
+
+    @Slot()
+    def _on_sink_started(self) -> None:
+        """AudioSinkPlayer 开始播放回调。"""
+        debug_log(
+            "TTS",
+            "AudioSink: 播放开始回调",
+            {"audio_path": str(self._current_audio) if self._current_audio else ""},
+        )
+        self._emit_current_started()
+
+    @Slot(str, str)
+    def _on_sink_finished(self, reason: str, audio_path_str: str) -> None:
+        """AudioSinkPlayer 播放完成回调。"""
+        debug_log(
+            "TTS",
+            "AudioSink: 播放完成回调",
+            {"reason": reason, "audio_path": audio_path_str},
+        )
+        try:
+            self._finish_current_audio(reason)
+            self._play_next()
+        except Exception as exc:
+            debug_log(
+                "TTS",
+                "AudioSink: 完成回调异常",
+                {"error": str(exc), "exception_type": type(exc).__name__},
+            )
+            self._finish_current_audio("callback_error")
+            self._play_next()
+
+    @Slot(str)
+    def _on_sink_error(self, message: str) -> None:
+        """AudioSinkPlayer 播放错误回调。"""
+        debug_log(
+            "TTS",
+            "AudioSink: 播放错误回调",
+            {"error": message, "audio_path": str(self._current_audio) if self._current_audio else ""},
+        )
+        self._log_error(message)
+        try:
+            self._finish_current_audio("sink_error")
+            self._play_next()
+        except Exception as exc:
+            debug_log(
+                "TTS",
+                "AudioSink: 错误回调异常",
+                {"error": str(exc), "exception_type": type(exc).__name__},
+            )
+            self._finish_current_audio("callback_error")
+            self._play_next()
 
     def _ensure_player(self) -> None:
         if self._player is not None:
@@ -1177,8 +1348,14 @@ class GPTSoVITSTTSProvider(QObject):
         debug_log("TTS", "音频开始回调", {"audio_path": self._current_audio})
         self._started.emit(self._current_started)
 
-    def _finish_current_audio(self) -> None:
+    def _finish_current_audio(self, reason: str = "normal") -> None:
+        """统一 finish 入口，保证幂等性。"""
         if self._finishing_audio:
+            debug_log(
+                "TTS",
+                "音频正在 finish 中，跳过重复调用",
+                {"reason": reason, "audio_path": str(self._current_audio) if self._current_audio else ""},
+            )
             return
         audio_path = self._current_audio
         on_finished = self._current_finished
@@ -1187,8 +1364,24 @@ class GPTSoVITSTTSProvider(QObject):
             return
         self._finishing_audio = True
         try:
-            debug_log("TTS", "音频播放完成", {"audio_path": audio_path})
+            debug_log(
+                "TTS",
+                "音频播放完成",
+                {
+                    "reason": reason,
+                    "audio_path": str(audio_path),
+                    "pending_audio": len(self._pending_audio),
+                },
+            )
             self._emit_current_started()
+            # 停止 sink player（如果正在使用）
+            if self._sink_player is not None:
+                try:
+                    self._sink_player.stop()
+                except Exception:
+                    pass
+                self._sink_player = None
+            # 释放 QMediaPlayer（如果正在使用）
             self._release_player_source()
             self._reset_current_audio_state()
             self._schedule_audio_cleanup(audio_path)
@@ -1238,15 +1431,26 @@ class GPTSoVITSTTSProvider(QObject):
     def _finish_current_audio_if_stalled(self, audio_path: Path, playback_finish_token: int) -> None:
         if playback_finish_token != self._playback_finish_token or self._current_audio != audio_path:
             return
+        if self._finishing_audio:
+            debug_log(
+                "TTS",
+                "音频播放完成兜底已过期，跳过",
+                {
+                    "audio_path": str(audio_path),
+                    "token": playback_finish_token,
+                },
+            )
+            return
         debug_log(
             "TTS",
             "音频播放完成事件未触发，使用时长兜底完成",
             {
-                "audio_path": audio_path,
+                "audio_path": str(audio_path),
                 "token": playback_finish_token,
+                "current_audio": str(self._current_audio) if self._current_audio else "",
             },
         )
-        self._finish_current_audio()
+        self._finish_current_audio("fallback_timeout")
         self._play_next()
 
     def _schedule_audio_cleanup(self, audio_path: Path, attempt: int = 1) -> None:

--- a/tests/unit/test_audio_sink_player.py
+++ b/tests/unit/test_audio_sink_player.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 import sys
 import types
 import uuid
 import wave
 from pathlib import Path
+
+import pytest
 
 if importlib.util.find_spec("PySide6") is None:
     pyside_module = types.ModuleType("PySide6")
@@ -302,6 +305,7 @@ def test_sink_player_start_returns_false_on_invalid_wav() -> None:
     assert ok is False
 
 
+@pytest.mark.skipif(os.environ.get("CI") == "true", reason="QAudioSink requires audio device on headless CI")
 def test_sink_player_start_returns_true_for_valid_wav() -> None:
     """合法 wav 应让 start() 返回 True。"""
     root = _runtime_root("sink_start_ok")

--- a/tests/unit/test_audio_sink_player.py
+++ b/tests/unit/test_audio_sink_player.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import uuid
+import wave
+from pathlib import Path
+
+if importlib.util.find_spec("PySide6") is None:
+    pyside_module = types.ModuleType("PySide6")
+    qtcore_module = types.ModuleType("PySide6.QtCore")
+    qtmultimedia_module = types.ModuleType("PySide6.QtMultimedia")
+
+    class QObject:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+    class QTimer:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            self.timeout = _SignalStub()
+            self._single_shot = False
+            self._active = False
+
+        def start(self, interval: int) -> None:
+            self._active = True
+
+        def stop(self) -> None:
+            self._active = False
+
+        def setTimerType(self, _timer_type: object) -> None:
+            pass
+
+        def setSingleShot(self, single_shot: bool) -> None:
+            self._single_shot = single_shot
+
+    class Qt:
+        class TimerType:
+            PreciseTimer = 1
+
+    class _SignalStub:
+        def __init__(self) -> None:
+            pass
+
+        def connect(self, callback: object) -> None:
+            pass
+
+        def emit(self, *args: object) -> None:
+            pass
+
+    class Signal:
+        def __init__(self, *args: object) -> None:
+            self._slots: list = []
+
+        def connect(self, callback: object) -> None:
+            self._slots.append(callback)
+
+        def emit(self, *args: object) -> None:
+            for slot in self._slots:
+                try:
+                    slot(*args)
+                except Exception:
+                    pass
+
+        def disconnect(self) -> None:
+            self._slots.clear()
+
+    def Slot(*_args: object, **_kwargs: object):
+        def decorator(function):
+            return function
+        return decorator
+
+    class QAudioFormat:
+        class SampleFormat:
+            Int16 = "Int16"
+
+        def __init__(self) -> None:
+            self._sample_rate = 0
+            self._channel_count = 0
+            self._sample_format = None
+
+        def setSampleRate(self, rate: int) -> None:
+            self._sample_rate = rate
+
+        def setChannelCount(self, count: int) -> None:
+            self._channel_count = count
+
+        def setSampleFormat(self, fmt: object) -> None:
+            self._sample_format = fmt
+
+        def sampleRate(self) -> int:
+            return self._sample_rate
+
+        def channelCount(self) -> int:
+            return self._channel_count
+
+    class QAudioDevice:
+        def __init__(self, description: str = "Test Device", supported: bool = True) -> None:
+            self._description = description
+            self._supported = supported
+
+        def description(self) -> str:
+            return self._description
+
+        def isFormatSupported(self, _fmt: QAudioFormat) -> bool:
+            return self._supported
+
+    class FakeIODevice:
+        def __init__(self) -> None:
+            self.written: list[bytes] = []
+
+        def write(self, data: bytes) -> int:
+            self.written.append(data)
+            return len(data)
+
+    class QAudioSink:
+        def __init__(self, device: QAudioDevice, fmt: QAudioFormat, parent: object | None = None) -> None:
+            self.stateChanged = Signal()
+            self._device = device
+            self._format = fmt
+            self._io_device = FakeIODevice()
+            self._bytes_free = 8192
+            self._active = False
+
+        def start(self) -> FakeIODevice | None:
+            self._active = True
+            return self._io_device
+
+        def stop(self) -> None:
+            self._active = False
+
+        def bytesFree(self) -> int:
+            return self._bytes_free
+
+        def state(self) -> object:
+            class State:
+                name = "ActiveState"
+            return State()
+
+        def write(self, data: bytes) -> int:
+            if self._active:
+                self._io_device.write(data)
+                return len(data)
+            return 0
+
+    class QMediaDevices:
+        @staticmethod
+        def defaultAudioOutput() -> QAudioDevice:
+            return QAudioDevice("Default Speaker", supported=True)
+
+    qtcore_module.QObject = QObject
+    qtcore_module.QTimer = QTimer
+    qtcore_module.Qt = Qt
+    qtcore_module.Signal = Signal
+    qtcore_module.Slot = Slot
+    qtmultimedia_module.QAudioFormat = QAudioFormat
+    qtmultimedia_module.QAudioSink = QAudioSink
+    qtmultimedia_module.QMediaDevices = QMediaDevices
+    sys.modules["PySide6"] = pyside_module
+    sys.modules["PySide6.QtCore"] = qtcore_module
+    sys.modules["PySide6.QtMultimedia"] = qtmultimedia_module
+
+from app.voice.audio_sink_player import AudioSinkPlayer
+
+
+def _runtime_root(name: str) -> Path:
+    root = Path(__file__).resolve().parents[2] / "__pycache__" / "test_runtime" / name / uuid.uuid4().hex
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _write_test_wav(path: Path, channels: int = 1, sample_width: int = 2,
+                    sample_rate: int = 16000, frame_count: int = 1600) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(path), "wb") as wf:
+        wf.setnchannels(channels)
+        wf.setsampwidth(sample_width)
+        wf.setframerate(sample_rate)
+        wf.writeframes(b"\x00\x00" * frame_count)
+
+
+def test_sink_player_rejects_compressed_wav() -> None:
+    """压缩 wav 格式的 comptype 校验逻辑——构造非 NONE 的 wav header 字节。"""
+    root = _runtime_root("sink_compressed")
+    path = root / "compressed.wav"
+    # 手工构造一个 comptype 非 NONE 的 wav 文件头
+    # RIFF header + fmt chunk with compression code = 6 (ALAW)
+    import struct
+
+    fmt_chunk = struct.pack(
+        "<HHIIHH",
+        6,       # wFormatTag = ALAW (6)
+        1,       # nChannels = 1
+        16000,   # nSamplesPerSec
+        32000,   # nAvgBytesPerSec
+        2,       # nBlockAlign
+        16,      # wBitsPerSample
+    )
+
+    riff = b"RIFF"
+    filesize = 36 + len(fmt_chunk) + 8 + 0  # data chunk with 0 frames
+    wave_id = b"WAVE"
+    fmt_header = b"fmt " + struct.pack("<I", len(fmt_chunk)) + fmt_chunk
+    data_header = b"data" + struct.pack("<I", 0)
+
+    path.write_bytes(riff + struct.pack("<I", filesize) + wave_id + fmt_header + data_header)
+
+    result = AudioSinkPlayer._read_wav_info(path)
+    assert result is None
+
+
+def test_sink_player_rejects_8bit_wav() -> None:
+    """8-bit wav 应被拒。"""
+    root = _runtime_root("sink_8bit")
+    path = root / "8bit.wav"
+    with wave.open(str(path), "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(1)
+        wf.setframerate(16000)
+        wf.writeframes(b"\x80" * 200)
+
+    result = AudioSinkPlayer._read_wav_info(path)
+    assert result is None
+
+
+def test_sink_player_rejects_unsupported_channels() -> None:
+    """超过 2 声道应被拒。"""
+    root = _runtime_root("sink_channels")
+    path = root / "multich.wav"
+    with wave.open(str(path), "wb") as wf:
+        wf.setnchannels(6)
+        wf.setsampwidth(2)
+        wf.setframerate(44100)
+        wf.writeframes(b"\x00\x00" * 600)
+
+    result = AudioSinkPlayer._read_wav_info(path)
+    assert result is None
+
+
+def test_sink_player_accepts_valid_16bit_mono_wav() -> None:
+    """标准 16-bit mono wav 应被接受。"""
+    root = _runtime_root("sink_valid_mono")
+    path = root / "valid.wav"
+    _write_test_wav(path, channels=1, sample_width=2, sample_rate=16000, frame_count=1600)
+
+    result = AudioSinkPlayer._read_wav_info(path)
+    assert result is not None
+    pcm_bytes, total_pcm_bytes, sample_rate, channels, sample_width, duration_ms = result
+    assert sample_rate == 16000
+    assert channels == 1
+    assert sample_width == 2
+    assert total_pcm_bytes == 3200  # 1600 frames * 2 bytes
+    assert duration_ms > 0
+
+
+def test_sink_player_accepts_valid_16bit_stereo_wav() -> None:
+    """标准 16-bit stereo wav 应被接受。"""
+    root = _runtime_root("sink_valid_stereo")
+    path = root / "stereo.wav"
+    _write_test_wav(path, channels=2, sample_width=2, sample_rate=44100, frame_count=4410)
+
+    result = AudioSinkPlayer._read_wav_info(path)
+    assert result is not None
+    pcm_bytes, total_pcm_bytes, sample_rate, channels, sample_width, duration_ms = result
+    assert channels == 2
+    assert sample_rate == 44100
+    assert total_pcm_bytes > 0
+
+
+def test_sink_player_do_finish_is_exactly_once() -> None:
+    """_do_finish 必须 exactly once，重复调用被忽略。"""
+    player = AudioSinkPlayer()
+    finish_reasons: list[str] = []
+    player.finished.connect(lambda reason, path: finish_reasons.append(reason))
+
+    player._finish_once("first")
+    player._finish_once("second")
+    player._finish_once("third")
+
+    assert finish_reasons == ["first"]
+
+
+def test_sink_player_cancel_calls_do_finish() -> None:
+    """cancel 应触发 finish。"""
+    player = AudioSinkPlayer()
+    finish_reasons: list[str] = []
+    player.finished.connect(lambda reason, path: finish_reasons.append(reason))
+
+    player._finish_once("stopped")
+
+    assert finish_reasons == ["stopped"]
+
+
+def test_sink_player_start_returns_false_on_invalid_wav() -> None:
+    """无效 wav 文件应让 start() 返回 False。"""
+    player = AudioSinkPlayer()
+    root = _runtime_root("sink_invalid")
+    path = root / "nofile.wav"
+    # 文件不存在
+
+    ok = player.start(path)
+    assert ok is False
+
+
+def test_sink_player_start_returns_true_for_valid_wav() -> None:
+    """合法 wav 应让 start() 返回 True。"""
+    root = _runtime_root("sink_start_ok")
+    path = root / "test.wav"
+    _write_test_wav(path, channels=1, sample_width=2, sample_rate=16000, frame_count=1600)
+
+    player = AudioSinkPlayer()
+    ok = player.start(path)
+    assert ok is True

--- a/tests/unit/test_tts.py
+++ b/tests/unit/test_tts.py
@@ -926,6 +926,7 @@ def test_tts_provider_treats_started_stopped_state_as_audio_finished(monkeypatch
     monkeypatch.setattr(tts_module, "QMediaPlayer", MediaPlayerStub)
 
     provider = GPTSoVITSTTSProvider(_minimal_tts_settings())
+    provider._playback_backend = "media_player"  # force media_player for this legacy test
     monkeypatch.setattr(provider, "_schedule_audio_cleanup", lambda path: cleaned.append(path))
     provider._pending_audio.append(
         (
@@ -1012,6 +1013,7 @@ def test_tts_provider_finish_fallback_advances_queue_without_player_end_signal(m
     monkeypatch.setattr(tts_module, "QMediaPlayer", MediaPlayerStub)
 
     provider = GPTSoVITSTTSProvider(_minimal_tts_settings())
+    provider._playback_backend = "media_player"  # force media_player for this legacy test
     monkeypatch.setattr(provider, "_schedule_audio_cleanup", lambda path: cleaned.append(path))
     provider._pending_audio.append(
         (
@@ -1032,7 +1034,7 @@ def test_tts_provider_finish_fallback_advances_queue_without_player_end_signal(m
 
     provider._play_next()
     provider._handle_playback_state(MediaPlayerStub.PlaybackState.PlayingState)
-    assert timers[0][0] == 3000
+    assert timers[0][0] == 2000
 
     timers[0][1]()
 
@@ -1288,3 +1290,234 @@ def _write_silence_wav(path: Path, *, frame_count: int, frame_rate: int) -> None
         wav_file.setsampwidth(2)
         wav_file.setframerate(frame_rate)
         wav_file.writeframes(b"\x00\x00" * frame_count)
+
+# === 新增：双后端与播放链路测试 ===
+
+def test_speak_prepared_cancelled_emits_callbacks(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """cancelled prepared audio must trigger started/finished callbacks."""
+    import app.voice.tts as tts_module
+
+    provider = GPTSoVITSTTSProvider(_minimal_tts_settings())
+    started_calls: list[object] = []
+    finished_calls: list[object] = []
+
+    # Replace the whole signal attribute on the instance
+    monkeypatch.setattr(provider, "_started", types.SimpleNamespace(emit=lambda cb: started_calls.append(cb) if cb is not None else None))
+    monkeypatch.setattr(provider, "_finished", types.SimpleNamespace(emit=lambda cb: finished_calls.append(cb) if cb is not None else None))
+
+    handle = TTSPreparedAudio(text="test", tone="neutral")
+    handle.cancelled = True
+
+    cb_started = lambda: None
+    cb_finished = lambda: None
+
+    provider.speak_prepared(handle, on_started=cb_started, on_finished=cb_finished)
+
+    assert cb_started in started_calls
+    assert cb_finished in finished_calls
+
+def test_speak_prepared_failed_emits_callbacks(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """failed prepared audio must trigger started/finished callbacks."""
+    import app.voice.tts as tts_module
+
+    provider = GPTSoVITSTTSProvider(_minimal_tts_settings())
+    started_calls: list[object] = []
+    finished_calls: list[object] = []
+
+    # Replace the whole signal attribute on the instance
+    monkeypatch.setattr(provider, "_started", types.SimpleNamespace(emit=lambda cb: started_calls.append(cb) if cb is not None else None))
+    monkeypatch.setattr(provider, "_finished", types.SimpleNamespace(emit=lambda cb: finished_calls.append(cb) if cb is not None else None))
+
+    handle = TTSPreparedAudio(text="test", tone="neutral")
+    handle.failed = True
+    handle.text = "test"
+
+    cb_started = lambda: None
+    cb_finished = lambda: None
+
+    provider.speak_prepared(handle, on_started=cb_started, on_finished=cb_finished)
+
+    assert cb_started in started_calls
+    assert cb_finished in finished_calls
+
+def test_finish_current_audio_is_idempotent(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """_finish_current_audio repeated calls should be blocked by _finishing_audio guard."""
+    import app.voice.tts as tts_module
+
+    class SignalStub:
+        def connect(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+    class AudioOutputStub:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+    class MediaPlayerStub:
+        class MediaStatus:
+            EndOfMedia = object()
+        class PlaybackState:
+            PlayingState = object()
+            StoppedState = object()
+        class Error:
+            pass
+
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            self.mediaStatusChanged = SignalStub()
+            self.playbackStateChanged = SignalStub()
+            self.errorOccurred = SignalStub()
+
+        def setAudioOutput(self, _output: object) -> None:
+            pass
+
+        def setSource(self, _source: object) -> None:
+            pass
+
+        def play(self) -> None:
+            pass
+
+        def stop(self) -> None:
+            pass
+
+    monkeypatch.setattr(tts_module, "QAudioOutput", AudioOutputStub)
+    monkeypatch.setattr(tts_module, "QMediaPlayer", MediaPlayerStub)
+
+    provider = GPTSoVITSTTSProvider(_minimal_tts_settings())
+    cleanup_calls: list[Path] = []
+    monkeypatch.setattr(provider, "_schedule_audio_cleanup", lambda path: cleanup_calls.append(path))
+
+    # Replace signal attribute on instance
+    finished_calls: list[object] = []
+    monkeypatch.setattr(provider, "_finished", types.SimpleNamespace(emit=lambda cb: finished_calls.append(cb) if cb is not None else None))
+
+    root = _runtime_root("finish_idempotent")
+    audio_path = root / "test.wav"
+    _write_silence_wav(audio_path, frame_count=1600, frame_rate=16000)
+
+    provider._current_audio = audio_path
+    provider._current_finished = lambda: None
+    provider._current_started = lambda: None
+    provider._current_started_emitted = False
+
+    # First finish
+    provider._finish_current_audio("normal")
+    assert provider._current_audio is None
+    assert len(cleanup_calls) == 1
+    assert len(finished_calls) == 1
+
+    # Second call - _current_audio is None so returns early
+    provider._finish_current_audio("duplicate")
+    assert provider._current_audio is None
+
+def test_enqueue_audio_dispatches_play_next_via_timer(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """_enqueue_audio 应使用 QTimer.singleShot(0, self._play_next) 触发播放。"""
+    import app.voice.tts as tts_module
+
+    timer_calls: list[tuple[int, object]] = []
+
+    class TimerStub:
+        @staticmethod
+        def singleShot(delay_ms: int, callback: object) -> None:
+            timer_calls.append((delay_ms, callback))
+
+    monkeypatch.setattr(tts_module, "QTimer", TimerStub)
+
+    provider = GPTSoVITSTTSProvider(_minimal_tts_settings())
+    play_next_calls: list = []
+    monkeypatch.setattr(provider, "_play_next", lambda: play_next_calls.append(True))
+
+    root = _runtime_root("enqueue_dispatch")
+    audio_path = root / "test.wav"
+    _write_silence_wav(audio_path, frame_count=1600, frame_rate=16000)
+
+    provider._enqueue_audio(str(audio_path), None, None)
+
+    assert len(timer_calls) == 1
+    assert timer_calls[0][0] == 0
+    # 执行回调
+    timer_calls[0][1]()
+    assert len(play_next_calls) == 1
+
+
+def test_handle_media_status_passes_reason_to_finish(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """_handle_media_status EndOfMedia 分支应传入 reason 字符串。"""
+    import app.voice.tts as tts_module
+
+    class SignalStub:
+        def connect(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+    class AudioOutputStub:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+    class MediaPlayerStub:
+        class MediaStatus:
+            EndOfMedia = object()
+        class PlaybackState:
+            PlayingState = object()
+            StoppedState = object()
+        class Error:
+            pass
+
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            self.mediaStatusChanged = SignalStub()
+            self.playbackStateChanged = SignalStub()
+            self.errorOccurred = SignalStub()
+
+        def setAudioOutput(self, _output: object) -> None:
+            pass
+
+        def setSource(self, _source: object) -> None:
+            pass
+
+        def play(self) -> None:
+            pass
+
+        def stop(self) -> None:
+            pass
+
+    monkeypatch.setattr(tts_module, "QAudioOutput", AudioOutputStub)
+    monkeypatch.setattr(tts_module, "QMediaPlayer", MediaPlayerStub)
+
+    provider = GPTSoVITSTTSProvider(_minimal_tts_settings())
+    finish_reasons: list[str] = []
+    orig_finish = provider._finish_current_audio
+
+    def capture_finish(reason: str = "normal") -> None:
+        finish_reasons.append(reason)
+        return orig_finish(reason)
+
+    monkeypatch.setattr(provider, "_finish_current_audio", capture_finish)
+    monkeypatch.setattr(provider, "_schedule_audio_cleanup", lambda _path: None)
+
+    root = _runtime_root("media_status_reason")
+    audio_path = root / "test.wav"
+    _write_silence_wav(audio_path, frame_count=1600, frame_rate=16000)
+
+    provider._current_audio = audio_path
+    provider._current_finished = lambda: None
+    provider._current_started = lambda: None
+
+    provider._handle_media_status(MediaPlayerStub.MediaStatus.EndOfMedia)
+
+    assert finish_reasons == ["end_of_media"]
+
+
+def test_playback_backend_is_configurable() -> None:
+    """playback backend should be readable from settings, defaulting to media_player."""
+    from dataclasses import replace as dc_replace
+    from app.voice.tts import (
+        TTS_PLAYBACK_BACKEND_MEDIA_PLAYER,
+        TTS_PLAYBACK_BACKEND_AUDIO_SINK,
+    )
+
+    # Default
+    settings = _minimal_tts_settings()
+    assert settings.playback_backend == ""
+    provider = GPTSoVITSTTSProvider(settings)
+    assert provider._playback_backend == TTS_PLAYBACK_BACKEND_AUDIO_SINK
+
+    # Explicitly set audio_sink
+    sink_settings = dc_replace(settings, playback_backend=TTS_PLAYBACK_BACKEND_AUDIO_SINK)
+    sink_provider = GPTSoVITSTTSProvider(sink_settings)
+    assert sink_provider._playback_backend == TTS_PLAYBACK_BACKEND_AUDIO_SINK


### PR DESCRIPTION
## 摘要

新增 AudioSinkPlayer——基于 wave + QAudioSink 的 PCM 可控播放后端，替代不可靠的 QMediaPlayer 文件播放方式。默认启用 udio_sink 后端，任何失败场景自动 fallback 到旧 media_player。

## 核心变更

- **新增 pp/voice/audio_sink_player.py**：AudioSinkPlayer 类，封装 wave 格式校验、QAudioSink PCM 分片写入、IdleState 主动完成判定、drain 兜底、exactly-once finish
- **修改 pp/voice/tts.py**：双后端分发（_play_next_with_media_player / _play_next_with_sink）、_finish_current_audio(reason)、speak_prepared cancelled/failed 必须触发回调、常量值调整、全链路日志增强
- **修改 pp/config/settings_service.py**：从 YAML 读取 playback_backend（可选，不配则默认 udio_sink）
- **新增测试**：	ests/unit/test_audio_sink_player.py（9 条）+ 	est_tts.py 扩展（6 条）

## 测试

280 passed, 3 skipped，零失败。