### PR TITLE
Fix/dev OpenAI compatible tool call fallback

### DIFF
--- a/app/agent/runtime.py
+++ b/app/agent/runtime.py
@@ -108,13 +108,16 @@ class AgentRuntime:
     ) -> ChatReply:
         """最终回复结构不合格时，只重试一次格式修复，避免坏 JSON 进入 UI。"""
         parsed = parse_chat_reply_result(raw_content)
-        if not parsed.needs_retry:
+        retry_reason = parsed.reason if parsed.needs_retry else ""
+        if not parsed.needs_retry and _reply_has_display_translation(parsed.reply):
             return parsed.reply
+        if not retry_reason:
+            retry_reason = "missing_translation"
 
         debug_log(
             "AgentRuntime",
             "最终回复结构异常，准备请求模型修复",
-            {"reason": parsed.reason, "raw_content": raw_content},
+            {"reason": retry_reason, "raw_content": raw_content},
         )
         repair_messages: list[ChatMessage] = [
             *working_messages,
@@ -940,6 +943,15 @@ def _should_emit_progress(metadata: dict[str, Any]) -> bool:
     if not isinstance(tool_names, list):
         return False
     return any(str(name).startswith("windows__") for name in tool_names)
+
+
+def _reply_has_display_translation(reply: ChatReply) -> bool:
+    """最终回复需要中文显示文本，避免兼容模型的纯日语正文漏到中文字幕 UI。"""
+
+    return any(
+        segment.text.strip() and segment.translation.strip()
+        for segment in reply.segments
+    )
 
 
 def _native_tool_call_to_policy_call(

--- a/app/agent/runtime.py
+++ b/app/agent/runtime.py
@@ -250,7 +250,10 @@ class AgentRuntime:
                     tools=tool_defs,
                     tool_choice="auto",
                     temperature=0.8,
-                    structured_response=True,
+                    # Some OpenAI-compatible providers return pseudo tool-call JSON
+                    # in message.content instead of native tool_calls when
+                    # response_format=json_object is combined with tools.
+                    structured_response=not bool(tool_defs),
                 )
             except ApiRequestError as exc:
                 if messages_contain_image(working_messages) and is_vision_unsupported_error(exc):

--- a/app/llm/api_client.py
+++ b/app/llm/api_client.py
@@ -258,6 +258,8 @@ class OpenAICompatibleClient:
 
         content = raw_message.get("content")
         tool_calls = _parse_native_tool_calls(raw_message.get("tool_calls"))
+        if not tool_calls:
+            tool_calls = _parse_pseudo_tool_calls_from_content(content)
         normalized_message = _normalize_assistant_message(raw_message, content, tool_calls)
         debug_log(
             "API",
@@ -633,6 +635,75 @@ def _parse_native_tool_calls(raw_tool_calls: Any) -> list[NativeToolCall]:
             )
         )
     return parsed
+
+
+def _parse_pseudo_tool_calls_from_content(content: Any) -> list[NativeToolCall]:
+    """Parse OpenAI-compatible providers that emit tool calls as JSON text.
+
+    Some providers combine poorly with response_format=json_object and return
+    {"tool_call": "name", "parameters": {...}} in message.content instead of
+    native message.tool_calls. Keep this conservative: only accept top-level
+    JSON objects/lists that clearly describe tool calls.
+    """
+
+    if not isinstance(content, str) or not content.strip():
+        return []
+    try:
+        raw = json.loads(content)
+    except json.JSONDecodeError:
+        return []
+
+    items: list[Any]
+    if isinstance(raw, dict) and isinstance(raw.get("tool_calls"), list):
+        items = raw["tool_calls"]
+    elif isinstance(raw, dict) and isinstance(raw.get("tool_call"), dict):
+        items = [raw["tool_call"]]
+    elif isinstance(raw, dict) and (
+        "tool_call" in raw or "tool" in raw or "name" in raw or "tool_name" in raw
+    ):
+        items = [raw]
+    elif isinstance(raw, list):
+        items = raw
+    else:
+        return []
+
+    parsed: list[NativeToolCall] = []
+    for index, item in enumerate(items):
+        call = _parse_pseudo_tool_call(item, index)
+        if call is not None:
+            parsed.append(call)
+    return parsed
+
+
+def _parse_pseudo_tool_call(item: Any, index: int) -> NativeToolCall | None:
+    if not isinstance(item, dict):
+        return None
+    name = item.get("tool_call") or item.get("tool") or item.get("name") or item.get("tool_name")
+    if not isinstance(name, str) or not name.strip():
+        return None
+    arguments = (
+        item.get("arguments")
+        if "arguments" in item
+        else item.get("parameters", item.get("args", {}))
+    )
+    if isinstance(arguments, str):
+        try:
+            decoded = json.loads(arguments or "{}")
+        except json.JSONDecodeError:
+            decoded = {}
+        arguments = decoded
+    if not isinstance(arguments, dict):
+        arguments = {}
+    arguments_json = json.dumps(arguments, ensure_ascii=False)
+    call_id = item.get("id")
+    if not isinstance(call_id, str) or not call_id.strip():
+        call_id = f"pseudo_tool_call_{index}"
+    return NativeToolCall(
+        id=call_id.strip(),
+        name=name.strip(),
+        arguments=dict(arguments),
+        arguments_json=arguments_json,
+    )
 
 
 def _normalize_assistant_message(

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -301,6 +301,37 @@ class TestAgentRuntimeBasics:
         assert client.complete_with_tools.call_count == 2
         assert result.reply.segments[0].text == "直したよ。"
 
+    def test_final_reply_retries_when_plain_japanese_lacks_translation(self) -> None:
+        client = _dummy_api_client()
+        client.complete_with_tools.side_effect = [
+            MagicMock(
+                content="……開いたよ。\n\n北京の天気は、今日は曇りみたい。",
+                tool_calls=[],
+            ),
+            MagicMock(
+                content=json.dumps(
+                    {
+                        "segments": [
+                            {
+                                "ja": "北京の天気を確認したよ。",
+                                "zh": "我确认了北京天气。",
+                                "tone": "中性",
+                            }
+                        ]
+                    },
+                    ensure_ascii=False,
+                ),
+                tool_calls=[],
+            ),
+        ]
+        runtime = AgentRuntime(client, _dummy_system_prompt())
+
+        result = runtime.handle_user_message([ChatMessage(role="user", content="北京天气")])
+
+        assert client.complete_with_tools.call_count == 2
+        assert result.reply.segments[0].text == "北京の天気を確認したよ。"
+        assert result.reply.segments[0].translation == "我确认了北京天气。"
+
     def test_final_reply_uses_safe_fallback_when_retry_still_invalid(self) -> None:
         client = _dummy_api_client()
         bad_content = '{"segments":[{"ja":"原因是 Mermaid 语法。","zh":"原因是 Mermaid 语法。"}]}'

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -320,6 +320,126 @@ def test_complete_with_tools_can_request_structured_json(monkeypatch) -> None:  
     assert captured["response_format"] == {"type": "json_object"}
 
 
+def test_complete_with_tools_parses_pseudo_tool_call_json_content(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    client = OpenAICompatibleClient(
+        ApiSettings(
+            base_url="https://api.example.com/v1",
+            api_key="key",
+            model="model",
+        )
+    )
+
+    def fake_post(_payload: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": (
+                            '{"tool":"playwright_navigate",'
+                            '"parameters":{"url":"https://example.com"}}'
+                        ),
+                    }
+                }
+            ]
+        }
+
+    monkeypatch.setattr(client, "_post_chat_completions", fake_post)
+
+    turn = client.complete_with_tools(
+        "system",
+        [{"role": "user", "content": "open"}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "playwright_navigate",
+                    "description": "Open",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+    )
+
+    assert turn.tool_calls[0].id == "pseudo_tool_call_0"
+    assert turn.tool_calls[0].name == "playwright_navigate"
+    assert turn.tool_calls[0].arguments == {"url": "https://example.com"}
+    assert turn.message["tool_calls"][0]["function"]["name"] == "playwright_navigate"
+
+
+def test_complete_with_tools_ignores_plain_json_reply_without_tool_call(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    client = OpenAICompatibleClient(
+        ApiSettings(
+            base_url="https://api.example.com/v1",
+            api_key="key",
+            model="model",
+        )
+    )
+
+    monkeypatch.setattr(
+        client,
+        "_post_chat_completions",
+        lambda _payload: {
+            "choices": [{"message": {"role": "assistant", "content": '{"segments":[]}'}}]
+        },
+    )
+
+    turn = client.complete_with_tools(
+        "system",
+        [{"role": "user", "content": "hello"}],
+        structured_response=True,
+    )
+
+    assert turn.tool_calls == []
+    assert "tool_calls" not in turn.message
+
+
+def test_complete_with_tools_parses_nested_pseudo_tool_call(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    client = OpenAICompatibleClient(
+        ApiSettings(
+            base_url="https://api.example.com/v1",
+            api_key="key",
+            model="model",
+        )
+    )
+
+    monkeypatch.setattr(
+        client,
+        "_post_chat_completions",
+        lambda _payload: {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": (
+                            '{"tool_call":{"name":"playwright_navigate",'
+                            '"arguments":{"url":"https://example.com"}}}'
+                        ),
+                    }
+                }
+            ]
+        },
+    )
+
+    turn = client.complete_with_tools(
+        "system",
+        [{"role": "user", "content": "open"}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "playwright_navigate",
+                    "description": "Open",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+    )
+
+    assert turn.tool_calls[0].name == "playwright_navigate"
+    assert turn.tool_calls[0].arguments == {"url": "https://example.com"}
+
+
 def test_segmented_reply_instruction_requests_portrait_field() -> None:
     instruction = _build_segmented_reply_instruction(
         ["中性", "请求"],


### PR DESCRIPTION
## 概要

本 PR 修复 OpenAI 兼容模型在工具调用和最终回复格式上的两个兼容性问题：

- 支持解析模型写在 `message.content` 里的伪工具调用 JSON。
- 避免工具链最终回复直接显示纯日语文本。
- 为上述路径补充单元测试和相关集成测试覆盖。

## 背景

部分 OpenAI 兼容模型在组合使用 `tools` 和结构化 JSON 输出时，并不会稳定返回原生 `tool_calls`，而是可能把工具调用写成普通 JSON 文本，例如：

```json
{"tool":"playwright_navigate","parameters":{"url":"https://example.com"}}
这会导致 Sakura 把工具调用当成普通回复处理，表现为用户要求打开浏览器后没有实际执行浏览器动作。
```
另外，工具调用完成后的最终回复也可能不按 Sakura 协议返回 {segments:[{ja,zh,...}]}，而是直接输出纯日语自然文本。此时 UI 即使处于中文字幕模式，也因为缺少 zh 译文而只能显示日语。

改动
在有工具可用时，不再强制组合 response_format=json_object，降低兼容模型把工具调用写进正文的概率。
为 OpenAI 兼容客户端增加伪工具调用解析兜底，支持：
{"tool":"name","parameters":{...}}
{"tool_call":"name","parameters":{...}}
{"tool_call":{"name":"name","arguments":{...}}}
顶层 tool_calls 数组
最终回复解析后增加中文显示译文检查；如果缺少 zh，会触发一次格式修复请求。
补充测试覆盖：
伪工具调用 JSON 解析
普通 JSON 回复不误判为工具调用
纯日语最终回复自动修复为双语结构化回复
测试
.venv/bin/python -m pytest tests/unit/test_agent_runtime.py tests/unit/test_api_client.py tests/integration/test_agent_core.py::test_browser_navigate_auto_snapshots_and_fast_forwards_lookup_reply tests/integration/test_agent_core.py::test_visible_browser_request_blocks_background_search_and_continues_planning
结果：

64 passed