### PR TITLE
fix: Windows深色主题修复 + TTS HTTP就绪探测 (整合 PR #44)

### DIFF
--- a/app/voice/tts.py
+++ b/app/voice/tts.py
@@ -748,6 +748,10 @@ class GPTSoVITSTTSProvider(QObject):
                 )
                 return False
             if GPTSoVITSTTSProvider._probe_service_port(self, host, port, timeout, purpose="startup_wait"):
+                if not _probe_gpt_sovits_http(self.settings.api_url, timeout):
+                    # 端口通但 HTTP 层尚未就绪（模型仍在加载），继续等待
+                    time.sleep(0.5)
+                    continue
                 self._service_checked = True
                 debug_log(
                     "TTS",
@@ -2128,6 +2132,23 @@ def _probe_tcp_port(host: str, port: int, timeout: int) -> bool:
         with socket.create_connection((host, port), timeout=timeout):
             pass
     except (TimeoutError, OSError):
+        return False
+    return True
+
+
+def _probe_gpt_sovits_http(api_url: str, timeout: int) -> bool:
+    """探测 GPT-SoVITS HTTP 层是否就绪（TCP 通后 HTTP 可能仍在初始化）。"""
+    parsed = urlparse(api_url)
+    base_path = parsed.path.rsplit("/", 1)[0]
+    probe_url = urlunparse(parsed._replace(path=base_path or "/", query=""))
+    request = urllib.request.Request(url=probe_url, method="GET")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout):
+            pass
+    except urllib.error.HTTPError:
+        # 任何 HTTP 状态码都说明服务 HTTP 层已就绪
+        pass
+    except (urllib.error.URLError, TimeoutError, OSError):
         return False
     return True
 

--- a/main.py
+++ b/main.py
@@ -6,8 +6,8 @@ from dataclasses import replace
 from pathlib import Path
 
 from PySide6.QtCore import QObject, QThread, QTimer, Qt, Signal, Slot
-from PySide6.QtGui import QGuiApplication
-from PySide6.QtWidgets import QApplication, QDialog, QLabel, QMessageBox, QProgressBar, QPushButton, QVBoxLayout
+from PySide6.QtGui import QGuiApplication, QPalette, QColor
+from PySide6.QtWidgets import QApplication, QDialog, QLabel, QMessageBox, QProgressBar, QPushButton, QVBoxLayout, QStyleFactory
 
 from app.core.app_context import AppContext
 from app.core.bootstrap import build_deferred_services, build_initial_app_context
@@ -35,6 +35,23 @@ from app.voice.tts_bundle import (
 
 
 BASE_DIR = Path(__file__).resolve().parent
+
+
+def _force_light_palette(app: QApplication) -> None:
+    """强制使用 Fusion 风格 + 亮色 palette，避免 Windows 暗色模式下系统控件文字与浅色背景冲突。"""
+    app.setStyle(QStyleFactory.create("Fusion"))
+    palette = QPalette()
+    palette.setColor(QPalette.ColorRole.Window, QColor("#fff6fa"))
+    palette.setColor(QPalette.ColorRole.WindowText, QColor("#3d2b35"))
+    palette.setColor(QPalette.ColorRole.Base, QColor("#ffffff"))
+    palette.setColor(QPalette.ColorRole.AlternateBase, QColor("#fff6fa"))
+    palette.setColor(QPalette.ColorRole.Text, QColor("#3d2b35"))
+    palette.setColor(QPalette.ColorRole.ButtonText, QColor("#3d2b35"))
+    palette.setColor(QPalette.ColorRole.Button, QColor("#ffe8f1"))
+    palette.setColor(QPalette.ColorRole.ToolTipBase, QColor("#fff6fa"))
+    palette.setColor(QPalette.ColorRole.ToolTipText, QColor("#3d2b35"))
+    palette.setColor(QPalette.ColorRole.PlaceholderText, QColor("#9b4f72"))
+    app.setPalette(palette)
 
 
 def _configure_windows_high_dpi() -> None:
@@ -222,6 +239,7 @@ def main() -> int:
     app = QApplication(sys.argv)
     app.setApplicationName("Sakura Desktop Pet")
     app.setQuitOnLastWindowClosed(False)
+    _force_light_palette(app)
 
     try:
         context = build_initial_app_context(BASE_DIR)

--- a/tests/unit/test_tts.py
+++ b/tests/unit/test_tts.py
@@ -330,6 +330,8 @@ def test_tts_service_probe_starts_local_gptsovits_when_port_is_down(monkeypatch)
 
     monkeypatch.setattr("app.voice.tts.socket.create_connection", fake_create_connection)
     monkeypatch.setattr("app.voice.tts.subprocess.Popen", fake_popen)
+    # TCP 探测成功后还会做 HTTP 探测，这里 mock 掉避免真实网络请求
+    monkeypatch.setattr("app.voice.tts._probe_gpt_sovits_http", lambda *_: True)
 
     assert GPTSoVITSTTSProvider._ensure_service_available(provider, messages.append)
     assert messages == []
@@ -410,6 +412,8 @@ def test_tts_service_waits_past_thirty_seconds_for_slow_gptsovits_start(monkeypa
     monkeypatch.setattr("app.voice.tts.subprocess.Popen", lambda *_args, **_kwargs: FakeProcess())
     monkeypatch.setattr("app.voice.tts.time.monotonic", lambda: elapsed)
     monkeypatch.setattr("app.voice.tts.time.sleep", fake_sleep)
+    # TCP 探测成功后还会做 HTTP 探测，这里 mock 掉避免真实网络请求
+    monkeypatch.setattr("app.voice.tts._probe_gpt_sovits_http", lambda *_: True)
     monkeypatch.setattr(
         "app.voice.tts.debug_log",
         lambda _category, message, data=None: debug_messages.append((message, data)),


### PR DESCRIPTION
## 说明

整合贡献者 @wzvideni 的 PR #44，保留其全部贡献（git author 信息已保留），并修复合入后出现的测试兼容性问题。

Closes #44

## 改动内容

### 来自 @wzvideni 的贡献

**fix: Windows深色主题文字显示白色** (`main.py`)
- 新增 `_force_light_palette()`，强制使用 Fusion 风格 + 亮色 palette
- 解决 Windows 深色模式下系统控件文字与浅色背景冲突导致文字显示白色的问题

**fix: TTS HTTP 就绪探测** (`app/voice/tts.py`)
- 新增 `_probe_gpt_sovits_http()`，在 TCP 端口通后额外探测 HTTP 层是否就绪
- 解决"端口开了但模型仍在加载"时 TTS 请求返回 502 的问题

### 测试修复

PR #44 新增的 HTTP 探测逻辑导致两个现有单元测试失败：
- `test_tts_service_probe_starts_local_gptsovits_when_port_is_down`
- `test_tts_service_waits_past_thirty_seconds_for_slow_gptsovits_start`

原因：`monkeypatch.setattr("app.voice.tts.socket.create_connection", ...)` 修改的是全局 `socket` 模块，`http.client` 内部也会拿到无 `close` 方法的 `FakeConnection`，触发 `AttributeError`。修复方式：在两个测试中额外 mock `_probe_gpt_sovits_http` 直接返回 `True`，隔离 TCP/HTTP 两层探测的测试责任。

## 测试结果

```
257 passed, 3 skipped
```