### PR TITLE
feat: 为输入框和文字气泡加入可调大小功能

### DIFF
--- a/app/ui/control_panel_layout.py
+++ b/app/ui/control_panel_layout.py
@@ -29,6 +29,11 @@ DEFAULT_CONTROL_PANEL_VERTICAL_OFFSET = 0
 MIN_CONTROL_PANEL_VERTICAL_OFFSET = -200
 MAX_CONTROL_PANEL_VERTICAL_OFFSET = 200
 
+# 输入栏相对气泡的额外下移：只能向下（>=0），用于加大输入栏与气泡的间距。
+DEFAULT_INPUT_BAR_OFFSET = 0
+MIN_INPUT_BAR_OFFSET = 0
+MAX_INPUT_BAR_OFFSET = 200
+
 # 布局固定量：输入栏高度、气泡与输入栏间距、控制组距舞台底部的基础留白。
 # 取自重构前 _layout_stage 中的硬编码值，提取为常量便于布局统一引用。
 INPUT_BAR_HEIGHT = 52
@@ -72,4 +77,13 @@ def normalize_control_panel_vertical_offset(value: object) -> int:
         minimum=MIN_CONTROL_PANEL_VERTICAL_OFFSET,
         maximum=MAX_CONTROL_PANEL_VERTICAL_OFFSET,
         default=DEFAULT_CONTROL_PANEL_VERTICAL_OFFSET,
+    )
+
+
+def normalize_input_bar_offset(value: object) -> int:
+    return _clamp_int(
+        value,
+        minimum=MIN_INPUT_BAR_OFFSET,
+        maximum=MAX_INPUT_BAR_OFFSET,
+        default=DEFAULT_INPUT_BAR_OFFSET,
     )

--- a/app/ui/control_panel_layout.py
+++ b/app/ui/control_panel_layout.py
@@ -1,0 +1,75 @@
+"""底部控制组（对话气泡 + 输入栏）的可调布局参数与归一化。
+
+气泡与输入栏在新架构里是各自独立的顶层卡片窗口（AcrylicCardWindow），
+其尺寸/位置由 PetWindow._layout_stage 计算的本地矩形决定。这里集中存放
+三个用户可调参数的取值范围与归一化逻辑：
+
+- control_panel_width：控制组（气泡与输入栏共用）的宽度
+- bubble_height：气泡卡片的高度
+- vertical_offset：控制组整体的上下偏移（正值=向上抬升，远离屏幕底部）
+
+独立成模块是为了让 PetWindow 与 SettingsDialog 都能引用，又不引入二者之间的
+循环导入（PetWindow 已经 import SettingsDialog）。本模块保持零外部依赖。
+"""
+
+from __future__ import annotations
+
+# 控制组宽度（气泡与输入栏共用同一宽度）
+DEFAULT_CONTROL_PANEL_WIDTH = 640
+MIN_CONTROL_PANEL_WIDTH = 420
+MAX_CONTROL_PANEL_WIDTH = 860
+
+# 气泡卡片高度
+DEFAULT_BUBBLE_HEIGHT = 128
+MIN_BUBBLE_HEIGHT = 96
+MAX_BUBBLE_HEIGHT = 260
+
+# 控制组整体上下偏移：正值向上抬升，负值向下沉。0 为原始默认位置。
+DEFAULT_CONTROL_PANEL_VERTICAL_OFFSET = 0
+MIN_CONTROL_PANEL_VERTICAL_OFFSET = -200
+MAX_CONTROL_PANEL_VERTICAL_OFFSET = 200
+
+# 布局固定量：输入栏高度、气泡与输入栏间距、控制组距舞台底部的基础留白。
+# 取自重构前 _layout_stage 中的硬编码值，提取为常量便于布局统一引用。
+INPUT_BAR_HEIGHT = 52
+CONTROL_PANEL_GAP = 10
+CONTROL_PANEL_BOTTOM_MARGIN = 84
+
+
+def _clamp_int(value: object, *, minimum: int, maximum: int, default: int) -> int:
+    """把任意输入归一化为 [minimum, maximum] 内的整数；无法解析时回退默认值。
+
+    兼容配置文件里写成字符串/浮点的情况（如 "640"、640.0）。
+    """
+    try:
+        parsed = int(str(value).strip())
+    except (TypeError, ValueError):
+        return default
+    return max(minimum, min(maximum, parsed))
+
+
+def normalize_control_panel_width(value: object) -> int:
+    return _clamp_int(
+        value,
+        minimum=MIN_CONTROL_PANEL_WIDTH,
+        maximum=MAX_CONTROL_PANEL_WIDTH,
+        default=DEFAULT_CONTROL_PANEL_WIDTH,
+    )
+
+
+def normalize_bubble_height(value: object) -> int:
+    return _clamp_int(
+        value,
+        minimum=MIN_BUBBLE_HEIGHT,
+        maximum=MAX_BUBBLE_HEIGHT,
+        default=DEFAULT_BUBBLE_HEIGHT,
+    )
+
+
+def normalize_control_panel_vertical_offset(value: object) -> int:
+    return _clamp_int(
+        value,
+        minimum=MIN_CONTROL_PANEL_VERTICAL_OFFSET,
+        maximum=MAX_CONTROL_PANEL_VERTICAL_OFFSET,
+        default=DEFAULT_CONTROL_PANEL_VERTICAL_OFFSET,
+    )

--- a/app/ui/input_bar_animator.py
+++ b/app/ui/input_bar_animator.py
@@ -58,6 +58,8 @@ class InputBarAnimator(QObject):
         self._started = False
         # 拖动期间挂起：停轮询并强制隐藏，避免静态模糊背景与移动后的真实桌面对不上而穿帮。
         self._suspended = False
+        # 外部强制常显（如设置对话框打开期间）：优先于 hover/pinned，便于实时调整时输入栏不被收起。
+        self._force_visible = False
         self._anim: QPropertyAnimation | None = None
         self._send_anim: QSequentialAnimationGroup | None = None
 
@@ -77,6 +79,15 @@ class InputBarAnimator(QObject):
     def sync(self) -> None:
         """外部 pinned 状态（如待确认动作出现）变化时，立即重算可见性。"""
         self._sync()
+
+    def set_force_visible(self, value: bool) -> None:
+        """外部强制常显开关（如设置对话框打开期间）：开启立即现身，关闭后按常规可见性重算。"""
+        value = bool(value)
+        if value == self._force_visible:
+            return
+        self._force_visible = value
+        if self._started and not self._suspended:
+            self._sync()
 
     def suspend_for_drag(self) -> None:
         """拖动开始：停轮询并淡出隐藏输入栏，避免静态模糊背景与移动后的真实桌面穿帮。"""
@@ -111,7 +122,7 @@ class InputBarAnimator(QObject):
         self._sync()
 
     def _target_visible(self) -> bool:
-        return self._hover or bool(self._is_pinned())
+        return self._force_visible or self._hover or bool(self._is_pinned())
 
     def _sync(self) -> None:
         if self._suspended:

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -113,11 +113,13 @@ from app.ui.control_panel_layout import (
     DEFAULT_BUBBLE_HEIGHT,
     DEFAULT_CONTROL_PANEL_VERTICAL_OFFSET,
     DEFAULT_CONTROL_PANEL_WIDTH,
+    DEFAULT_INPUT_BAR_OFFSET,
     INPUT_BAR_HEIGHT,
     MIN_CONTROL_PANEL_WIDTH,
     normalize_bubble_height,
     normalize_control_panel_vertical_offset,
     normalize_control_panel_width,
+    normalize_input_bar_offset,
 )
 from app.ui.subtitle_controller import (
     REPLY_SEGMENT_PAUSE_MS,
@@ -391,6 +393,7 @@ class PetWindow(QWidget):
         self.control_panel_width = self._load_control_panel_width()
         self.bubble_height = self._load_bubble_height()
         self.control_panel_vertical_offset = self._load_control_panel_vertical_offset()
+        self.input_bar_offset = self._load_input_bar_offset()
         (
             self.subtitle_typing_interval_ms,
             self.reply_segment_pause_ms,
@@ -399,6 +402,7 @@ class PetWindow(QWidget):
             self.portrait_scale_percent,
             self.control_panel_width,
             self.bubble_height,
+            self.input_bar_offset,
         )
         self.pending_tool_action: PendingToolAction | None = None
         self.pending_manual_screen_observation: ScreenObservation | None = None
@@ -1163,7 +1167,8 @@ class PetWindow(QWidget):
         )
         self._bubble_local_rect = QRect(bubble_x, bubble_y, bubble_width, bubble_height)
 
-        input_y = bubble_y + bubble_height + CONTROL_PANEL_GAP
+        # input_bar_offset 只能为正：在气泡正下方再额外下移，加大与气泡的间距。
+        input_y = bubble_y + bubble_height + CONTROL_PANEL_GAP + self.input_bar_offset
         self._input_local_rect = QRect(bubble_x, input_y, bubble_width, INPUT_BAR_HEIGHT)
         self._reposition_child_windows()
 
@@ -2992,40 +2997,45 @@ class PetWindow(QWidget):
             control_panel_width=self.control_panel_width,
             bubble_height=self.bubble_height,
             control_panel_vertical_offset=self.control_panel_vertical_offset,
+            input_bar_offset=self.input_bar_offset,
             subtitle_typing_interval_ms=self.subtitle_typing_interval_ms,
             reply_segment_pause_ms=self.reply_segment_pause_ms,
             theme_settings=getattr(self, "theme_settings", DEFAULT_THEME_SETTINGS),
             startup_settings=getattr(self, "startup_settings", StartupSettings()),
             bubble_settings=getattr(self, "bubble_settings", BubbleSettings()),
-            on_control_panel_layout_preview=self._preview_control_panel_layout,
+            on_layout_preview=self._preview_layout,
         )
         self.settings_dialog = dialog
         # 始终置顶，避免被桌宠卡片（同为置顶窗口）盖住。
         _mark_dialog_always_on_top(dialog)
-        # 记录打开前的控制组布局，便于取消时回滚实时预览。
-        original_control_panel_layout = (
+        # 记录打开前的立绘缩放与控制组布局，便于取消时回滚实时预览。
+        original_layout = (
+            self.portrait_scale_percent,
             self.control_panel_width,
             self.bubble_height,
             self.control_panel_vertical_offset,
+            self.input_bar_offset,
         )
-        # 设置期间保持气泡常显并停掉自动隐藏倒计时，方便实时观察调整效果。
+        # 设置期间保持气泡与输入栏常显并停掉自动隐藏，方便实时观察调整效果。
         bubble_auto_hide = getattr(self, "bubble_auto_hide", None)
         if bubble_auto_hide is not None:
             bubble_auto_hide.notify_speaking()
+        input_bar_animator = getattr(self, "input_bar_animator", None)
+        if input_bar_animator is not None:
+            input_bar_animator.set_force_visible(True)
         try:
             dialog_result = dialog.exec()
         finally:
             if getattr(self, "settings_dialog", None) is dialog:
                 self.settings_dialog = None
-            # 关闭设置后恢复气泡自动隐藏计时（开关关闭时控制器空转）。
+            # 关闭设置后恢复气泡自动隐藏计时与输入栏常规显隐。
             if bubble_auto_hide is not None:
                 bubble_auto_hide.notify_settled()
+            if input_bar_animator is not None:
+                input_bar_animator.set_force_visible(False)
         if dialog_result != QDialog.DialogCode.Accepted:
-            # 取消/关闭：回滚到打开前的布局，撤销实时预览的改动。
-            self._apply_control_panel_layout(
-                *original_control_panel_layout,
-                persist=False,
-            )
+            # 取消/关闭：回滚到打开前的立绘与控制组布局，撤销实时预览的改动。
+            self._preview_layout(*original_layout)
             return
         result_subtitle_typing_interval_ms = getattr(
             dialog,
@@ -3063,6 +3073,9 @@ class PetWindow(QWidget):
             dialog,
             "result_control_panel_vertical_offset",
             self.control_panel_vertical_offset,
+        )
+        result_input_bar_offset = getattr(
+            dialog, "result_input_bar_offset", self.input_bar_offset
         )
         if (
             dialog.result_api_settings is None
@@ -3150,6 +3163,7 @@ class PetWindow(QWidget):
             result_control_panel_width,
             result_bubble_height,
             result_control_panel_vertical_offset,
+            result_input_bar_offset,
         )
         self._apply_subtitle_display_speed(
             result_subtitle_typing_interval_ms,
@@ -3503,6 +3517,12 @@ class PetWindow(QWidget):
             )
         )
 
+    def _load_input_bar_offset(self) -> int:
+        system_values = self._load_system_config_values("ui")
+        return normalize_input_bar_offset(
+            system_values.get("input_bar_offset", DEFAULT_INPUT_BAR_OFFSET)
+        )
+
     def _load_subtitle_display_speed(self) -> tuple[int, int]:
         system_values = self._load_system_config_values("ui")
         return normalize_subtitle_display_speed(
@@ -3618,6 +3638,7 @@ class PetWindow(QWidget):
             self.portrait_scale_percent,
             self.control_panel_width,
             self.bubble_height,
+            self.input_bar_offset,
         )
         self.portrait_controller.set_stage_size(self.stage_size)
         self.portrait_controller.set_portrait_scale_percent(self.portrait_scale_percent)
@@ -3628,25 +3649,30 @@ class PetWindow(QWidget):
         control_panel_width: object,
         bubble_height: object,
         vertical_offset: object,
+        input_bar_offset: object,
         *,
         persist: bool = True,
     ) -> None:
-        """应用控制组宽度/气泡高度/上下偏移：归一化 → 更新状态 → 重算舞台并重新布局，可选持久化。"""
+        """应用控制组宽度/气泡高度/上下偏移/输入栏下移：归一化 → 更新状态 → 重算舞台并重新布局，可选持久化。"""
         next_width = normalize_control_panel_width(control_panel_width)
         next_bubble_height = normalize_bubble_height(bubble_height)
         next_offset = normalize_control_panel_vertical_offset(vertical_offset)
+        next_input_offset = normalize_input_bar_offset(input_bar_offset)
         changed = (
             next_width != self.control_panel_width
             or next_bubble_height != self.bubble_height
             or next_offset != self.control_panel_vertical_offset
+            or next_input_offset != self.input_bar_offset
         )
         self.control_panel_width = next_width
         self.bubble_height = next_bubble_height
         self.control_panel_vertical_offset = next_offset
+        self.input_bar_offset = next_input_offset
         self.stage_size = _stage_size_for_layout(
             self.portrait_scale_percent,
             self.control_panel_width,
             self.bubble_height,
+            self.input_bar_offset,
         )
         self.portrait_controller.set_stage_size(self.stage_size)
         self.resize(*self.stage_size)
@@ -3662,22 +3688,27 @@ class PetWindow(QWidget):
                     "control_panel_width": self.control_panel_width,
                     "bubble_height": self.bubble_height,
                     "control_panel_vertical_offset": self.control_panel_vertical_offset,
+                    "input_bar_offset": self.input_bar_offset,
                 },
             )
         except OSError as exc:
             debug_log("PetWindow", "保存控制组布局失败", {"error": str(exc)})
 
-    def _preview_control_panel_layout(
+    def _preview_layout(
         self,
+        portrait_scale_percent: object,
         control_panel_width: object,
         bubble_height: object,
         vertical_offset: object,
+        input_bar_offset: object,
     ) -> None:
-        """设置对话框滑块拖动时的实时预览：立即应用到界面但不持久化。"""
+        """设置对话框滑块拖动时的实时预览：立绘缩放 + 控制组布局立即应用到界面但不持久化。"""
+        self._apply_portrait_scale_percent(normalize_portrait_scale_percent(portrait_scale_percent))
         self._apply_control_panel_layout(
             control_panel_width,
             bubble_height,
             vertical_offset,
+            input_bar_offset,
             persist=False,
         )
 
@@ -4060,19 +4091,24 @@ def _stage_size_for_layout(
     portrait_scale_percent: int,
     control_panel_width: object = DEFAULT_CONTROL_PANEL_WIDTH,
     bubble_height: object = DEFAULT_BUBBLE_HEIGHT,
+    input_bar_offset: object = DEFAULT_INPUT_BAR_OFFSET,
 ) -> tuple[int, int]:
-    """按立绘缩放、控制组宽度、气泡高度计算舞台（主窗口）尺寸。
+    """按立绘缩放、控制组宽度、气泡高度、输入栏下移计算舞台（主窗口）尺寸。
 
     宽度：以默认舞台宽度（860）保底；控制组加宽时随之扩展，保证气泡水平居中不越界。
-    高度：沿用按立绘缩放的高度，并叠加气泡相对默认高度的增量，使气泡变高时舞台同步增高。
+    高度：沿用按立绘缩放的高度，叠加气泡相对默认高度的增量，并预留输入栏下移占用，使其不越出底部。
     """
     scale = normalize_portrait_scale_percent(portrait_scale_percent) / 100
     panel_width = normalize_control_panel_width(control_panel_width)
     normalized_bubble_height = normalize_bubble_height(bubble_height)
+    normalized_input_offset = normalize_input_bar_offset(input_bar_offset)
     width = max(DEFAULT_STAGE_WIDTH, panel_width + 96)
     height = max(
         MIN_STAGE_HEIGHT,
-        round(DEFAULT_STAGE_HEIGHT * scale) + normalized_bubble_height - DEFAULT_BUBBLE_HEIGHT,
+        round(DEFAULT_STAGE_HEIGHT * scale)
+        + normalized_bubble_height
+        - DEFAULT_BUBBLE_HEIGHT
+        + normalized_input_offset,
     )
     return width, height
 

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -107,6 +107,18 @@ from app.ui.portrait_controller import (
     PORTRAIT_SCALE_DEFAULT_PERCENT,
     normalize_portrait_scale_percent,
 )
+from app.ui.control_panel_layout import (
+    CONTROL_PANEL_BOTTOM_MARGIN,
+    CONTROL_PANEL_GAP,
+    DEFAULT_BUBBLE_HEIGHT,
+    DEFAULT_CONTROL_PANEL_VERTICAL_OFFSET,
+    DEFAULT_CONTROL_PANEL_WIDTH,
+    INPUT_BAR_HEIGHT,
+    MIN_CONTROL_PANEL_WIDTH,
+    normalize_bubble_height,
+    normalize_control_panel_vertical_offset,
+    normalize_control_panel_width,
+)
 from app.ui.subtitle_controller import (
     REPLY_SEGMENT_PAUSE_MS,
     SPEECH_TYPING_INTERVAL_MS,
@@ -376,11 +388,18 @@ class PetWindow(QWidget):
         # 是否正在拖动窗口：首次 move 置位，用于拖动时收起输入栏、区分单击与拖动（单击桌宠唤回气泡）。
         self._dragging = False
         self.portrait_scale_percent = self._load_portrait_scale_percent()
+        self.control_panel_width = self._load_control_panel_width()
+        self.bubble_height = self._load_bubble_height()
+        self.control_panel_vertical_offset = self._load_control_panel_vertical_offset()
         (
             self.subtitle_typing_interval_ms,
             self.reply_segment_pause_ms,
         ) = self._load_subtitle_display_speed()
-        self.stage_size = _stage_size_for_portrait_scale_percent(self.portrait_scale_percent)
+        self.stage_size = _stage_size_for_layout(
+            self.portrait_scale_percent,
+            self.control_panel_width,
+            self.bubble_height,
+        )
         self.pending_tool_action: PendingToolAction | None = None
         self.pending_manual_screen_observation: ScreenObservation | None = None
         self.manual_screenshot_overlay: ManualScreenshotOverlay | None = None
@@ -1130,16 +1149,22 @@ class PetWindow(QWidget):
             max(0, height - transition_height - 62),
         )
 
-        bubble_width = min(640, width - 96)
-        bubble_height = 128
-        input_height = 52
-        input_gap = 10
+        bubble_width = min(self.control_panel_width, max(MIN_CONTROL_PANEL_WIDTH, width - 32))
+        bubble_height = self.bubble_height
         bubble_x = (width - bubble_width) // 2
-        bubble_y = height - bubble_height - input_height - input_gap - 84
+        # vertical_offset 正值向上抬升整组（减小 y），负值向下沉。
+        bubble_y = (
+            height
+            - bubble_height
+            - INPUT_BAR_HEIGHT
+            - CONTROL_PANEL_GAP
+            - CONTROL_PANEL_BOTTOM_MARGIN
+            - self.control_panel_vertical_offset
+        )
         self._bubble_local_rect = QRect(bubble_x, bubble_y, bubble_width, bubble_height)
 
-        input_y = bubble_y + bubble_height + input_gap
-        self._input_local_rect = QRect(bubble_x, input_y, bubble_width, input_height)
+        input_y = bubble_y + bubble_height + CONTROL_PANEL_GAP
+        self._input_local_rect = QRect(bubble_x, input_y, bubble_width, INPUT_BAR_HEIGHT)
         self._reposition_child_windows()
 
     def _reposition_child_windows(self) -> None:
@@ -2964,21 +2989,43 @@ class PetWindow(QWidget):
             getattr(self.plugin_manager, "settings_panels", []),
             parent=self,
             portrait_scale_percent=self.portrait_scale_percent,
+            control_panel_width=self.control_panel_width,
+            bubble_height=self.bubble_height,
+            control_panel_vertical_offset=self.control_panel_vertical_offset,
             subtitle_typing_interval_ms=self.subtitle_typing_interval_ms,
             reply_segment_pause_ms=self.reply_segment_pause_ms,
             theme_settings=getattr(self, "theme_settings", DEFAULT_THEME_SETTINGS),
             startup_settings=getattr(self, "startup_settings", StartupSettings()),
             bubble_settings=getattr(self, "bubble_settings", BubbleSettings()),
+            on_control_panel_layout_preview=self._preview_control_panel_layout,
         )
         self.settings_dialog = dialog
         # 始终置顶，避免被桌宠卡片（同为置顶窗口）盖住。
         _mark_dialog_always_on_top(dialog)
+        # 记录打开前的控制组布局，便于取消时回滚实时预览。
+        original_control_panel_layout = (
+            self.control_panel_width,
+            self.bubble_height,
+            self.control_panel_vertical_offset,
+        )
+        # 设置期间保持气泡常显并停掉自动隐藏倒计时，方便实时观察调整效果。
+        bubble_auto_hide = getattr(self, "bubble_auto_hide", None)
+        if bubble_auto_hide is not None:
+            bubble_auto_hide.notify_speaking()
         try:
             dialog_result = dialog.exec()
         finally:
             if getattr(self, "settings_dialog", None) is dialog:
                 self.settings_dialog = None
+            # 关闭设置后恢复气泡自动隐藏计时（开关关闭时控制器空转）。
+            if bubble_auto_hide is not None:
+                bubble_auto_hide.notify_settled()
         if dialog_result != QDialog.DialogCode.Accepted:
+            # 取消/关闭：回滚到打开前的布局，撤销实时预览的改动。
+            self._apply_control_panel_layout(
+                *original_control_panel_layout,
+                persist=False,
+            )
             return
         result_subtitle_typing_interval_ms = getattr(
             dialog,
@@ -3005,6 +3052,17 @@ class PetWindow(QWidget):
             dialog,
             "result_bubble_settings",
             getattr(self, "bubble_settings", BubbleSettings()),
+        )
+        result_control_panel_width = getattr(
+            dialog, "result_control_panel_width", self.control_panel_width
+        )
+        result_bubble_height = getattr(
+            dialog, "result_bubble_height", self.bubble_height
+        )
+        result_control_panel_vertical_offset = getattr(
+            dialog,
+            "result_control_panel_vertical_offset",
+            self.control_panel_vertical_offset,
         )
         if (
             dialog.result_api_settings is None
@@ -3088,6 +3146,11 @@ class PetWindow(QWidget):
             self.api_client.update_settings(dialog.result_api_settings)
             self.memory_store.reload_api_settings(dialog.result_api_settings, wait=False)
         self._apply_portrait_scale_percent(dialog.result_portrait_scale_percent)
+        self._apply_control_panel_layout(
+            result_control_panel_width,
+            result_bubble_height,
+            result_control_panel_vertical_offset,
+        )
         self._apply_subtitle_display_speed(
             result_subtitle_typing_interval_ms,
             result_reply_segment_pause_ms,
@@ -3419,6 +3482,27 @@ class PetWindow(QWidget):
             system_values.get("portrait_scale_percent", PORTRAIT_SCALE_DEFAULT_PERCENT)
         )
 
+    def _load_control_panel_width(self) -> int:
+        system_values = self._load_system_config_values("ui")
+        return normalize_control_panel_width(
+            system_values.get("control_panel_width", DEFAULT_CONTROL_PANEL_WIDTH)
+        )
+
+    def _load_bubble_height(self) -> int:
+        system_values = self._load_system_config_values("ui")
+        return normalize_bubble_height(
+            system_values.get("bubble_height", DEFAULT_BUBBLE_HEIGHT)
+        )
+
+    def _load_control_panel_vertical_offset(self) -> int:
+        system_values = self._load_system_config_values("ui")
+        return normalize_control_panel_vertical_offset(
+            system_values.get(
+                "control_panel_vertical_offset",
+                DEFAULT_CONTROL_PANEL_VERTICAL_OFFSET,
+            )
+        )
+
     def _load_subtitle_display_speed(self) -> tuple[int, int]:
         system_values = self._load_system_config_values("ui")
         return normalize_subtitle_display_speed(
@@ -3530,10 +3614,72 @@ class PetWindow(QWidget):
 
     def _apply_portrait_scale_percent(self, portrait_scale_percent: int) -> None:
         self.portrait_scale_percent = normalize_portrait_scale_percent(portrait_scale_percent)
-        self.stage_size = _stage_size_for_portrait_scale_percent(self.portrait_scale_percent)
+        self.stage_size = _stage_size_for_layout(
+            self.portrait_scale_percent,
+            self.control_panel_width,
+            self.bubble_height,
+        )
         self.portrait_controller.set_stage_size(self.stage_size)
         self.portrait_controller.set_portrait_scale_percent(self.portrait_scale_percent)
         self.portrait_controller.apply_current()
+
+    def _apply_control_panel_layout(
+        self,
+        control_panel_width: object,
+        bubble_height: object,
+        vertical_offset: object,
+        *,
+        persist: bool = True,
+    ) -> None:
+        """应用控制组宽度/气泡高度/上下偏移：归一化 → 更新状态 → 重算舞台并重新布局，可选持久化。"""
+        next_width = normalize_control_panel_width(control_panel_width)
+        next_bubble_height = normalize_bubble_height(bubble_height)
+        next_offset = normalize_control_panel_vertical_offset(vertical_offset)
+        changed = (
+            next_width != self.control_panel_width
+            or next_bubble_height != self.bubble_height
+            or next_offset != self.control_panel_vertical_offset
+        )
+        self.control_panel_width = next_width
+        self.bubble_height = next_bubble_height
+        self.control_panel_vertical_offset = next_offset
+        self.stage_size = _stage_size_for_layout(
+            self.portrait_scale_percent,
+            self.control_panel_width,
+            self.bubble_height,
+        )
+        self.portrait_controller.set_stage_size(self.stage_size)
+        self.resize(*self.stage_size)
+        self._layout_stage()
+        if changed and persist:
+            self._save_control_panel_layout()
+
+    def _save_control_panel_layout(self) -> None:
+        try:
+            self._save_system_config_values(
+                "ui",
+                {
+                    "control_panel_width": self.control_panel_width,
+                    "bubble_height": self.bubble_height,
+                    "control_panel_vertical_offset": self.control_panel_vertical_offset,
+                },
+            )
+        except OSError as exc:
+            debug_log("PetWindow", "保存控制组布局失败", {"error": str(exc)})
+
+    def _preview_control_panel_layout(
+        self,
+        control_panel_width: object,
+        bubble_height: object,
+        vertical_offset: object,
+    ) -> None:
+        """设置对话框滑块拖动时的实时预览：立即应用到界面但不持久化。"""
+        self._apply_control_panel_layout(
+            control_panel_width,
+            bubble_height,
+            vertical_offset,
+            persist=False,
+        )
 
     def _apply_subtitle_display_speed(
         self,
@@ -3910,12 +4056,30 @@ def _parse_bool(value: Any, default: bool = False) -> bool:
     return default
 
 
-def _stage_size_for_portrait_scale_percent(portrait_scale_percent: int) -> tuple[int, int]:
+def _stage_size_for_layout(
+    portrait_scale_percent: int,
+    control_panel_width: object = DEFAULT_CONTROL_PANEL_WIDTH,
+    bubble_height: object = DEFAULT_BUBBLE_HEIGHT,
+) -> tuple[int, int]:
+    """按立绘缩放、控制组宽度、气泡高度计算舞台（主窗口）尺寸。
+
+    宽度：以默认舞台宽度（860）保底；控制组加宽时随之扩展，保证气泡水平居中不越界。
+    高度：沿用按立绘缩放的高度，并叠加气泡相对默认高度的增量，使气泡变高时舞台同步增高。
+    """
     scale = normalize_portrait_scale_percent(portrait_scale_percent) / 100
-    return (
-        DEFAULT_STAGE_WIDTH,
-        max(MIN_STAGE_HEIGHT, round(DEFAULT_STAGE_HEIGHT * scale)),
+    panel_width = normalize_control_panel_width(control_panel_width)
+    normalized_bubble_height = normalize_bubble_height(bubble_height)
+    width = max(DEFAULT_STAGE_WIDTH, panel_width + 96)
+    height = max(
+        MIN_STAGE_HEIGHT,
+        round(DEFAULT_STAGE_HEIGHT * scale) + normalized_bubble_height - DEFAULT_BUBBLE_HEIGHT,
     )
+    return width, height
+
+
+def _stage_size_for_portrait_scale_percent(portrait_scale_percent: int) -> tuple[int, int]:
+    """兼容旧调用：按默认控制组宽度与气泡高度计算舞台尺寸。"""
+    return _stage_size_for_layout(portrait_scale_percent)
 
 
 def _is_screen_change_event(event: object) -> bool:

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -88,15 +88,19 @@ from app.ui.control_panel_layout import (
     DEFAULT_BUBBLE_HEIGHT,
     DEFAULT_CONTROL_PANEL_VERTICAL_OFFSET,
     DEFAULT_CONTROL_PANEL_WIDTH,
+    DEFAULT_INPUT_BAR_OFFSET,
     MAX_BUBBLE_HEIGHT,
     MAX_CONTROL_PANEL_VERTICAL_OFFSET,
     MAX_CONTROL_PANEL_WIDTH,
+    MAX_INPUT_BAR_OFFSET,
     MIN_BUBBLE_HEIGHT,
     MIN_CONTROL_PANEL_VERTICAL_OFFSET,
     MIN_CONTROL_PANEL_WIDTH,
+    MIN_INPUT_BAR_OFFSET,
     normalize_bubble_height,
     normalize_control_panel_vertical_offset,
     normalize_control_panel_width,
+    normalize_input_bar_offset,
 )
 from app.ui.subtitle_controller import (
     REPLY_SEGMENT_PAUSE_MAX_MS,
@@ -497,12 +501,13 @@ class SettingsDialog(QDialog):
         control_panel_width: int = DEFAULT_CONTROL_PANEL_WIDTH,
         bubble_height: int = DEFAULT_BUBBLE_HEIGHT,
         control_panel_vertical_offset: int = DEFAULT_CONTROL_PANEL_VERTICAL_OFFSET,
+        input_bar_offset: int = DEFAULT_INPUT_BAR_OFFSET,
         subtitle_typing_interval_ms: int = SPEECH_TYPING_INTERVAL_MS,
         reply_segment_pause_ms: int = REPLY_SEGMENT_PAUSE_MS,
         theme_settings: ThemeSettings | None = None,
         startup_settings: StartupSettings | None = None,
         bubble_settings: BubbleSettings | None = None,
-        on_control_panel_layout_preview: Callable[[int, int, int], None] | None = None,
+        on_layout_preview: Callable[[int, int, int, int, int], None] | None = None,
     ) -> None:
         super().__init__(parent)
         self.base_dir = base_dir
@@ -530,8 +535,9 @@ class SettingsDialog(QDialog):
         self.control_panel_vertical_offset = normalize_control_panel_vertical_offset(
             control_panel_vertical_offset
         )
-        # 控制组三项滑块拖动时的实时预览回调（由宿主窗口注入，不持久化）。
-        self._on_control_panel_layout_preview = on_control_panel_layout_preview
+        self.input_bar_offset = normalize_input_bar_offset(input_bar_offset)
+        # 立绘/控制组滑块拖动时的实时预览回调（由宿主窗口注入，不持久化）。
+        self._on_layout_preview = on_layout_preview
         (
             self.subtitle_typing_interval_ms,
             self.reply_segment_pause_ms,
@@ -553,6 +559,7 @@ class SettingsDialog(QDialog):
         self.result_control_panel_width: int | None = None
         self.result_bubble_height: int | None = None
         self.result_control_panel_vertical_offset: int | None = None
+        self.result_input_bar_offset: int | None = None
         self.result_subtitle_typing_interval_ms: int | None = None
         self.result_reply_segment_pause_ms: int | None = None
         self.result_proactive_care_settings: ProactiveCareSettings | None = None
@@ -723,6 +730,7 @@ class SettingsDialog(QDialog):
         form_layout.addRow("对话框宽度", self._build_control_panel_width_control(tab))
         form_layout.addRow("气泡高度", self._build_bubble_height_control(tab))
         form_layout.addRow("气泡上下位置", self._build_control_panel_offset_control(tab))
+        form_layout.addRow("输入框下移", self._build_input_bar_offset_control(tab))
         form_layout.addRow("角色包", self._build_character_archive_controls(tab))
         tab.setLayout(form_layout)
         self._sync_character_archive_controls()
@@ -860,6 +868,8 @@ class SettingsDialog(QDialog):
 
         self.portrait_scale_slider.valueChanged.connect(self.portrait_scale_spin.setValue)
         self.portrait_scale_spin.valueChanged.connect(self.portrait_scale_slider.setValue)
+        # 立绘缩放也接入实时预览。
+        self.portrait_scale_spin.valueChanged.connect(self._emit_layout_preview)
 
         layout = QHBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
@@ -898,8 +908,8 @@ class SettingsDialog(QDialog):
 
         slider.valueChanged.connect(spin.setValue)
         spin.valueChanged.connect(slider.setValue)
-        # 拖动时实时回调宿主窗口预览（_build_range_control 仅被控制组三项滑块复用）。
-        spin.valueChanged.connect(self._emit_control_panel_layout_preview)
+        # 拖动时实时回调宿主窗口预览（_build_range_control 被控制组各项滑块复用）。
+        spin.valueChanged.connect(self._emit_layout_preview)
 
         setattr(self, slider_attr, slider)
         setattr(self, spin_attr, spin)
@@ -945,6 +955,19 @@ class SettingsDialog(QDialog):
             minimum=MIN_CONTROL_PANEL_VERTICAL_OFFSET,
             maximum=MAX_CONTROL_PANEL_VERTICAL_OFFSET,
             value=self.control_panel_vertical_offset,
+            single_step=10,
+            suffix=" px",
+        )
+
+    def _build_input_bar_offset_control(self, parent: QWidget) -> QWidget:
+        # 输入栏相对气泡的额外下移：只能往下（>=0）。
+        return self._build_range_control(
+            parent,
+            slider_attr="input_bar_offset_slider",
+            spin_attr="input_bar_offset_spin",
+            minimum=MIN_INPUT_BAR_OFFSET,
+            maximum=MAX_INPUT_BAR_OFFSET,
+            value=self.input_bar_offset,
             single_step=10,
             suffix=" px",
         )
@@ -2252,6 +2275,7 @@ class SettingsDialog(QDialog):
             "control_panel_width": self._selected_control_panel_width(),
             "bubble_height": self._selected_bubble_height(),
             "control_panel_vertical_offset": self._selected_control_panel_vertical_offset(),
+            "input_bar_offset": self._selected_input_bar_offset(),
             "subtitle_typing_interval_ms": subtitle_typing_interval_ms,
             "reply_segment_pause_ms": reply_segment_pause_ms,
             "theme_settings": theme_settings,
@@ -2294,6 +2318,7 @@ class SettingsDialog(QDialog):
         control_panel_width = values["control_panel_width"]
         bubble_height = values["bubble_height"]
         control_panel_vertical_offset = values["control_panel_vertical_offset"]
+        input_bar_offset = values["input_bar_offset"]
         subtitle_typing_interval_ms = values["subtitle_typing_interval_ms"]
         reply_segment_pause_ms = values["reply_segment_pause_ms"]
         theme_settings = values["theme_settings"]
@@ -2350,6 +2375,9 @@ class SettingsDialog(QDialog):
             control_panel_vertical_offset
             if isinstance(control_panel_vertical_offset, int)
             else self.control_panel_vertical_offset
+        )
+        self.result_input_bar_offset = (
+            input_bar_offset if isinstance(input_bar_offset, int) else self.input_bar_offset
         )
         self.result_subtitle_typing_interval_ms = subtitle_typing_interval_ms
         self.result_reply_segment_pause_ms = reply_segment_pause_ms
@@ -3043,15 +3071,22 @@ class SettingsDialog(QDialog):
             )
         return self.control_panel_vertical_offset
 
-    def _emit_control_panel_layout_preview(self, *_args) -> None:  # type: ignore[no-untyped-def]
-        """三个控制组滑块变化时，实时把当前取值回调给宿主窗口预览（不持久化）。"""
-        callback = getattr(self, "_on_control_panel_layout_preview", None)
+    def _selected_input_bar_offset(self) -> int:
+        if hasattr(self, "input_bar_offset_spin"):
+            return normalize_input_bar_offset(self.input_bar_offset_spin.value())
+        return self.input_bar_offset
+
+    def _emit_layout_preview(self, *_args) -> None:  # type: ignore[no-untyped-def]
+        """立绘/控制组滑块变化时，实时把当前取值回调给宿主窗口预览（不持久化）。"""
+        callback = getattr(self, "_on_layout_preview", None)
         if callback is None:
             return
         callback(
+            self._selected_portrait_scale_percent(),
             self._selected_control_panel_width(),
             self._selected_bubble_height(),
             self._selected_control_panel_vertical_offset(),
+            self._selected_input_bar_offset(),
         )
 
     def _refresh_character_combo(self, selected_character_id: str | None = None) -> None:

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -4,7 +4,7 @@ import base64
 import mimetypes
 from datetime import datetime
 from pathlib import Path
-from typing import Literal
+from typing import Callable, Literal
 from urllib.parse import urlparse
 
 from PySide6.QtCore import QObject, QStringListModel, Qt, QThread, QTimer, Signal, Slot
@@ -83,6 +83,20 @@ from app.ui.portrait_controller import (
     PORTRAIT_SCALE_MAX_PERCENT,
     PORTRAIT_SCALE_MIN_PERCENT,
     normalize_portrait_scale_percent,
+)
+from app.ui.control_panel_layout import (
+    DEFAULT_BUBBLE_HEIGHT,
+    DEFAULT_CONTROL_PANEL_VERTICAL_OFFSET,
+    DEFAULT_CONTROL_PANEL_WIDTH,
+    MAX_BUBBLE_HEIGHT,
+    MAX_CONTROL_PANEL_VERTICAL_OFFSET,
+    MAX_CONTROL_PANEL_WIDTH,
+    MIN_BUBBLE_HEIGHT,
+    MIN_CONTROL_PANEL_VERTICAL_OFFSET,
+    MIN_CONTROL_PANEL_WIDTH,
+    normalize_bubble_height,
+    normalize_control_panel_vertical_offset,
+    normalize_control_panel_width,
 )
 from app.ui.subtitle_controller import (
     REPLY_SEGMENT_PAUSE_MAX_MS,
@@ -480,11 +494,15 @@ class SettingsDialog(QDialog):
         settings_panel_contributions: list[SettingsPanelContribution] | None = None,
         parent=None,  # type: ignore[no-untyped-def]
         portrait_scale_percent: int = PORTRAIT_SCALE_DEFAULT_PERCENT,
+        control_panel_width: int = DEFAULT_CONTROL_PANEL_WIDTH,
+        bubble_height: int = DEFAULT_BUBBLE_HEIGHT,
+        control_panel_vertical_offset: int = DEFAULT_CONTROL_PANEL_VERTICAL_OFFSET,
         subtitle_typing_interval_ms: int = SPEECH_TYPING_INTERVAL_MS,
         reply_segment_pause_ms: int = REPLY_SEGMENT_PAUSE_MS,
         theme_settings: ThemeSettings | None = None,
         startup_settings: StartupSettings | None = None,
         bubble_settings: BubbleSettings | None = None,
+        on_control_panel_layout_preview: Callable[[int, int, int], None] | None = None,
     ) -> None:
         super().__init__(parent)
         self.base_dir = base_dir
@@ -507,6 +525,13 @@ class SettingsDialog(QDialog):
         self.character_registry = character_registry
         self.current_character = current_character
         self.portrait_scale_percent = normalize_portrait_scale_percent(portrait_scale_percent)
+        self.control_panel_width = normalize_control_panel_width(control_panel_width)
+        self.bubble_height = normalize_bubble_height(bubble_height)
+        self.control_panel_vertical_offset = normalize_control_panel_vertical_offset(
+            control_panel_vertical_offset
+        )
+        # 控制组三项滑块拖动时的实时预览回调（由宿主窗口注入，不持久化）。
+        self._on_control_panel_layout_preview = on_control_panel_layout_preview
         (
             self.subtitle_typing_interval_ms,
             self.reply_segment_pause_ms,
@@ -525,6 +550,9 @@ class SettingsDialog(QDialog):
         self.result_tts_settings: GPTSoVITSTTSSettings | None = None
         self.result_character_id: str | None = None
         self.result_portrait_scale_percent: int | None = None
+        self.result_control_panel_width: int | None = None
+        self.result_bubble_height: int | None = None
+        self.result_control_panel_vertical_offset: int | None = None
         self.result_subtitle_typing_interval_ms: int | None = None
         self.result_reply_segment_pause_ms: int | None = None
         self.result_proactive_care_settings: ProactiveCareSettings | None = None
@@ -692,6 +720,9 @@ class SettingsDialog(QDialog):
         form_layout.addRow("状态", self.character_empty_label)
         form_layout.addRow("当前角色", self.character_combo)
         form_layout.addRow("立绘大小", self._build_portrait_scale_control(tab))
+        form_layout.addRow("对话框宽度", self._build_control_panel_width_control(tab))
+        form_layout.addRow("气泡高度", self._build_bubble_height_control(tab))
+        form_layout.addRow("气泡上下位置", self._build_control_panel_offset_control(tab))
         form_layout.addRow("角色包", self._build_character_archive_controls(tab))
         tab.setLayout(form_layout)
         self._sync_character_archive_controls()
@@ -837,6 +868,86 @@ class SettingsDialog(QDialog):
         layout.addWidget(self.portrait_scale_spin)
         container.setLayout(layout)
         return container
+
+    def _build_range_control(
+        self,
+        parent: QWidget,
+        *,
+        slider_attr: str,
+        spin_attr: str,
+        minimum: int,
+        maximum: int,
+        value: int,
+        single_step: int,
+        suffix: str = "",
+    ) -> QWidget:
+        """构造一行「滑块 + 数值框」联动控件，并把两个子控件挂到 self 的指定属性名上。"""
+        container = QWidget(parent)
+        slider = QSlider(Qt.Orientation.Horizontal, container)
+        slider.setRange(minimum, maximum)
+        slider.setSingleStep(single_step)
+        slider.setPageStep(single_step * 2)
+        slider.setValue(value)
+
+        spin = QSpinBox(container)
+        spin.setRange(minimum, maximum)
+        spin.setSingleStep(single_step)
+        if suffix:
+            spin.setSuffix(suffix)
+        spin.setValue(value)
+
+        slider.valueChanged.connect(spin.setValue)
+        spin.valueChanged.connect(slider.setValue)
+        # 拖动时实时回调宿主窗口预览（_build_range_control 仅被控制组三项滑块复用）。
+        spin.valueChanged.connect(self._emit_control_panel_layout_preview)
+
+        setattr(self, slider_attr, slider)
+        setattr(self, spin_attr, spin)
+
+        layout = QHBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(10)
+        layout.addWidget(slider, 1)
+        layout.addWidget(spin)
+        container.setLayout(layout)
+        return container
+
+    def _build_control_panel_width_control(self, parent: QWidget) -> QWidget:
+        return self._build_range_control(
+            parent,
+            slider_attr="control_panel_width_slider",
+            spin_attr="control_panel_width_spin",
+            minimum=MIN_CONTROL_PANEL_WIDTH,
+            maximum=MAX_CONTROL_PANEL_WIDTH,
+            value=self.control_panel_width,
+            single_step=10,
+            suffix=" px",
+        )
+
+    def _build_bubble_height_control(self, parent: QWidget) -> QWidget:
+        return self._build_range_control(
+            parent,
+            slider_attr="bubble_height_slider",
+            spin_attr="bubble_height_spin",
+            minimum=MIN_BUBBLE_HEIGHT,
+            maximum=MAX_BUBBLE_HEIGHT,
+            value=self.bubble_height,
+            single_step=4,
+            suffix=" px",
+        )
+
+    def _build_control_panel_offset_control(self, parent: QWidget) -> QWidget:
+        # 正值=气泡与输入栏整体向上，负值=向下；范围对称。
+        return self._build_range_control(
+            parent,
+            slider_attr="control_panel_offset_slider",
+            spin_attr="control_panel_offset_spin",
+            minimum=MIN_CONTROL_PANEL_VERTICAL_OFFSET,
+            maximum=MAX_CONTROL_PANEL_VERTICAL_OFFSET,
+            value=self.control_panel_vertical_offset,
+            single_step=10,
+            suffix=" px",
+        )
 
     def _build_api_tab(self, settings: ApiSettings) -> QWidget:
         tab = QWidget(self)
@@ -2138,6 +2249,9 @@ class SettingsDialog(QDialog):
             "tts_settings": tts_settings,
             "character_id": character_id,
             "portrait_scale_percent": self._selected_portrait_scale_percent(),
+            "control_panel_width": self._selected_control_panel_width(),
+            "bubble_height": self._selected_bubble_height(),
+            "control_panel_vertical_offset": self._selected_control_panel_vertical_offset(),
             "subtitle_typing_interval_ms": subtitle_typing_interval_ms,
             "reply_segment_pause_ms": reply_segment_pause_ms,
             "theme_settings": theme_settings,
@@ -2177,6 +2291,9 @@ class SettingsDialog(QDialog):
         tts_settings = values["tts_settings"]
         character_id = values["character_id"]
         portrait_scale_percent = values["portrait_scale_percent"]
+        control_panel_width = values["control_panel_width"]
+        bubble_height = values["bubble_height"]
+        control_panel_vertical_offset = values["control_panel_vertical_offset"]
         subtitle_typing_interval_ms = values["subtitle_typing_interval_ms"]
         reply_segment_pause_ms = values["reply_segment_pause_ms"]
         theme_settings = values["theme_settings"]
@@ -2221,6 +2338,19 @@ class SettingsDialog(QDialog):
         self.result_tts_settings = tts_settings
         self.result_character_id = character_id
         self.result_portrait_scale_percent = portrait_scale_percent
+        self.result_control_panel_width = (
+            control_panel_width
+            if isinstance(control_panel_width, int)
+            else self.control_panel_width
+        )
+        self.result_bubble_height = (
+            bubble_height if isinstance(bubble_height, int) else self.bubble_height
+        )
+        self.result_control_panel_vertical_offset = (
+            control_panel_vertical_offset
+            if isinstance(control_panel_vertical_offset, int)
+            else self.control_panel_vertical_offset
+        )
         self.result_subtitle_typing_interval_ms = subtitle_typing_interval_ms
         self.result_reply_segment_pause_ms = reply_segment_pause_ms
         self.result_theme_settings = theme_settings
@@ -2895,6 +3025,34 @@ class SettingsDialog(QDialog):
         if hasattr(self, "portrait_scale_spin"):
             return normalize_portrait_scale_percent(self.portrait_scale_spin.value())
         return self.portrait_scale_percent
+
+    def _selected_control_panel_width(self) -> int:
+        if hasattr(self, "control_panel_width_spin"):
+            return normalize_control_panel_width(self.control_panel_width_spin.value())
+        return self.control_panel_width
+
+    def _selected_bubble_height(self) -> int:
+        if hasattr(self, "bubble_height_spin"):
+            return normalize_bubble_height(self.bubble_height_spin.value())
+        return self.bubble_height
+
+    def _selected_control_panel_vertical_offset(self) -> int:
+        if hasattr(self, "control_panel_offset_spin"):
+            return normalize_control_panel_vertical_offset(
+                self.control_panel_offset_spin.value()
+            )
+        return self.control_panel_vertical_offset
+
+    def _emit_control_panel_layout_preview(self, *_args) -> None:  # type: ignore[no-untyped-def]
+        """三个控制组滑块变化时，实时把当前取值回调给宿主窗口预览（不持久化）。"""
+        callback = getattr(self, "_on_control_panel_layout_preview", None)
+        if callback is None:
+            return
+        callback(
+            self._selected_control_panel_width(),
+            self._selected_bubble_height(),
+            self._selected_control_panel_vertical_offset(),
+        )
 
     def _refresh_character_combo(self, selected_character_id: str | None = None) -> None:
         if not hasattr(self, "character_combo"):

--- a/app/ui/theme.py
+++ b/app/ui/theme.py
@@ -396,6 +396,37 @@ QLineEdit, QSpinBox, QDoubleSpinBox, QTextEdit, QTableWidget, QComboBox {{
     color: {theme.text_color};
     selection-background-color: {rgba(theme.primary_color, 71)};
 }}
+QSlider {{
+    min-height: 22px;
+}}
+QSlider::groove:horizontal {{
+    height: 4px;
+    background: {rgba(theme.border_color, 130)};
+    border-radius: 2px;
+}}
+QSlider::sub-page:horizontal {{
+    background: {theme.accent_color};
+    border-radius: 2px;
+}}
+QSlider::add-page:horizontal {{
+    background: {rgba(theme.border_color, 92)};
+    border-radius: 2px;
+}}
+QSlider::handle:horizontal {{
+    width: 14px;
+    height: 14px;
+    margin: -6px 0;
+    border-radius: 7px;
+    background: {theme.accent_color};
+    border: 2px solid {rgba(theme.input_background_color, 235)};
+}}
+QSlider::handle:horizontal:hover {{
+    background: {theme.primary_color};
+}}
+QSlider::handle:horizontal:disabled {{
+    background: {rgba(theme.muted_text_color, 130)};
+    border: 2px solid {rgba(theme.border_color, 92)};
+}}
 QLineEdit:disabled, QSpinBox:disabled, QDoubleSpinBox:disabled, QTextEdit:disabled, QComboBox:disabled {{
     background: {rgba(mix(theme.panel_background_color, "#808080", 0.16), 172)};
     border: 1px solid {rgba(mix(theme.border_color, "#808080", 0.28), 102)};

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -4771,7 +4771,7 @@ def test_settings_dialog_emits_control_panel_layout_preview() -> None:
     QApplication = qtwidgets.QApplication
     app = QApplication.instance() or QApplication([])
     root = _ui_runtime_root("control_panel_preview_dialog")
-    previews: list[tuple[int, int, int]] = []
+    previews: list[tuple[int, int, int, int, int]] = []
     dialog = SettingsDialog(
         api_settings=ApiSettings(
             base_url="https://api.example.com/v1",
@@ -4786,7 +4786,7 @@ def test_settings_dialog_emits_control_panel_layout_preview() -> None:
         control_panel_width=600,
         bubble_height=150,
         control_panel_vertical_offset=0,
-        on_control_panel_layout_preview=lambda w, h, o: previews.append((w, h, o)),
+        on_layout_preview=lambda p, w, h, o, i: previews.append((p, w, h, o, i)),
     )
 
     # 构造时的初始 setValue 不应触发预览（信号连接在赋值之后）
@@ -4795,10 +4795,18 @@ def test_settings_dialog_emits_control_panel_layout_preview() -> None:
     # 修改某个滑块即实时触发预览，参数为当前三项取值
     dialog.bubble_height_spin.setValue(180)
     assert previews
-    assert previews[-1] == (600, 180, 0)
+    assert previews[-1] == (100, 600, 180, 0, 0)
 
     dialog.control_panel_width_spin.setValue(720)
-    assert previews[-1] == (720, 180, 0)
+    assert previews[-1] == (100, 720, 180, 0, 0)
+
+    # 立绘缩放也接入实时预览
+    dialog.portrait_scale_spin.setValue(120)
+    assert previews[-1] == (120, 720, 180, 0, 0)
+
+    # 输入框下移也接入实时预览
+    dialog.input_bar_offset_spin.setValue(40)
+    assert previews[-1] == (120, 720, 180, 0, 40)
 
     dialog.deleteLater()
     app.processEvents()
@@ -6886,7 +6894,7 @@ def _minimal_settings_window(pet_window_cls, settings_service, api_client, memor
     class MinimalSettingsWindow:
         show_settings = pet_window_cls.show_settings
         _activate_settings_dialog = pet_window_cls._activate_settings_dialog
-        _preview_control_panel_layout = pet_window_cls._preview_control_panel_layout
+        _preview_layout = pet_window_cls._preview_layout
         _retire_tts_provider = pet_window_cls._retire_tts_provider
         _apply_subtitle_display_speed = pet_window_cls._apply_subtitle_display_speed
         _apply_launch_at_login_settings = pet_window_cls._apply_launch_at_login_settings
@@ -6903,12 +6911,14 @@ def _minimal_settings_window(pet_window_cls, settings_service, api_client, memor
             control_panel_width,
             bubble_height,
             vertical_offset,
+            input_bar_offset,
             *,
             persist: bool = True,
         ) -> None:
             self.control_panel_width = control_panel_width
             self.bubble_height = bubble_height
             self.control_panel_vertical_offset = vertical_offset
+            self.input_bar_offset = input_bar_offset
 
         def _sync_proactive_care_timer(self) -> None:
             pass
@@ -6938,6 +6948,7 @@ def _minimal_settings_window(pet_window_cls, settings_service, api_client, memor
     window.control_panel_width = 640
     window.bubble_height = 128
     window.control_panel_vertical_offset = 0
+    window.input_bar_offset = 0
     window.subtitle_typing_interval_ms = 35
     window.reply_segment_pause_ms = 100
     window.retired_tts_providers = []

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -975,6 +975,75 @@ def test_stage_size_shrinks_with_portrait_scale_below_default_height() -> None:
         assert width == 860
 
 
+def test_control_panel_layout_normalization() -> None:
+    from app.ui.control_panel_layout import (
+        DEFAULT_BUBBLE_HEIGHT,
+        DEFAULT_CONTROL_PANEL_VERTICAL_OFFSET,
+        DEFAULT_CONTROL_PANEL_WIDTH,
+        MAX_BUBBLE_HEIGHT,
+        MAX_CONTROL_PANEL_VERTICAL_OFFSET,
+        MAX_CONTROL_PANEL_WIDTH,
+        MIN_BUBBLE_HEIGHT,
+        MIN_CONTROL_PANEL_VERTICAL_OFFSET,
+        MIN_CONTROL_PANEL_WIDTH,
+        normalize_bubble_height,
+        normalize_control_panel_vertical_offset,
+        normalize_control_panel_width,
+    )
+
+    # 非法输入回退默认值
+    assert normalize_control_panel_width("invalid") == DEFAULT_CONTROL_PANEL_WIDTH
+    assert normalize_bubble_height(None) == DEFAULT_BUBBLE_HEIGHT
+    assert normalize_control_panel_vertical_offset("x") == DEFAULT_CONTROL_PANEL_VERTICAL_OFFSET
+
+    # 越界裁剪到上下限
+    assert normalize_control_panel_width(1) == MIN_CONTROL_PANEL_WIDTH
+    assert normalize_control_panel_width(9999) == MAX_CONTROL_PANEL_WIDTH
+    assert normalize_bubble_height(1) == MIN_BUBBLE_HEIGHT
+    assert normalize_bubble_height(9999) == MAX_BUBBLE_HEIGHT
+    assert normalize_control_panel_vertical_offset(-9999) == MIN_CONTROL_PANEL_VERTICAL_OFFSET
+    assert normalize_control_panel_vertical_offset(9999) == MAX_CONTROL_PANEL_VERTICAL_OFFSET
+
+    # 合法值（含字符串/0/负值）原样保留
+    assert normalize_control_panel_width(512) == 512
+    assert normalize_control_panel_width("700") == 700
+    assert normalize_bubble_height(180) == 180
+    assert normalize_control_panel_vertical_offset(40) == 40
+    assert normalize_control_panel_vertical_offset(-40) == -40
+    assert normalize_control_panel_vertical_offset(0) == 0
+
+
+def test_stage_size_for_layout_respects_panel_and_bubble() -> None:
+    from app.ui.pet_window import DEFAULT_STAGE_WIDTH, _stage_size_for_layout
+    from app.ui.control_panel_layout import (
+        DEFAULT_BUBBLE_HEIGHT,
+        DEFAULT_CONTROL_PANEL_WIDTH,
+        MAX_CONTROL_PANEL_WIDTH,
+        MIN_CONTROL_PANEL_WIDTH,
+    )
+
+    # 默认参数：宽度保底为默认舞台宽度 860，高度 640
+    width, height = _stage_size_for_layout(
+        100, DEFAULT_CONTROL_PANEL_WIDTH, DEFAULT_BUBBLE_HEIGHT
+    )
+    assert width == DEFAULT_STAGE_WIDTH
+    assert height == 640
+
+    # 控制组加宽到上限：舞台宽度扩展为 panel + 96
+    wide_width, _ = _stage_size_for_layout(100, MAX_CONTROL_PANEL_WIDTH, DEFAULT_BUBBLE_HEIGHT)
+    assert wide_width == MAX_CONTROL_PANEL_WIDTH + 96
+
+    # 控制组窄于默认时仍保底 860
+    narrow_width, _ = _stage_size_for_layout(100, MIN_CONTROL_PANEL_WIDTH, DEFAULT_BUBBLE_HEIGHT)
+    assert narrow_width == DEFAULT_STAGE_WIDTH
+
+    # 气泡变高：舞台高度随气泡增量同步增高
+    _, taller = _stage_size_for_layout(
+        100, DEFAULT_CONTROL_PANEL_WIDTH, DEFAULT_BUBBLE_HEIGHT + 60
+    )
+    assert taller == 640 + 60
+
+
 def test_pet_window_defaults_subtitle_language_to_chinese() -> None:
     from app.ui.pet_window import PetWindow, SUBTITLE_LANGUAGE_JA, SUBTITLE_LANGUAGE_ZH
 
@@ -4646,6 +4715,95 @@ def test_settings_dialog_returns_portrait_scale_percent() -> None:
     app.processEvents()
 
 
+def test_settings_dialog_returns_control_panel_layout() -> None:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    if not hasattr(qtwidgets, "QApplication"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+
+    from app.ui.settings_dialog import SettingsDialog
+
+    QApplication = qtwidgets.QApplication
+    app = QApplication.instance() or QApplication([])
+    root = _ui_runtime_root("control_panel_layout_dialog")
+    dialog = SettingsDialog(
+        api_settings=ApiSettings(
+            base_url="https://api.example.com/v1",
+            api_key="test-key",
+            model="test-model",
+        ),
+        tts_settings=_minimal_tts_settings(),
+        base_dir=root,
+        **_settings_dialog_character_kwargs(root),
+        proactive_care_settings=ProactiveCareSettings(screen_context_enabled=True),
+        mcp_settings=MCPRuntimeSettings(windows_enabled=False),
+        control_panel_width=600,
+        bubble_height=150,
+        control_panel_vertical_offset=30,
+    )
+
+    # 构造时把当前值回填到控件
+    assert dialog.control_panel_width_spin.value() == 600
+    assert dialog.bubble_height_spin.value() == 150
+    assert dialog.control_panel_offset_spin.value() == 30
+
+    # 修改后 accept 回收归一化结果
+    dialog.control_panel_width_spin.setValue(720)
+    dialog.bubble_height_spin.setValue(200)
+    dialog.control_panel_offset_spin.setValue(-40)
+    dialog.accept()
+
+    assert dialog.result_control_panel_width == 720
+    assert dialog.result_bubble_height == 200
+    assert dialog.result_control_panel_vertical_offset == -40
+    dialog.deleteLater()
+    app.processEvents()
+
+
+def test_settings_dialog_emits_control_panel_layout_preview() -> None:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    if not hasattr(qtwidgets, "QApplication"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+
+    from app.ui.settings_dialog import SettingsDialog
+
+    QApplication = qtwidgets.QApplication
+    app = QApplication.instance() or QApplication([])
+    root = _ui_runtime_root("control_panel_preview_dialog")
+    previews: list[tuple[int, int, int]] = []
+    dialog = SettingsDialog(
+        api_settings=ApiSettings(
+            base_url="https://api.example.com/v1",
+            api_key="test-key",
+            model="test-model",
+        ),
+        tts_settings=_minimal_tts_settings(),
+        base_dir=root,
+        **_settings_dialog_character_kwargs(root),
+        proactive_care_settings=ProactiveCareSettings(screen_context_enabled=True),
+        mcp_settings=MCPRuntimeSettings(windows_enabled=False),
+        control_panel_width=600,
+        bubble_height=150,
+        control_panel_vertical_offset=0,
+        on_control_panel_layout_preview=lambda w, h, o: previews.append((w, h, o)),
+    )
+
+    # 构造时的初始 setValue 不应触发预览（信号连接在赋值之后）
+    assert previews == []
+
+    # 修改某个滑块即实时触发预览，参数为当前三项取值
+    dialog.bubble_height_spin.setValue(180)
+    assert previews
+    assert previews[-1] == (600, 180, 0)
+
+    dialog.control_panel_width_spin.setValue(720)
+    assert previews[-1] == (720, 180, 0)
+
+    dialog.deleteLater()
+    app.processEvents()
+
+
 def test_settings_dialog_returns_subtitle_display_speed() -> None:
     os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
     qtwidgets = pytest.importorskip("PySide6.QtWidgets")
@@ -6728,6 +6886,7 @@ def _minimal_settings_window(pet_window_cls, settings_service, api_client, memor
     class MinimalSettingsWindow:
         show_settings = pet_window_cls.show_settings
         _activate_settings_dialog = pet_window_cls._activate_settings_dialog
+        _preview_control_panel_layout = pet_window_cls._preview_control_panel_layout
         _retire_tts_provider = pet_window_cls._retire_tts_provider
         _apply_subtitle_display_speed = pet_window_cls._apply_subtitle_display_speed
         _apply_launch_at_login_settings = pet_window_cls._apply_launch_at_login_settings
@@ -6738,6 +6897,18 @@ def _minimal_settings_window(pet_window_cls, settings_service, api_client, memor
 
         def _apply_portrait_scale_percent(self, percent: int) -> None:
             self.portrait_scale_percent = percent
+
+        def _apply_control_panel_layout(  # type: ignore[no-untyped-def]
+            self,
+            control_panel_width,
+            bubble_height,
+            vertical_offset,
+            *,
+            persist: bool = True,
+        ) -> None:
+            self.control_panel_width = control_panel_width
+            self.bubble_height = bubble_height
+            self.control_panel_vertical_offset = vertical_offset
 
         def _sync_proactive_care_timer(self) -> None:
             pass
@@ -6764,6 +6935,9 @@ def _minimal_settings_window(pet_window_cls, settings_service, api_client, memor
     window.memory_store = memory_store
     window.plugin_manager = PluginManagerStub()
     window.portrait_scale_percent = 100
+    window.control_panel_width = 640
+    window.bubble_height = 128
+    window.control_panel_vertical_offset = 0
     window.subtitle_typing_interval_ms = 35
     window.reply_segment_pause_ms = 100
     window.retired_tts_providers = []


### PR DESCRIPTION
## Summary

基于 #55 的实现思路，重新整合并适配了当前 `dev` 分支，新增可调整大小的控制面板能力。

由于 #55 是基于重构前的 `dev` 提交的，后续 `dev` 已经发生较大结构调整，直接合并会产生较多冲突和兼容问题。因此本 PR 在 `feat/resizable-control-panel` 分支中，按照原 PR 的功能目标重新接入到当前代码结构中。

感谢 #55 提供的初始实现思路，本 PR 用于替代 #55 进行合并。

## Changes

* 新增控制面板尺寸调整能力
* 适配当前 `dev` 分支重构后的代码结构
* 处理原 #55 在新 `dev` 上产生的冲突
* 整理相关 UI / 状态同步逻辑，使其符合当前项目结构

## Notes

* This PR supersedes #55.
* 原 #55 的功能目标已在本 PR 中重新整合。
* 如后续还有控制面板交互细节问题，可继续在本 PR 中跟进。

## Test

* [x] 启动 Sakura 后控制面板显示正常
* [x] 控制面板可正常调整大小
* [x] 调整大小后不会影响基础交互流程
* [x] 关闭 / 重新打开后表现符合预期
