### PR TITLE
feat: resize pet control panel

### DIFF
--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -27,6 +27,7 @@ from PySide6.QtGui import (
     QMouseEvent,
     QPainter,
     QPixmap,
+    QRegion,
 )
 from PySide6.QtWidgets import (
     QApplication,
@@ -104,6 +105,7 @@ from app.agent.screen_observation import (
 )
 from app.ui.settings_dialog import SettingsDialog
 from app.ui.portrait_controller import (
+    PORTRAIT_BASE_MAX_WIDTH,
     PORTRAIT_SCALE_DEFAULT_PERCENT,
     normalize_portrait_scale_percent,
 )
@@ -171,6 +173,16 @@ REPLY_HISTORY_PREVIOUS_SYMBOL = "▲"
 REPLY_HISTORY_NEXT_SYMBOL = "▼"
 DEFAULT_STAGE_WIDTH = 860
 DEFAULT_STAGE_HEIGHT = 640
+DEFAULT_CONTROL_PANEL_WIDTH = 640
+MIN_CONTROL_PANEL_WIDTH = 420
+MAX_CONTROL_PANEL_WIDTH = 860
+DEFAULT_BUBBLE_HEIGHT = 128
+MIN_BUBBLE_HEIGHT = 96
+MAX_BUBBLE_HEIGHT = 260
+INPUT_BAR_HEIGHT = 52
+CONTROL_PANEL_GAP = 10
+CONTROL_PANEL_BOTTOM_MARGIN = 84
+CONTROL_PANEL_RESIZE_MARGIN = 8
 # 立绘缩放时碰撞箱高度下限：底部 UI 区（气泡 128 + 输入框 52 + 间距 94 = 274px）
 # 加上立绘顶部约 146px 可见区，合计 ~420px。
 MIN_STAGE_HEIGHT = 420
@@ -365,11 +377,23 @@ class PetWindow(QWidget):
         self.pending_history_clear_after_curation = False
         self.drag_anchor: QPoint | None = None
         self.portrait_scale_percent = self._load_portrait_scale_percent()
+        self.control_panel_width = self._load_control_panel_width()
+        self.bubble_height = self._load_bubble_height()
+        self.control_resize_edges: frozenset[str] = frozenset()
+        self.control_resize_start_global: QPoint | None = None
+        self.control_resize_start_width = self.control_panel_width
+        self.control_resize_start_bubble_height = self.bubble_height
+        self.control_resize_start_global_rect: QRect | None = None
+        self.control_resize_dirty = False
         (
             self.subtitle_typing_interval_ms,
             self.reply_segment_pause_ms,
         ) = self._load_subtitle_display_speed()
-        self.stage_size = _stage_size_for_portrait_scale_percent(self.portrait_scale_percent)
+        self.stage_size = _stage_size_for_layout(
+            self.portrait_scale_percent,
+            self.control_panel_width,
+            self.bubble_height,
+        )
         self.pending_tool_action: PendingToolAction | None = None
         self.pending_manual_screen_observation: ScreenObservation | None = None
         self.manual_screenshot_overlay: ManualScreenshotOverlay | None = None
@@ -623,6 +647,7 @@ class PetWindow(QWidget):
             self.label,
             self.portrait_transition_label,
             self.bubble,
+            self.input_bar,
             self.name_label,
             self.speech_label,
         ):
@@ -692,13 +717,14 @@ class PetWindow(QWidget):
             self.label,
             self.portrait_transition_label,
             self.bubble,
+            self.input_bar,
             self.name_label,
             self.speech_label,
         } and isinstance(event, QMouseEvent):
             if event.type() == QEvent.Type.MouseButtonPress:
                 return self._handle_mouse_press(event, watched)
             if event.type() == QEvent.Type.MouseMove:
-                return self._handle_mouse_move(event)
+                return self._handle_mouse_move(event, watched)
             if event.type() == QEvent.Type.MouseButtonRelease:
                 return self._handle_mouse_release(event)
         return super().eventFilter(watched, event)
@@ -785,6 +811,22 @@ class PetWindow(QWidget):
 
     def _handle_mouse_press(self, event: QMouseEvent, source_widget: QWidget | None = None) -> bool:
         if event.button() == Qt.MouseButton.LeftButton:
+            event_position_in_window = getattr(self, "_event_position_in_window", None)
+            resize_edges_at = getattr(self, "_control_resize_edges_at", None)
+            resize_edges = frozenset()
+            if callable(event_position_in_window) and callable(resize_edges_at):
+                position = event_position_in_window(event, source_widget)
+                resize_edges = resize_edges_at(position)
+            if resize_edges:
+                self.control_resize_edges = resize_edges
+                self.control_resize_start_global = event.globalPosition().toPoint()
+                self.control_resize_start_width = self.control_panel_width
+                self.control_resize_start_bubble_height = self.bubble_height
+                self.control_resize_start_global_rect = self._control_group_global_rect()
+                self.control_resize_dirty = False
+                self.drag_anchor = None
+                event.accept()
+                return True
             self.drag_anchor = self._drag_anchor_from_event(event, source_widget)
             event.accept()
             return True
@@ -793,15 +835,30 @@ class PetWindow(QWidget):
             return True
         return False
 
-    def _handle_mouse_move(self, event: QMouseEvent) -> bool:
+    def _handle_mouse_move(self, event: QMouseEvent, source_widget: QWidget | None = None) -> bool:
+        if (
+            getattr(self, "control_resize_edges", frozenset())
+            and getattr(self, "control_resize_start_global", None) is not None
+        ):
+            self._resize_control_panel_from_event(event)
+            event.accept()
+            return True
         if event.buttons() & Qt.MouseButton.LeftButton and self.drag_anchor is not None:
             self.move(event.globalPosition().toPoint() - self.drag_anchor)
             event.accept()
             return True
+        event_position_in_window = getattr(self, "_event_position_in_window", None)
+        update_cursor = getattr(self, "_update_control_resize_cursor", None)
+        if callable(event_position_in_window) and callable(update_cursor):
+            update_cursor(event_position_in_window(event, source_widget))
         return False
 
     def _handle_mouse_release(self, event: QMouseEvent) -> bool:
         if event.button() == Qt.MouseButton.LeftButton:
+            if getattr(self, "control_resize_edges", frozenset()):
+                self._finish_control_resize()
+                event.accept()
+                return True
             self.drag_anchor = None
             event.accept()
             return True
@@ -825,10 +882,133 @@ class PetWindow(QWidget):
             return map_to(self, position)
         return position
 
+    def _event_position_in_window(
+        self,
+        event: QMouseEvent,
+        source_widget: QWidget | None = None,
+    ) -> QPoint:
+        position = event.position().toPoint()
+        if source_widget is None or source_widget is self:
+            return position
+        map_to = getattr(source_widget, "mapTo", None)
+        if callable(map_to):
+            return map_to(self, position)
+        return position
+
+    def _control_group_rect(self) -> QRect | None:
+        bubble = getattr(self, "bubble", None)
+        input_bar = getattr(self, "input_bar", None)
+        if bubble is None or input_bar is None:
+            return None
+        return QRect(bubble.geometry()).united(QRect(input_bar.geometry()))
+
+    def _control_group_global_rect(self) -> QRect | None:
+        rect = self._control_group_rect()
+        if rect is None:
+            return None
+        return QRect(self.pos() + rect.topLeft(), rect.size())
+
+    def _control_resize_edges_at(self, position: QPoint) -> frozenset[str]:
+        rect = self._control_group_rect()
+        if rect is None:
+            return frozenset()
+        hit_rect = QRect(rect).adjusted(
+            -CONTROL_PANEL_RESIZE_MARGIN,
+            -CONTROL_PANEL_RESIZE_MARGIN,
+            CONTROL_PANEL_RESIZE_MARGIN,
+            CONTROL_PANEL_RESIZE_MARGIN,
+        )
+        if not hit_rect.contains(position):
+            return frozenset()
+
+        edges: set[str] = set()
+        if abs(position.x() - rect.left()) <= CONTROL_PANEL_RESIZE_MARGIN:
+            edges.add("left")
+        if abs(position.x() - rect.right()) <= CONTROL_PANEL_RESIZE_MARGIN:
+            edges.add("right")
+        if abs(position.y() - rect.top()) <= CONTROL_PANEL_RESIZE_MARGIN:
+            edges.add("top")
+        if abs(position.y() - rect.bottom()) <= CONTROL_PANEL_RESIZE_MARGIN:
+            edges.add("bottom")
+        return frozenset(edges)
+
+    def _resize_control_panel_from_event(self, event: QMouseEvent) -> None:
+        start_global = self.control_resize_start_global
+        if start_global is None:
+            return
+        delta = event.globalPosition().toPoint() - start_global
+        next_width = self.control_resize_start_width
+        next_height = self.control_resize_start_bubble_height
+        if "left" in self.control_resize_edges:
+            next_width -= delta.x()
+        if "right" in self.control_resize_edges:
+            next_width += delta.x()
+        if "top" in self.control_resize_edges:
+            next_height -= delta.y()
+        if "bottom" in self.control_resize_edges:
+            next_height += delta.y()
+        self._apply_control_panel_size(next_width, next_height, persist=False)
+        self._anchor_resized_control_group(delta)
+        self.control_resize_dirty = True
+
+    def _anchor_resized_control_group(self, delta: QPoint) -> None:
+        start_rect = self.control_resize_start_global_rect
+        current_rect = self._control_group_global_rect()
+        if start_rect is None or current_rect is None:
+            return
+        offset = QPoint(0, 0)
+        if "left" in self.control_resize_edges:
+            offset.setX(start_rect.left() + delta.x() - current_rect.left())
+        if "top" in self.control_resize_edges:
+            offset.setY(start_rect.top() + delta.y() - current_rect.top())
+        if not offset.isNull():
+            self.move(self.pos() + offset)
+
+    def _finish_control_resize(self) -> None:
+        should_persist = self.control_resize_dirty
+        self.control_resize_edges = frozenset()
+        self.control_resize_start_global = None
+        self.control_resize_start_global_rect = None
+        self.control_resize_dirty = False
+        self.unsetCursor()
+        if should_persist:
+            self._save_control_panel_size()
+
+    def _update_control_resize_cursor(self, position: QPoint) -> None:
+        edges = self._control_resize_edges_at(position)
+        if not edges:
+            self.unsetCursor()
+            return
+        if {"left", "top"}.issubset(edges) or {"right", "bottom"}.issubset(edges):
+            self.setCursor(Qt.CursorShape.SizeFDiagCursor)
+            return
+        if {"right", "top"}.issubset(edges) or {"left", "bottom"}.issubset(edges):
+            self.setCursor(Qt.CursorShape.SizeBDiagCursor)
+            return
+        if "left" in edges or "right" in edges:
+            self.setCursor(Qt.CursorShape.SizeHorCursor)
+            return
+        self.setCursor(Qt.CursorShape.SizeVerCursor)
+
     def _schedule_screen_change_relayout(self) -> None:
         QTimer.singleShot(0, self._restore_geometry_after_screen_change)
 
     def _restore_geometry_after_screen_change(self) -> None:
+        if all(
+            hasattr(self, name)
+            for name in (
+                "portrait_scale_percent",
+                "control_panel_width",
+                "bubble_height",
+                "portrait_controller",
+            )
+        ):
+            self.stage_size = _stage_size_for_layout(
+                self.portrait_scale_percent,
+                self.control_panel_width,
+                self.bubble_height,
+            )
+            self.portrait_controller.set_stage_size(self.stage_size)
         self.resize(*self.stage_size)
         self._layout_stage()
         self._schedule_native_topmost_sync()
@@ -1006,19 +1186,18 @@ class PetWindow(QWidget):
             max(0, height - transition_height - 62),
         )
 
-        bubble_width = min(640, width - 96)
-        bubble_height = 128
-        input_height = 52
-        input_gap = 10
+        bubble_width = min(self.control_panel_width, max(MIN_CONTROL_PANEL_WIDTH, width - 32))
+        bubble_height = self.bubble_height
         bubble_x = (width - bubble_width) // 2
-        bubble_y = height - bubble_height - input_height - input_gap - 84
+        bubble_y = height - bubble_height - INPUT_BAR_HEIGHT - CONTROL_PANEL_GAP - CONTROL_PANEL_BOTTOM_MARGIN
         self.bubble.setGeometry(QRect(bubble_x, bubble_y, bubble_width, bubble_height))
         self.bubble.raise_()
 
-        input_y = bubble_y + bubble_height + input_gap
-        self.input_bar.setGeometry(QRect(bubble_x, input_y, bubble_width, input_height))
+        input_y = bubble_y + bubble_height + CONTROL_PANEL_GAP
+        self.input_bar.setGeometry(QRect(bubble_x, input_y, bubble_width, INPUT_BAR_HEIGHT))
         self._update_input_backdrop_geometry()
         self.input_bar.raise_()
+        self._apply_stage_mask()
 
     def _update_input_backdrop_geometry(self) -> None:
         self.input_bar.layout().activate()
@@ -1026,6 +1205,33 @@ class PetWindow(QWidget):
         self.input_backdrop.setGeometry(QRect(input_top_left, self.input_edit.size()))
         self.input_backdrop.raise_()
         self.input_backdrop.update()
+
+    def _apply_stage_mask(self) -> None:
+        label_rect = QRect(self.label.geometry())
+        transition_rect = (
+            QRect(self.portrait_transition_label.geometry())
+            if self.portrait_transition_label.isVisible()
+            else None
+        )
+        bubble_rect = QRect(self.bubble.geometry())
+        input_rect = QRect(self.input_bar.geometry())
+        resize_rect = self._control_group_rect()
+        if resize_rect is not None:
+            resize_rect = QRect(resize_rect).adjusted(
+                -CONTROL_PANEL_RESIZE_MARGIN,
+                -CONTROL_PANEL_RESIZE_MARGIN,
+                CONTROL_PANEL_RESIZE_MARGIN,
+                CONTROL_PANEL_RESIZE_MARGIN,
+            )
+
+        region = QRegion()
+        for rect in (label_rect, transition_rect, bubble_rect, input_rect, resize_rect):
+            if rect is not None and rect.isValid() and not rect.isEmpty():
+                region = region.united(QRegion(rect))
+        if region.isEmpty():
+            self.clearMask()
+            return
+        self.setMask(region)
 
     def _create_tray_icon(self) -> None:
         icon = _build_status_tray_icon(self.theme_settings.primary_color)
@@ -3164,6 +3370,18 @@ class PetWindow(QWidget):
             system_values.get("portrait_scale_percent", PORTRAIT_SCALE_DEFAULT_PERCENT)
         )
 
+    def _load_control_panel_width(self) -> int:
+        system_values = self._load_system_config_values("ui")
+        return _normalize_control_panel_width(
+            system_values.get("control_panel_width", DEFAULT_CONTROL_PANEL_WIDTH)
+        )
+
+    def _load_bubble_height(self) -> int:
+        system_values = self._load_system_config_values("ui")
+        return _normalize_bubble_height(
+            system_values.get("bubble_height", DEFAULT_BUBBLE_HEIGHT)
+        )
+
     def _load_subtitle_display_speed(self) -> tuple[int, int]:
         system_values = self._load_system_config_values("ui")
         return normalize_subtitle_display_speed(
@@ -3263,10 +3481,52 @@ class PetWindow(QWidget):
 
     def _apply_portrait_scale_percent(self, portrait_scale_percent: int) -> None:
         self.portrait_scale_percent = normalize_portrait_scale_percent(portrait_scale_percent)
-        self.stage_size = _stage_size_for_portrait_scale_percent(self.portrait_scale_percent)
+        self.stage_size = _stage_size_for_layout(
+            self.portrait_scale_percent,
+            self.control_panel_width,
+            self.bubble_height,
+        )
         self.portrait_controller.set_stage_size(self.stage_size)
         self.portrait_controller.set_portrait_scale_percent(self.portrait_scale_percent)
         self.portrait_controller.apply_current()
+
+    def _apply_control_panel_size(
+        self,
+        width: object,
+        bubble_height: object,
+        *,
+        persist: bool = True,
+    ) -> None:
+        next_width = _normalize_control_panel_width(width)
+        next_bubble_height = _normalize_bubble_height(bubble_height)
+        changed = (
+            next_width != self.control_panel_width
+            or next_bubble_height != self.bubble_height
+        )
+        self.control_panel_width = next_width
+        self.bubble_height = next_bubble_height
+        self.stage_size = _stage_size_for_layout(
+            self.portrait_scale_percent,
+            self.control_panel_width,
+            self.bubble_height,
+        )
+        self.portrait_controller.set_stage_size(self.stage_size)
+        self.resize(*self.stage_size)
+        self._layout_stage()
+        if changed and persist:
+            self._save_control_panel_size()
+
+    def _save_control_panel_size(self) -> None:
+        try:
+            self._save_system_config_values(
+                "ui",
+                {
+                    "control_panel_width": self.control_panel_width,
+                    "bubble_height": self.bubble_height,
+                },
+            )
+        except OSError as exc:
+            debug_log("PetWindow", "保存操作区尺寸失败", {"error": str(exc)})
 
     def _apply_subtitle_display_speed(
         self,
@@ -3610,6 +3870,42 @@ def _stage_size_for_portrait_scale_percent(portrait_scale_percent: int) -> tuple
         DEFAULT_STAGE_WIDTH,
         max(MIN_STAGE_HEIGHT, round(DEFAULT_STAGE_HEIGHT * scale)),
     )
+
+
+def _stage_size_for_layout(
+    portrait_scale_percent: int,
+    control_panel_width: object = DEFAULT_CONTROL_PANEL_WIDTH,
+    bubble_height: object = DEFAULT_BUBBLE_HEIGHT,
+) -> tuple[int, int]:
+    scale = normalize_portrait_scale_percent(portrait_scale_percent) / 100
+    portrait_width = round(PORTRAIT_BASE_MAX_WIDTH * scale)
+    panel_width = _normalize_control_panel_width(control_panel_width)
+    normalized_bubble_height = _normalize_bubble_height(bubble_height)
+    width = max(
+        portrait_width + 40,
+        panel_width + 96,
+    )
+    height = max(
+        MIN_STAGE_HEIGHT,
+        round(DEFAULT_STAGE_HEIGHT * scale) + normalized_bubble_height - DEFAULT_BUBBLE_HEIGHT,
+    )
+    return width, height
+
+
+def _normalize_control_panel_width(value: object) -> int:
+    try:
+        width = int(str(value).strip())
+    except (TypeError, ValueError):
+        return DEFAULT_CONTROL_PANEL_WIDTH
+    return max(MIN_CONTROL_PANEL_WIDTH, min(MAX_CONTROL_PANEL_WIDTH, width))
+
+
+def _normalize_bubble_height(value: object) -> int:
+    try:
+        height = int(str(value).strip())
+    except (TypeError, ValueError):
+        return DEFAULT_BUBBLE_HEIGHT
+    return max(MIN_BUBBLE_HEIGHT, min(MAX_BUBBLE_HEIGHT, height))
 
 
 def _is_screen_change_event(event: object) -> bool:

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -948,6 +948,54 @@ def test_stage_size_shrinks_with_portrait_scale_below_default_height() -> None:
         assert width == 860
 
 
+def test_control_panel_size_normalization() -> None:
+    from app.ui.pet_window import (
+        DEFAULT_BUBBLE_HEIGHT,
+        DEFAULT_CONTROL_PANEL_WIDTH,
+        MAX_BUBBLE_HEIGHT,
+        MAX_CONTROL_PANEL_WIDTH,
+        MIN_BUBBLE_HEIGHT,
+        MIN_CONTROL_PANEL_WIDTH,
+        _normalize_bubble_height,
+        _normalize_control_panel_width,
+    )
+
+    assert _normalize_control_panel_width("invalid") == DEFAULT_CONTROL_PANEL_WIDTH
+    assert _normalize_control_panel_width(1) == MIN_CONTROL_PANEL_WIDTH
+    assert _normalize_control_panel_width(9999) == MAX_CONTROL_PANEL_WIDTH
+    assert _normalize_control_panel_width(512) == 512
+
+    assert _normalize_bubble_height("invalid") == DEFAULT_BUBBLE_HEIGHT
+    assert _normalize_bubble_height(1) == MIN_BUBBLE_HEIGHT
+    assert _normalize_bubble_height(9999) == MAX_BUBBLE_HEIGHT
+    assert _normalize_bubble_height(180) == 180
+
+
+def test_stage_size_for_layout_wraps_portrait_and_control_panel() -> None:
+    from app.ui.pet_window import (
+        DEFAULT_BUBBLE_HEIGHT,
+        DEFAULT_CONTROL_PANEL_WIDTH,
+        _stage_size_for_layout,
+    )
+
+    default_width, default_height = _stage_size_for_layout(
+        100,
+        DEFAULT_CONTROL_PANEL_WIDTH,
+        DEFAULT_BUBBLE_HEIGHT,
+    )
+    assert default_width == DEFAULT_CONTROL_PANEL_WIDTH + 96
+    assert default_height == 640
+
+    wide_width, _ = _stage_size_for_layout(100, 860, DEFAULT_BUBBLE_HEIGHT)
+    assert wide_width == 956
+
+    portrait_width, _ = _stage_size_for_layout(150, DEFAULT_CONTROL_PANEL_WIDTH, DEFAULT_BUBBLE_HEIGHT)
+    assert portrait_width == 880
+
+    _, tall_height = _stage_size_for_layout(50, DEFAULT_CONTROL_PANEL_WIDTH, 260)
+    assert tall_height == 452
+
+
 def test_pet_window_defaults_subtitle_language_to_chinese() -> None:
     from app.ui.pet_window import PetWindow, SUBTITLE_LANGUAGE_JA, SUBTITLE_LANGUAGE_ZH
 


### PR DESCRIPTION
# feat: 支持调整底部操作区和对话框尺寸

## 📌 PR 描述 (Description)
这个 PR 引入了对主界面底部操作区（控制面板）和气泡对话框的缩放与自定义调整功能。

随着多平台和多场景用户的增多，固定宽高的操作面板可能在不同分辨率的屏幕或不同的桌宠立绘下显得不协调。此功能的加入允许用户根据个人喜好或不同场景，自由调整对话框高度及控制面板的宽度。

## 🚀 核心改动 (Changes)
1. **控制面板与气泡缩放逻辑：**
   - 实现了对底部操作区（包括输入框区域和控制按钮区）宽度的动态缩放支持。
   - 实现了气泡对话框（Bubble）高度的动态调整。
   - 界面布局算法 (`_stage_size_for_layout`) 现已支持基于用户设定的面板宽度和气泡高度动态计算舞台 (Stage) 尺寸。

2. **Qt 遮罩层 (Mask) 动态渲染：**
   - 新增 `_apply_stage_mask` 方法：基于缩放后的组件边界动态合并 `QRegion`，实时生成透明遮罩。这确保了在面板尺寸变化后，桌面的点击穿透依然准确无误，不会出现无法点击或遮挡下层窗口的问题。

3. **设置项持久化：**
   - 新增 `_save_control_panel_size` 与相关的配置加载逻辑。缩放后的宽度和高度数据会自动持久化保存到配置文件 `system_config.yaml` 的 `ui` 区块中，确保重启后设置不丢失。

4. **配套单元测试：**
   - 在 `tests/ui/test_pet_window.py` 补充了针对尺寸标准化 (`_normalize_control_panel_width`, `_normalize_bubble_height`) 以及基于布局动态计算舞台大小 (`_stage_size_for_layout`) 的完善测试用例。


## 🧪 测试说明 (Testing)
- [x] 在配置文件中修改控制面板参数并重启，界面能正确按照设定尺寸渲染。
- [x] 拉伸或调整参数后，鼠标穿透测试正常（透明区域可点击下层窗口，实体组件不可穿透）。
- [x] 所有单元测试均已通过 (`pytest`)。

## 📸 效果截图 (Screenshots)
<img width="1032" height="998" alt="image" src="https://github.com/user-attachments/assets/47479a8a-7328-44a5-92ce-b8aac50c9a08" />
上图为516* 499
<img width="1912" height="840" alt="image" src="https://github.com/user-attachments/assets/6e2ed1b3-605e-4d6e-8a20-13a57ca114d7" />
上图为956* 420
