### PR TITLE
Feat/macos native backdrop

### DIFF
--- a/app/ui/acrylic_card_window.py
+++ b/app/ui/acrylic_card_window.py
@@ -74,3 +74,10 @@ class AcrylicCardWindow(QWidget):
         super().showEvent(event)
         # winId 在 show 之后才有效，此时施加亚克力最稳。圆角由 backdrop 内部的 DWM 原生圆角负责。
         self._backdrop.apply(self, self._tint)
+
+    def hideEvent(self, event) -> None:  # type: ignore[no-untyped-def]
+        super().hideEvent(event)
+        # macOS 上 hide() 销毁 native NSWindow，Content Swap 的 effect_view
+        # 也被释放（PyObjC 引用虽在但底层 NSView 已 dead）。remove 清理引用，
+        # 确保下次 showEvent 中 apply 能重建。
+        self._backdrop.remove(self)

--- a/app/ui/acrylic_card_window.py
+++ b/app/ui/acrylic_card_window.py
@@ -72,12 +72,5 @@ class AcrylicCardWindow(QWidget):
 
     def showEvent(self, event) -> None:  # type: ignore[no-untyped-def]
         super().showEvent(event)
-        # winId 在 show 之后才有效，此时施加亚克力最稳。圆角由 backdrop 内部的 DWM 原生圆角负责。
+        # winId 在 show 之后才有效，此时施加 backdrop 最稳。
         self._backdrop.apply(self, self._tint)
-
-    def hideEvent(self, event) -> None:  # type: ignore[no-untyped-def]
-        super().hideEvent(event)
-        # macOS 上 hide() 销毁 native NSWindow，Content Swap 的 effect_view
-        # 也被释放（PyObjC 引用虽在但底层 NSView 已 dead）。remove 清理引用，
-        # 确保下次 showEvent 中 apply 能重建。
-        self._backdrop.remove(self)

--- a/app/ui/input_bar_animator.py
+++ b/app/ui/input_bar_animator.py
@@ -76,6 +76,14 @@ class InputBarAnimator(QObject):
         self._apply_resting_state()
         self._poll_timer.start()
 
+    def set_before_show(self, callback: Callable[[], None] | None) -> None:
+        """按当前视觉效果模式动态替换显示前回调。
+
+        - 高斯模糊：_refresh_input_blur_background（截图桌面 + 模糊）
+        - 纯色块 / macOS 毛玻璃 / Windows 亚克力：None（无需截图）
+        """
+        self._before_show = callback
+
     def sync(self) -> None:
         """外部 pinned 状态（如待确认动作出现）变化时，立即重算可见性。"""
         self._sync()

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -3796,6 +3796,24 @@ class PetWindow(QWidget):
 
     # ── 输入栏视觉效果（对称统一管线）────────────────────────────────
 
+    def _input_bar_visual_effect_mode(self) -> str:
+        return VisualEffectMode.validate(
+            getattr(self.theme_settings, "visual_effect_mode", VisualEffectMode.DEFAULT)
+        )
+
+    def _apply_input_bar_visual_effect_property(self, mode: str) -> None:
+        """同步动态样式属性，让纯色块等模式能触发对应 QSS。"""
+        for widget in (getattr(self, "input_bar", None), getattr(self, "input_edit", None)):
+            if widget is None:
+                continue
+            if widget.property("visualEffectMode") == mode:
+                continue
+            widget.setProperty("visualEffectMode", mode)
+            style = widget.style()
+            style.unpolish(widget)
+            style.polish(widget)
+            widget.update()
+
     def _backdrop_for_input_bar(self) -> tuple:
         """根据当前主题的 visual_effect_mode 返回 (backdrop, needs_bg_layer, before_show_callback)。
 
@@ -3805,9 +3823,7 @@ class PetWindow(QWidget):
         - WINDOWS_ACRYLIC:    WindowsAcrylicBackdrop + 无 bg 层 + 无回调
         - MACOS_VISUAL_EFFECT: MacOSVisualEffectBackdrop + 无 bg 层 + 无回调
         """
-        mode = VisualEffectMode.validate(
-            getattr(self.theme_settings, "visual_effect_mode", VisualEffectMode.DEFAULT)
-        )
+        mode = self._input_bar_visual_effect_mode()
         backdrop = create_window_backdrop(mode=mode)
 
         if mode == VisualEffectMode.GAUSSIAN_BLUR:
@@ -3821,6 +3837,8 @@ class PetWindow(QWidget):
 
     def _sync_input_bar_backdrop(self) -> None:
         """外观效果模式 / 主题改变时，重建整个输入栏外观管线。"""
+        mode = self._input_bar_visual_effect_mode()
+        self._apply_input_bar_visual_effect_property(mode)
         backdrop, needs_bg, before_show = self._backdrop_for_input_bar()
         window = getattr(self, "input_window", None)
         if window is None:
@@ -3829,18 +3847,17 @@ class PetWindow(QWidget):
         if type(window._backdrop) is type(backdrop):  # noqa: SLF001
             return
 
-        # 用户可见时才需要过渡动画。窗口始终不手动 apply —
-        # 由 show() → showEvent → backdrop.apply(window) 接管，
-        # 保证 winId 有效（hidden 时 winId==0 会 crash PyObjC/ctypes）。
+        # 先移除旧 backdrop，再隐藏窗口。Windows DWM 状态绑定在 HWND 上；
+        # 若先 hide，后续 remove 可能拿不到有效窗口句柄，导致亚克力/小圆角残留。
         visible = window.isVisible()
-        if visible:
-            window.hide()
-            QApplication.processEvents()
-
         try:
             window._backdrop.remove(window)  # noqa: SLF001
         except Exception:  # noqa: BLE001
             pass
+
+        if visible:
+            window.hide()
+            QApplication.processEvents()
 
         window._backdrop = backdrop  # noqa: SLF001
 

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -3820,24 +3820,18 @@ class PetWindow(QWidget):
         return backdrop, needs_bg, before_show
 
     def _sync_input_bar_backdrop(self) -> None:
-        """外观效果模式 / 主题改变时，重建整个输入栏外观管线。
-
-        所有模式对称统一处理：
-        - backdrop 的 remove / apply
-        - InputBlurBackground 背景层的显隐
-        - InputBarAnimator 的 before_show 回调（仅高斯模糊需要截图）
-        """
+        """外观效果模式 / 主题改变时，重建整个输入栏外观管线。"""
         backdrop, needs_bg, before_show = self._backdrop_for_input_bar()
         window = getattr(self, "input_window", None)
         if window is None:
             return
 
-        # 模式未变则跳过，避免频繁删除/创建导致白色闪烁
         if type(window._backdrop) is type(backdrop):  # noqa: SLF001
             return
 
-        # 模式真正变化：隐藏 → 同步 → 应用新 → 显示
-        # hide + processEvents 确保 NSWindow 在 remove 前已不可见，避免中间态白框
+        # 用户可见时才需要过渡动画。窗口始终不手动 apply —
+        # 由 show() → showEvent → backdrop.apply(window) 接管，
+        # 保证 winId 有效（hidden 时 winId==0 会 crash PyObjC/ctypes）。
         visible = window.isVisible()
         if visible:
             window.hide()
@@ -3850,7 +3844,7 @@ class PetWindow(QWidget):
 
         window._backdrop = backdrop  # noqa: SLF001
 
-        # 控制软件模糊背景层显隐
+        # 同步软件模糊背景层和 InputBarAnimator 回调
         bg = getattr(self, "input_blur_background", None)
         window._background_layer = bg if needs_bg else None  # noqa: SLF001
         if bg is not None:
@@ -3862,15 +3856,11 @@ class PetWindow(QWidget):
             else:
                 bg.hide()
 
-        # 同步 InputBarAnimator 的 before_show 回调
         animator = getattr(self, "input_bar_animator", None)
         if animator is not None:
             animator.set_before_show(before_show)
 
-        # 重新应用新 backdrop 并显示
         if visible:
-            tint = self._card_tint()
-            backdrop.apply(window, tint)
             window.show()
 
     # ── 角色切换 ─────────────────────────────────────────────────────

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -735,9 +735,12 @@ class PetWindow(QWidget):
             self.input_bar_animator.start()
         if hasattr(self, "bubble_auto_hide"):
             self.bubble_auto_hide.start()
-        # macOS 上 Qt.Tool 子窗口 show() 后不会自动浮在父窗口之上，需要延迟一帧 raise
+        # macOS 上 Qt.Tool 子窗口 show() 后不会自动浮在父窗口之上。
+        # singleShot(0) 延迟一帧 → 窗口刚创建完但 WindowServer 合成器可能尚未提交；
+        # singleShot(100ms) 补一发确保 bubble 确实在立绘前端渲染。
         if sys.platform == "darwin":
             QTimer.singleShot(0, self._raise_foreground_controls)
+            QTimer.singleShot(100, self._raise_foreground_controls)
         self._refresh_tray_menu()
         self._schedule_native_topmost_sync()
         if getattr(self, "memory_failure_dialog_pending_message", ""):

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -3756,8 +3756,7 @@ class PetWindow(QWidget):
             self.tray_icon.setIcon(_build_status_tray_icon(self.theme_settings.primary_color))
 
     def _apply_app_chrome_stylesheet(self) -> None:
-        # 全局美化下拉弹窗与滚动条：这些是独立顶层控件，对话框级样式传播不到，
-        # 且 app 用 Fusion 风格后系统原生外观失效，只能在 QApplication 级统一设置。
+        # 全局美化滚动条与菜单等独立顶层控件。
         app = QApplication.instance()
         if app is not None:
             app.setStyleSheet(build_app_chrome_stylesheet(self.theme_settings))

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 import time
+from dataclasses import replace
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -4299,9 +4300,13 @@ def _theme_settings_for_character(
     saved_settings: ThemeSettings,
     profile: CharacterProfile,
 ) -> ThemeSettings:
+    saved = saved_settings.normalized()
     if profile.theme_source == THEME_SOURCE_PACKAGE:
-        return (profile.theme_settings or DEFAULT_THEME_SETTINGS).normalized()
-    return saved_settings.normalized()
+        # 角色包主题只贡献配色；visual_effect_mode 是用户级偏好
+        # （character.json 不存储该键），沿用已保存的视觉效果。
+        theme = (profile.theme_settings or DEFAULT_THEME_SETTINGS).normalized()
+        return replace(theme, visual_effect_mode=saved.visual_effect_mode)
+    return saved
 
 
 def _mark_dialog_always_on_top(window) -> None:  # type: ignore[no-untyped-def]

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -661,7 +661,7 @@ class PetWindow(QWidget):
         # 输入栏独立为可激活的卡片子窗口：默认视觉模式从主题读取，
         # 支持纯色/高斯模糊/Windows亚克力/macOS毛玻璃四种效果。
         self.input_blur_background = InputBlurBackground(corner_radius=22.0)
-        input_backdrop, needs_bg = self._backdrop_for_input_bar()
+        input_backdrop, needs_bg, input_before_show = self._backdrop_for_input_bar()
         self.input_window = AcrylicCardWindow(
             self.input_bar,
             activatable=True,
@@ -675,7 +675,7 @@ class PetWindow(QWidget):
             self._input_bar_pinned,
             self._cursor_in_pet_region,
             parent=self,
-            before_show=self._refresh_input_blur_background,
+            before_show=input_before_show,
         )
         # 气泡无操作自动隐藏控制器：说完话后倒计时，悬停桌宠暂停，超时淡出，点击桌宠唤回。
         self.bubble_settings = self.settings_service.load_bubble_settings()
@@ -1199,21 +1199,11 @@ class PetWindow(QWidget):
         return QRect(self.mapToGlobal(rect.topLeft()), rect.size())
 
     def _refresh_input_blur_background(self) -> None:
-        """输入栏现身前刷新软件模糊背景：截输入栏正后方那块桌面，模糊后铺到背景层。
+        """输入栏现身前刷新软件模糊背景：截输入栏正后方桌面，模糊后铺到背景层。
 
-        仅在当前视觉效果模式为高斯模糊（SoftwareBlurBackdrop 路径）时执行截图/模糊。
-        其他模式（纯色/macOS毛玻璃/Windows亚克力）不需要软件截图背景层，
-        反而会因为 hide() 破坏原生 NSWindow 的 Content Swap 状态导致毛玻璃永久失效。
+        此回调仅在高斯模糊模式下才会被绑定到 InputBarAnimator，其他模式不需要截图。
+        调用前已确保 input_window 在当前实际区域正上方，截图后再显示。
         """
-        # 非高斯模糊模式：不需要软件截图模糊，直接返回。
-        # 注意：不要在这里调用 hide()，否则 macOS 的 MacOSVisualEffectBackdrop
-        # Content Swap 会被销毁，且 apply() 的幂等检查会阻止重建。
-        mode = VisualEffectMode.validate(
-            getattr(self.theme_settings, "visual_effect_mode", VisualEffectMode.DEFAULT)
-        )
-        if mode != VisualEffectMode.GAUSSIAN_BLUR:
-            return
-
         background = getattr(self, "input_blur_background", None)
         input_rect = getattr(self, "_input_local_rect", None)
         if background is None or input_rect is None:
@@ -3804,20 +3794,40 @@ class PetWindow(QWidget):
         )
         return overlay
 
-    # ── 输入栏视觉效果模式 ────────────────────────────────────────────
+    # ── 输入栏视觉效果（对称统一管线）────────────────────────────────
 
     def _backdrop_for_input_bar(self) -> tuple:
-        """根据当前主题的 visual_effect_mode 返回 (backdrop, needs_bg_layer)。"""
+        """根据当前主题的 visual_effect_mode 返回 (backdrop, needs_bg_layer, before_show_callback)。
+
+        三种输出对称映射到四个视觉模式：
+        - SOLID:              FallbackTintBackdrop  + 无 bg 层 + 无回调
+        - GAUSSIAN_BLUR:      SoftwareBlurBackdrop  + InputBlurBackground 层 + 截图回调
+        - WINDOWS_ACRYLIC:    WindowsAcrylicBackdrop + 无 bg 层 + 无回调
+        - MACOS_VISUAL_EFFECT: MacOSVisualEffectBackdrop + 无 bg 层 + 无回调
+        """
         mode = VisualEffectMode.validate(
             getattr(self.theme_settings, "visual_effect_mode", VisualEffectMode.DEFAULT)
         )
-        needs_bg = (mode == VisualEffectMode.GAUSSIAN_BLUR)
         backdrop = create_window_backdrop(mode=mode)
-        return backdrop, needs_bg
+
+        if mode == VisualEffectMode.GAUSSIAN_BLUR:
+            needs_bg = True
+            before_show: Callable[[], None] | None = self._refresh_input_blur_background
+        else:
+            needs_bg = False
+            before_show = None
+
+        return backdrop, needs_bg, before_show
 
     def _sync_input_bar_backdrop(self) -> None:
-        """外观效果模式改变时，重建输入栏背景实现。"""
-        backdrop, needs_bg = self._backdrop_for_input_bar()
+        """外观效果模式 / 主题改变时，重建整个输入栏外观管线。
+
+        所有模式对称统一处理：
+        - backdrop 的 remove / apply
+        - InputBlurBackground 背景层的显隐
+        - InputBarAnimator 的 before_show 回调（仅高斯模糊需要截图）
+        """
+        backdrop, needs_bg, before_show = self._backdrop_for_input_bar()
         window = getattr(self, "input_window", None)
         if window is None:
             return
@@ -3851,6 +3861,11 @@ class PetWindow(QWidget):
                 bg.show()
             else:
                 bg.hide()
+
+        # 同步 InputBarAnimator 的 before_show 回调
+        animator = getattr(self, "input_bar_animator", None)
+        if animator is not None:
+            animator.set_before_show(before_show)
 
         # 重新应用新 backdrop 并显示
         if visible:

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -721,6 +721,9 @@ class PetWindow(QWidget):
     def moveEvent(self, event) -> None:  # type: ignore[no-untyped-def]
         super().moveEvent(event)
         self._reposition_child_windows()
+        # macOS 上拖动导致 Qt.Tool 子窗口层级丢失，需要重新 raise
+        if sys.platform == "darwin":
+            self._raise_foreground_controls()
 
     def showEvent(self, event) -> None:  # type: ignore[no-untyped-def]
         super().showEvent(event)
@@ -916,6 +919,9 @@ class PetWindow(QWidget):
     def _finish_drag_resume(self) -> None:
         """拖动松手后：把卡片窗口摆到新位置，再让输入栏按可见性重算（重截新位置桌面后现身）。"""
         self._reposition_child_windows()
+        # macOS 上拖动结束后子窗口层级可能丢失，重新 raise
+        if sys.platform == "darwin":
+            self._raise_foreground_controls()
         animator = getattr(self, "input_bar_animator", None)
         if animator is not None:
             animator.resume_after_drag()

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -3600,9 +3600,18 @@ class PetWindow(QWidget):
     def _apply_window_flags(self) -> None:
         was_visible = self.isVisible()
         self.setWindowFlags(self._window_flags())
+        # 同步气泡/输入栏卡片窗口的置顶标志，避免主窗口置顶后立绘盖住气泡和输入栏
+        self._sync_card_window_topmost_flags()
         if was_visible:
             self.show()
             self._schedule_native_topmost_sync()
+            QTimer.singleShot(0, self._raise_foreground_controls)
+
+    def _sync_card_window_topmost_flags(self) -> None:
+        enabled = self.always_on_top_enabled
+        for window in (getattr(self, "bubble_window", None), getattr(self, "input_window", None)):
+            if window is not None:
+                window.setWindowFlag(Qt.WindowType.WindowStaysOnTopHint, enabled)
 
     def _schedule_native_topmost_sync(self) -> None:
         if sys.platform not in {"win32", "darwin"}:

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -3814,10 +3814,12 @@ class PetWindow(QWidget):
         if type(window._backdrop) is type(backdrop):  # noqa: SLF001
             return
 
-        # 模式真正变化：先隐藏窗口避免过渡闪现白框
+        # 模式真正变化：隐藏 → 同步 → 应用新 → 显示
+        # hide + processEvents 确保 NSWindow 在 remove 前已不可见，避免中间态白框
         visible = window.isVisible()
         if visible:
             window.hide()
+            QApplication.processEvents()
 
         try:
             window._backdrop.remove(window)  # noqa: SLF001

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -1201,10 +1201,19 @@ class PetWindow(QWidget):
     def _refresh_input_blur_background(self) -> None:
         """输入栏现身前刷新软件模糊背景：截输入栏正后方那块桌面，模糊后铺到背景层。
 
-        输入栏窗口自身在截图区域内，会被 grabWindow 截进去，故截图前先确保它隐藏、
-        让出一帧待合成器把窗口移出画面后再截。气泡位于输入栏正上方、不在输入栏截图区域内
-        （_layout_stage 中两者有 input_gap 间隔不重叠），无需隐藏气泡——隐藏反而会导致气泡闪烁。
+        仅在当前视觉效果模式为高斯模糊（SoftwareBlurBackdrop 路径）时执行截图/模糊。
+        其他模式（纯色/macOS毛玻璃/Windows亚克力）不需要软件截图背景层，
+        反而会因为 hide() 破坏原生 NSWindow 的 Content Swap 状态导致毛玻璃永久失效。
         """
+        # 非高斯模糊模式：不需要软件截图模糊，直接返回。
+        # 注意：不要在这里调用 hide()，否则 macOS 的 MacOSVisualEffectBackdrop
+        # Content Swap 会被销毁，且 apply() 的幂等检查会阻止重建。
+        mode = VisualEffectMode.validate(
+            getattr(self.theme_settings, "visual_effect_mode", VisualEffectMode.DEFAULT)
+        )
+        if mode != VisualEffectMode.GAUSSIAN_BLUR:
+            return
+
         background = getattr(self, "input_blur_background", None)
         input_rect = getattr(self, "_input_local_rect", None)
         if background is None or input_rect is None:

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -146,7 +146,7 @@ from app.storage.visual_observation import (
 from app.ui.fonts import _rounded_chinese_font, _rounded_japanese_font
 from app.ui.input_bar_animator import InputBarAnimator
 from app.ui.acrylic_card_window import AcrylicCardWindow
-from app.ui.window_backdrop import FallbackTintBackdrop, SoftwareBlurBackdrop
+from app.ui.window_backdrop import SoftwareBlurBackdrop, create_window_backdrop
 from app.ui.input_blur_background import InputBlurBackground, make_blurred_pixmap
 from app.ui.bubble_auto_hide import BubbleAutoHideController
 from app.ui import (
@@ -607,12 +607,13 @@ class PetWindow(QWidget):
         bubble_layout.setSpacing(0)
         bubble_layout.addLayout(bubble_body_layout, 1)
         self.bubble.setLayout(bubble_layout)
-        # 气泡独立为半透明卡片子窗口：放弃 DWM 亚克力（做不出大圆角），改纯半透明无模糊，
+        # 气泡独立为半透明卡片子窗口：macOS 用 NSVisualEffectView 原生毛玻璃，
+        # Windows 用 DWM 亚克力，其他平台降级为纯半透明无模糊。
         # 圆角与底色由 #speechBubble 的 QSS 大圆角 + 较高 alpha 背景负责（保证文字可读）。
         self.bubble_window = AcrylicCardWindow(
             self.bubble,
             activatable=False,
-            backdrop=FallbackTintBackdrop(),
+            backdrop=create_window_backdrop(),
             parent=self,
         )
 
@@ -730,6 +731,9 @@ class PetWindow(QWidget):
             self.input_bar_animator.start()
         if hasattr(self, "bubble_auto_hide"):
             self.bubble_auto_hide.start()
+        # macOS 上 Qt.Tool 子窗口 show() 后不会自动浮在父窗口之上，需要延迟一帧 raise
+        if sys.platform == "darwin":
+            QTimer.singleShot(0, self._raise_foreground_controls)
         self._refresh_tray_menu()
         self._schedule_native_topmost_sync()
         if getattr(self, "memory_failure_dialog_pending_message", ""):

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -146,7 +146,7 @@ from app.storage.visual_observation import (
 from app.ui.fonts import _rounded_chinese_font, _rounded_japanese_font
 from app.ui.input_bar_animator import InputBarAnimator
 from app.ui.acrylic_card_window import AcrylicCardWindow
-from app.ui.window_backdrop import SoftwareBlurBackdrop, create_window_backdrop
+from app.ui.window_backdrop import FallbackTintBackdrop, SoftwareBlurBackdrop, VisualEffectMode, create_window_backdrop
 from app.ui.input_blur_background import InputBlurBackground, make_blurred_pixmap
 from app.ui.bubble_auto_hide import BubbleAutoHideController
 from app.ui import (
@@ -607,13 +607,13 @@ class PetWindow(QWidget):
         bubble_layout.setSpacing(0)
         bubble_layout.addLayout(bubble_body_layout, 1)
         self.bubble.setLayout(bubble_layout)
-        # 气泡独立为半透明卡片子窗口：macOS 用 NSVisualEffectView 原生毛玻璃，
-        # Windows 用 DWM 亚克力，其他平台降级为纯半透明无模糊。
+        # 气泡独立为半透明卡片子窗口：纯色半透明，不加系统级毛玻璃。
+        # macOS 毛玻璃已移入输入框（与高斯模糊/亚克力并列为可选外观效果）。
         # 圆角与底色由 #speechBubble 的 QSS 大圆角 + 较高 alpha 背景负责（保证文字可读）。
         self.bubble_window = AcrylicCardWindow(
             self.bubble,
             activatable=False,
-            backdrop=create_window_backdrop(),
+            backdrop=FallbackTintBackdrop(),
             parent=self,
         )
 
@@ -658,14 +658,15 @@ class PetWindow(QWidget):
         input_layout.addWidget(self.screenshot_button)
         input_layout.addWidget(self.send_button)
         self.input_bar.setLayout(input_layout)
-        # 输入栏独立为可激活的卡片子窗口（可聚焦打字），默认收起、hover 浮现。
-        # 改软件截图模糊（替代亚克力以实现大圆角）：背景层垫在内容下，浮现/松手时刷新截图。
+        # 输入栏独立为可激活的卡片子窗口：默认视觉模式从主题读取，
+        # 支持纯色/高斯模糊/Windows亚克力/macOS毛玻璃四种效果。
         self.input_blur_background = InputBlurBackground(corner_radius=22.0)
+        input_backdrop, needs_bg = self._backdrop_for_input_bar()
         self.input_window = AcrylicCardWindow(
             self.input_bar,
             activatable=True,
-            backdrop=SoftwareBlurBackdrop(),
-            background_layer=self.input_blur_background,
+            backdrop=input_backdrop,
+            background_layer=self.input_blur_background if needs_bg else None,
             parent=self,
         )
         self.input_bar_animator = InputBarAnimator(
@@ -3771,6 +3772,8 @@ class PetWindow(QWidget):
         if background is not None:
             background.set_tint(tint)
             background.set_shadow_overlay(self._card_shadow_overlay())
+        # 外观效果模式可能改变，重建输入栏 backdrop
+        self._sync_input_bar_backdrop()
 
     def _card_tint(self) -> QColor:
         # 亚克力磨砂底色：从气泡背景色派生，alpha 偏低让背后桌面更通透、磨砂更淡。
@@ -3788,6 +3791,52 @@ class PetWindow(QWidget):
             24,
         )
         return overlay
+
+    # ── 输入栏视觉效果模式 ────────────────────────────────────────────
+
+    def _backdrop_for_input_bar(self) -> tuple:
+        """根据当前主题的 visual_effect_mode 返回 (backdrop, needs_bg_layer)。"""
+        mode = VisualEffectMode.validate(
+            getattr(self.theme_settings, "visual_effect_mode", VisualEffectMode.DEFAULT)
+        )
+        needs_bg = (mode == VisualEffectMode.GAUSSIAN_BLUR)
+        backdrop = create_window_backdrop(mode=mode)
+        return backdrop, needs_bg
+
+    def _sync_input_bar_backdrop(self) -> None:
+        """外观效果模式改变时，重建输入栏背景实现。"""
+        backdrop, needs_bg = self._backdrop_for_input_bar()
+        window = getattr(self, "input_window", None)
+        if window is None:
+            return
+
+        # 移除旧 backdrop
+        try:
+            window._backdrop.remove(window)  # noqa: SLF001
+        except Exception:  # noqa: BLE001
+            pass
+
+        # 替换 backdrop
+        window._backdrop = backdrop  # noqa: SLF001
+
+        # 控制软件模糊背景层显隐
+        bg = getattr(self, "input_blur_background", None)
+        window._background_layer = bg if needs_bg else None  # noqa: SLF001
+        if bg is not None:
+            if needs_bg:
+                bg.setParent(window)
+                bg.setGeometry(window.rect())
+                bg.lower()
+                bg.show()
+            else:
+                bg.hide()
+
+        # 窗口可见则立刻应用新 backdrop
+        if window.isVisible():
+            tint = self._card_tint()
+            backdrop.apply(window, tint)
+
+    # ── 角色切换 ─────────────────────────────────────────────────────
 
     def _apply_character(self, profile: CharacterProfile) -> None:
         previous_character_id = self.character_profile.id

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -3810,13 +3810,20 @@ class PetWindow(QWidget):
         if window is None:
             return
 
-        # 移除旧 backdrop
+        # 模式未变则跳过，避免频繁删除/创建导致白色闪烁
+        if type(window._backdrop) is type(backdrop):  # noqa: SLF001
+            return
+
+        # 模式真正变化：先隐藏窗口避免过渡闪现白框
+        visible = window.isVisible()
+        if visible:
+            window.hide()
+
         try:
             window._backdrop.remove(window)  # noqa: SLF001
         except Exception:  # noqa: BLE001
             pass
 
-        # 替换 backdrop
         window._backdrop = backdrop  # noqa: SLF001
 
         # 控制软件模糊背景层显隐
@@ -3831,10 +3838,11 @@ class PetWindow(QWidget):
             else:
                 bg.hide()
 
-        # 窗口可见则立刻应用新 backdrop
-        if window.isVisible():
+        # 重新应用新 backdrop 并显示
+        if visible:
             tint = self._card_tint()
             backdrop.apply(window, tint)
+            window.show()
 
     # ── 角色切换 ─────────────────────────────────────────────────────
 

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import sys
 import time
-from dataclasses import replace
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -164,6 +163,7 @@ from app.ui.theme import (
     ThemeSettings,
     build_app_chrome_stylesheet,
     build_message_box_stylesheet,
+    merge_theme_with_character,
 )
 from app.voice import VoicePlaybackController
 
@@ -357,7 +357,7 @@ class PetWindow(QWidget):
         self.mcp_settings = context.mcp_settings
         self.debug_log_settings = context.debug_log_settings
         self.startup_settings = context.startup_settings
-        self.theme_settings = _theme_settings_for_character(
+        self.theme_settings = merge_theme_with_character(
             self.settings_service.load_theme_settings(),
             self.character_profile,
         )
@@ -4294,19 +4294,6 @@ def _same_optional_path(left: Path | None, right: Path | None) -> bool:
 
 def _should_write_character_theme(theme_write_mode: object, profile: CharacterProfile) -> bool:
     return theme_write_mode in {"manual", "ai"}
-
-
-def _theme_settings_for_character(
-    saved_settings: ThemeSettings,
-    profile: CharacterProfile,
-) -> ThemeSettings:
-    saved = saved_settings.normalized()
-    if profile.theme_source == THEME_SOURCE_PACKAGE:
-        # 角色包主题只贡献配色；visual_effect_mode 是用户级偏好
-        # （character.json 不存储该键），沿用已保存的视觉效果。
-        theme = (profile.theme_settings or DEFAULT_THEME_SETTINGS).normalized()
-        return replace(theme, visual_effect_mode=saved.visual_effect_mode)
-    return saved
 
 
 def _mark_dialog_always_on_top(window) -> None:  # type: ignore[no-untyped-def]

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -7,11 +7,10 @@ from pathlib import Path
 from typing import Callable, Literal
 from urllib.parse import urlparse
 
-from PySide6.QtCore import QObject, QSize, QStringListModel, Qt, QThread, QTimer, Signal, Slot
-from PySide6.QtGui import QAction, QBrush, QColor, QPainterPath, QPalette, QRegion
+from PySide6.QtCore import QObject, QStringListModel, Qt, QThread, QTimer, Signal, Slot
+from PySide6.QtGui import QAction, QBrush, QColor
 from PySide6.QtWidgets import (
     QAbstractItemView,
-    QApplication,
     QCheckBox,
     QComboBox,
     QCompleter,
@@ -26,9 +25,6 @@ from PySide6.QtWidgets import (
     QHBoxLayout,
     QLabel,
     QLineEdit,
-    QListView,
-    QListWidget,
-    QListWidgetItem,
     QMessageBox,
     QMenu,
     QPushButton,
@@ -134,17 +130,13 @@ from app.voice.tts import (
 from app.ui.tts_bundle_dialog import TTSBundleDownloadDialog
 from app.ui.theme import (
     DEFAULT_THEME_SETTINGS,
-    SETTINGS_COMBO_POPUP_CONTAINER_OBJECT_NAME,
-    SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME,
     THEME_COLOR_FIELDS,
     ThemeSettings,
-    build_app_chrome_stylesheet,
     build_color_button_stylesheet,
     build_settings_dialog_stylesheet,
     normalize_hex_color,
     mix,
     parse_ai_theme_response,
-    rgba,
 )
 from app.ui.window_backdrop import VisualEffectMode
 from app.voice.tts_bundle import default_provider_bundle_work_dir, is_provider_bundle_work_dir
@@ -153,17 +145,6 @@ from sdk.types import SettingsPanelContribution, ToolsTabContribution
 
 MEMORY_READING_TEXT = "正在读取长期记忆..."
 MEMORY_DEPENDENCY_LOADING_TEXT = "长期记忆系统正在初始化，首次启动可能需要下载本地嵌入模型，请稍等。"
-SETTINGS_COMBO_POPUP_ITEM_HEIGHT = 28
-SETTINGS_COMBO_POPUP_PADDING = 0
-
-
-def _prepare_combo_popup_view(combo: QComboBox) -> None:
-    # 仍给内置 view 标记对象名，避免 Qt 在补全/辅助绘制路径里回落到默认样式。
-    view = QListView(combo)
-    view.setFrameShape(QFrame.Shape.NoFrame)
-    view.setLineWidth(0)
-    view.setObjectName(SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME)
-    combo.setView(view)
 
 
 def _prepare_popup_menu(menu: QMenu) -> None:
@@ -174,88 +155,6 @@ def _prepare_popup_menu(menu: QMenu) -> None:
         | Qt.WindowType.NoDropShadowWindowHint
     )
     menu.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
-
-
-def _apply_combo_popup_palette(widget: QWidget, settings: ThemeSettings) -> None:
-    """给自绘下拉/补全弹层显式同步调色板，避免沿用旧的全局主题色。"""
-    theme = settings.normalized()
-    background = QColor(theme.input_background_color)
-    text = QColor(theme.text_color)
-    selected = QColor(theme.primary_color)
-    palette = widget.palette()
-    for role in (
-        QPalette.ColorRole.Window,
-        QPalette.ColorRole.Base,
-        QPalette.ColorRole.AlternateBase,
-    ):
-        palette.setColor(role, background)
-    palette.setColor(QPalette.ColorRole.Text, text)
-    palette.setColor(QPalette.ColorRole.WindowText, text)
-    palette.setColor(QPalette.ColorRole.Highlight, selected)
-    palette.setColor(QPalette.ColorRole.HighlightedText, text)
-    widget.setPalette(palette)
-    widget.setAutoFillBackground(True)
-    widget.setStyleSheet(_combo_popup_stylesheet(theme))
-    viewport = getattr(widget, "viewport", lambda: None)()
-    if isinstance(viewport, QWidget):
-        viewport.setPalette(palette)
-        viewport.setAutoFillBackground(True)
-
-
-def _combo_popup_stylesheet(settings: ThemeSettings) -> str:
-    theme = settings.normalized()
-    return f"""
-QFrame#{SETTINGS_COMBO_POPUP_CONTAINER_OBJECT_NAME} {{
-    background: {rgba(theme.input_background_color, 246)};
-    border: none;
-    border-radius: 7px;
-    padding: 0;
-}}
-QAbstractItemView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME},
-QListView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME},
-QListWidget#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME} {{
-    background: {rgba(theme.input_background_color, 246)};
-    border: none;
-    border-radius: 7px;
-    color: {theme.text_color};
-    outline: 0;
-    padding: 0;
-    selection-background-color: {rgba(theme.primary_color, 72)};
-    selection-color: {theme.text_color};
-}}
-QAbstractItemView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME} QWidget#qt_scrollarea_viewport,
-QListView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME} QWidget#qt_scrollarea_viewport,
-QListWidget#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME} QWidget#qt_scrollarea_viewport {{
-    background: {rgba(theme.input_background_color, 246)};
-}}
-QAbstractItemView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item,
-QListView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item,
-QListWidget#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item {{
-    min-height: 22px;
-    padding: 3px 8px;
-    border: 1px solid transparent;
-    border-radius: 5px;
-}}
-QAbstractItemView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:hover,
-QListView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:hover,
-QListWidget#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:hover {{
-    background: {rgba(theme.primary_color, 34)};
-    border: 1px solid {rgba(theme.primary_color, 58)};
-}}
-QAbstractItemView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected,
-QAbstractItemView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected:active,
-QAbstractItemView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected:!active,
-QListView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected,
-QListView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected:active,
-QListView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected:!active,
-QListWidget#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected,
-QListWidget#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected:active,
-QListWidget#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected:!active {{
-    background: {rgba(theme.primary_color, 72)};
-    border: 1px solid {rgba(theme.primary_color, 118)};
-    color: {theme.text_color};
-}}
-"""
 
 
 class ApiConnectionTestWorker(QObject):
@@ -300,97 +199,7 @@ class ApiModelListProbeWorker(QObject):
             self.finished.emit()
 
 
-class SettingsComboBox(QComboBox):
-    """设置页下拉框，使用自绘无边框弹层避开 Qt 原生矩形容器。"""
-
-    def __init__(self, parent: QWidget | None = None) -> None:
-        super().__init__(parent)
-        _prepare_combo_popup_view(self)
-        self._popup_frame: QFrame | None = None
-        self._popup_list: QListWidget | None = None
-        self._popup_theme = DEFAULT_THEME_SETTINGS
-
-    def set_popup_theme(self, settings: ThemeSettings) -> None:
-        self._popup_theme = settings.normalized()
-        if self._popup_frame is not None:
-            _apply_combo_popup_palette(self._popup_frame, self._popup_theme)
-        if self._popup_list is not None:
-            _apply_combo_popup_palette(self._popup_list, self._popup_theme)
-
-    def showPopup(self) -> None:  # noqa: N802 - Qt 虚函数命名。
-        if not self.isEnabled() or self.count() <= 0:
-            return
-        popup, popup_list = self._ensure_popup()
-        self.set_popup_theme(self._popup_theme)
-        popup_list.clear()
-        for index in range(self.count()):
-            item = QListWidgetItem(self.itemText(index))
-            item.setData(Qt.ItemDataRole.UserRole, index)
-            item.setSizeHint(QSize(0, SETTINGS_COMBO_POPUP_ITEM_HEIGHT))
-            popup_list.addItem(item)
-        if self.currentIndex() >= 0:
-            popup_list.setCurrentRow(self.currentIndex())
-
-        visible_rows = min(max(self.count(), 1), 10)
-        popup_height = (
-            SETTINGS_COMBO_POPUP_ITEM_HEIGHT * visible_rows
-            + SETTINGS_COMBO_POPUP_PADDING
-        )
-        popup_list.setFixedHeight(popup_height)
-        bottom_left = self.mapToGlobal(self.rect().bottomLeft())
-        popup.setGeometry(bottom_left.x(), bottom_left.y(), self.width(), popup_height)
-        path = QPainterPath()
-        path.addRoundedRect(0, 0, self.width(), popup_height, 7, 7)
-        popup.setMask(QRegion(path.toFillPolygon().toPolygon()))
-        popup.show()
-        popup.raise_()
-        popup_list.setFocus(Qt.FocusReason.PopupFocusReason)
-
-    def hidePopup(self) -> None:  # noqa: N802 - Qt 虚函数命名。
-        if self._popup_frame is not None:
-            self._popup_frame.hide()
-
-    def _ensure_popup(self) -> tuple[QFrame, QListWidget]:
-        if self._popup_frame is None or self._popup_list is None:
-            popup = QFrame(
-                self,
-                Qt.WindowType.Popup
-                | Qt.WindowType.FramelessWindowHint
-                | Qt.WindowType.NoDropShadowWindowHint,
-            )
-            popup.setObjectName(SETTINGS_COMBO_POPUP_CONTAINER_OBJECT_NAME)
-            popup.setFrameShape(QFrame.Shape.NoFrame)
-            popup.setLineWidth(0)
-
-            popup_list = QListWidget(popup)
-            popup_list.setObjectName(SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME)
-            popup_list.setFrameShape(QFrame.Shape.NoFrame)
-            popup_list.setLineWidth(0)
-            popup_list.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
-            popup_list.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
-            popup_list.itemClicked.connect(self._select_popup_item)
-            popup_list.itemActivated.connect(self._select_popup_item)
-            _apply_combo_popup_palette(popup, self._popup_theme)
-            _apply_combo_popup_palette(popup_list, self._popup_theme)
-
-            layout = QVBoxLayout()
-            layout.setContentsMargins(0, 0, 0, 0)
-            layout.addWidget(popup_list)
-            popup.setLayout(layout)
-            self._popup_frame = popup
-            self._popup_list = popup_list
-        return self._popup_frame, self._popup_list
-
-    def _select_popup_item(self, item: QListWidgetItem) -> None:
-        index = int(item.data(Qt.ItemDataRole.UserRole))
-        if 0 <= index < self.count():
-            self.setCurrentIndex(index)
-            if self.isEditable():
-                self.setEditText(self.itemText(index))
-        self.hidePopup()
-
-
-class ModelComboBox(SettingsComboBox):
+class ModelComboBox(QComboBox):
     """可编辑模型选择框，保留 QLineEdit 风格的 text/setText 兼容接口。"""
 
     def __init__(self, parent: QWidget | None = None) -> None:
@@ -398,22 +207,11 @@ class ModelComboBox(SettingsComboBox):
         self._model_names: list[str] = []
         self._completion_model = QStringListModel(self)
         completer = QCompleter(self._completion_model, self)
-        completion_popup = QListView(self)
-        completion_popup.setFrameShape(QFrame.Shape.NoFrame)
-        completion_popup.setLineWidth(0)
-        completion_popup.setObjectName(SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME)
-        completer.setPopup(completion_popup)
         completer.setCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
         completer.setFilterMode(Qt.MatchFlag.MatchContains)
-        self._completion_popup = completion_popup
         self.setEditable(True)
         self.setInsertPolicy(QComboBox.InsertPolicy.NoInsert)
         self.setCompleter(completer)
-        self.set_popup_theme(DEFAULT_THEME_SETTINGS)
-
-    def set_popup_theme(self, settings: ThemeSettings) -> None:
-        super().set_popup_theme(settings)
-        _apply_combo_popup_palette(self._completion_popup, self._popup_theme)
 
     def setText(self, text: str) -> None:
         self.setEditText(text)
@@ -422,7 +220,6 @@ class ModelComboBox(SettingsComboBox):
         return self.currentText()
 
     def set_model_names(self, model_names: list[str]) -> None:
-        self.hidePopup()
         current_text = self.currentText().strip()
         self._model_names = list(model_names)
         self.blockSignals(True)
@@ -821,7 +618,7 @@ class SettingsDialog(QDialog):
         current_character: CharacterProfile | None,
     ) -> QWidget:
         tab = QWidget(self)
-        self.character_combo = SettingsComboBox(tab)
+        self.character_combo = QComboBox(tab)
         self.character_empty_label = QLabel("尚未导入角色", tab)
         self._refresh_character_combo(
             current_character.id if current_character is not None else None
@@ -920,7 +717,7 @@ class SettingsDialog(QDialog):
         self.theme_text_edit = self.theme_color_edits["text_color"]
         self.theme_text_button = self.theme_color_buttons["text_color"]
         # 外观效果模式下拉框
-        self.theme_visual_effect_combo = SettingsComboBox(tab)
+        self.theme_visual_effect_combo = QComboBox(tab)
         for mode_id in VisualEffectMode.available_modes():
             label = {
                 VisualEffectMode.SOLID: "纯色块",
@@ -1140,7 +937,7 @@ class SettingsDialog(QDialog):
         self.tts_enabled_check = QCheckBox("启用 TTS 语音", tab)
         self.tts_enabled_check.setChecked(settings.enabled)
 
-        self.tts_provider_combo = SettingsComboBox(tab)
+        self.tts_provider_combo = QComboBox(tab)
         self.tts_provider_combo.addItem("GPT-SoVITS 整合包（GPU）", TTS_PROVIDER_GPT_SOVITS)
         self.tts_provider_combo.addItem("Genie TTS 整合包（CPU）", TTS_PROVIDER_GENIE)
         self.tts_provider_combo.addItem("自定义 GPT-SoVITS（macOS/Linux）", TTS_PROVIDER_CUSTOM_GPT_SOVITS)
@@ -2139,9 +1936,6 @@ class SettingsDialog(QDialog):
         theme = settings.normalized()
         self.theme_settings = theme
         self.setStyleSheet(build_settings_dialog_stylesheet(theme))
-        self._apply_app_chrome_stylesheet()
-        for combo in self.findChildren(SettingsComboBox):
-            combo.set_popup_theme(theme)
         inline_styles = {
             "theme_status_label": f"color: {theme.muted_text_color};",
             "memory_status_label": f"color: {theme.muted_text_color};",
@@ -2153,12 +1947,6 @@ class SettingsDialog(QDialog):
             widget = getattr(self, attr, None)
             if isinstance(widget, QLabel):
                 widget.setStyleSheet(style)
-
-    def _apply_app_chrome_stylesheet(self) -> None:
-        # QComboBox 弹出列表是独立顶层控件，对话框级样式不会稳定传播到弹层。
-        app = QApplication.instance()
-        if app is not None:
-            app.setStyleSheet(build_app_chrome_stylesheet(self.theme_settings))
 
     def _choose_theme_color(self, edit: QLineEdit) -> None:
         current_color = QColor(normalize_hex_color(edit.text(), DEFAULT_THEME_SETTINGS.primary_color))

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import mimetypes
+from dataclasses import replace
 from datetime import datetime
 from pathlib import Path
 from typing import Callable, Literal
@@ -2007,8 +2008,9 @@ class SettingsDialog(QDialog):
     ) -> None:
         """将主题控件的颜色值同步到界面，可选择性同步视觉效果下拉框。
 
-        sync_visual_effect 默认为 False：切换角色/AI配色/重置时不覆盖用户手动选择的视觉效果。
-        仅在对话框初始化（__init__）和点击"恢复默认配色"时传 True。
+        sync_visual_effect 默认为 False：视觉效果是用户级偏好（角色主题只贡献配色），
+        切换角色/AI配色/恢复默认配色均不覆盖用户手动选择的视觉效果。
+        仅在对话框初始化（__init__）时传 True。
         """
         theme = settings.normalized()
         self._syncing_theme_controls = True
@@ -2034,10 +2036,10 @@ class SettingsDialog(QDialog):
     def _reset_theme_colors(self) -> None:
         profile = self._selected_character_profile()
         if profile is None:
-            self._set_theme_controls(ThemeSettings(), sync_visual_effect=True)
+            self._set_theme_controls(ThemeSettings())
             self.theme_status_label.setText("已恢复默认 Sakura 粉色配色。")
         else:
-            self._set_theme_controls(profile.theme_settings or DEFAULT_THEME_SETTINGS, sync_visual_effect=True)
+            self._set_theme_controls(profile.theme_settings or DEFAULT_THEME_SETTINGS)
             if profile.theme_source == THEME_SOURCE_COMPAT_DEFAULT:
                 self.theme_status_label.setText("已恢复默认 Sakura 粉色配色。")
             else:
@@ -3061,9 +3063,13 @@ def _theme_settings_for_character(
     settings: ThemeSettings,
     profile: CharacterProfile | None,
 ) -> ThemeSettings:
+    saved = settings.normalized()
     if profile is not None and profile.theme_source == THEME_SOURCE_PACKAGE:
-        return (profile.theme_settings or DEFAULT_THEME_SETTINGS).normalized()
-    return settings.normalized()
+        # 角色包主题只贡献配色；visual_effect_mode 是用户级偏好
+        # （character.json 不存储该键），沿用已保存的视觉效果。
+        theme = (profile.theme_settings or DEFAULT_THEME_SETTINGS).normalized()
+        return replace(theme, visual_effect_mode=saved.visual_effect_mode)
+    return saved
 
 
 def _default_tts_api_url(provider: str) -> str:

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -17,6 +17,7 @@ from PySide6.QtWidgets import (
     QDialog,
     QDialogButtonBox,
     QColorDialog,
+    QDoubleSpinBox,
     QFileDialog,
     QFormLayout,
     QFrame,
@@ -200,7 +201,33 @@ class ApiModelListProbeWorker(QObject):
             self.finished.emit()
 
 
-class ModelComboBox(QComboBox):
+class _NoWheelMixin:
+    """禁止未获焦时响应滚轮，防止滚动设置页时意外改值。"""
+
+    def wheelEvent(self, event):  # type: ignore[no-untyped-def]
+        if self.hasFocus():  # type: ignore[attr-defined]
+            super().wheelEvent(event)  # type: ignore[misc]
+        else:
+            event.ignore()
+
+
+class _NoWheelSpinBox(_NoWheelMixin, QSpinBox):
+    pass
+
+
+class _NoWheelDoubleSpinBox(_NoWheelMixin, QDoubleSpinBox):
+    pass
+
+
+class _NoWheelComboBox(_NoWheelMixin, QComboBox):
+    pass
+
+
+class _NoWheelSlider(_NoWheelMixin, QSlider):
+    pass
+
+
+class ModelComboBox(_NoWheelMixin, QComboBox):
     """可编辑模型选择框，保留 QLineEdit 风格的 text/setText 兼容接口。"""
 
     def __init__(self, parent: QWidget | None = None) -> None:
@@ -619,7 +646,7 @@ class SettingsDialog(QDialog):
         current_character: CharacterProfile | None,
     ) -> QWidget:
         tab = QWidget(self)
-        self.character_combo = QComboBox(tab)
+        self.character_combo = _NoWheelComboBox(tab)
         self.character_empty_label = QLabel("尚未导入角色", tab)
         self._refresh_character_combo(
             current_character.id if current_character is not None else None
@@ -718,7 +745,7 @@ class SettingsDialog(QDialog):
         self.theme_text_edit = self.theme_color_edits["text_color"]
         self.theme_text_button = self.theme_color_buttons["text_color"]
         # 外观效果模式下拉框
-        self.theme_visual_effect_combo = QComboBox(tab)
+        self.theme_visual_effect_combo = _NoWheelComboBox(tab)
         for mode_id in VisualEffectMode.available_modes():
             label = {
                 VisualEffectMode.SOLID: "纯色块",
@@ -765,7 +792,7 @@ class SettingsDialog(QDialog):
 
     def _build_portrait_scale_control(self, parent: QWidget) -> QWidget:
         container = QWidget(parent)
-        self.portrait_scale_slider = QSlider(Qt.Orientation.Horizontal, container)
+        self.portrait_scale_slider = _NoWheelSlider(Qt.Orientation.Horizontal, container)
         self.portrait_scale_slider.setRange(
             PORTRAIT_SCALE_MIN_PERCENT,
             PORTRAIT_SCALE_MAX_PERCENT,
@@ -776,7 +803,7 @@ class SettingsDialog(QDialog):
         self.portrait_scale_slider.setTickPosition(QSlider.TickPosition.TicksBelow)
         self.portrait_scale_slider.setValue(self.portrait_scale_percent)
 
-        self.portrait_scale_spin = QSpinBox(container)
+        self.portrait_scale_spin = _NoWheelSpinBox(container)
         self.portrait_scale_spin.setRange(
             PORTRAIT_SCALE_MIN_PERCENT,
             PORTRAIT_SCALE_MAX_PERCENT,
@@ -812,13 +839,13 @@ class SettingsDialog(QDialog):
     ) -> QWidget:
         """构造一行「滑块 + 数值框」联动控件，并把两个子控件挂到 self 的指定属性名上。"""
         container = QWidget(parent)
-        slider = QSlider(Qt.Orientation.Horizontal, container)
+        slider = _NoWheelSlider(Qt.Orientation.Horizontal, container)
         slider.setRange(minimum, maximum)
         slider.setSingleStep(single_step)
         slider.setPageStep(single_step * 2)
         slider.setValue(value)
 
-        spin = QSpinBox(container)
+        spin = _NoWheelSpinBox(container)
         spin.setRange(minimum, maximum)
         spin.setSingleStep(single_step)
         if suffix:
@@ -904,7 +931,7 @@ class SettingsDialog(QDialog):
         self.model_edit.setText(settings.model)
         self.model_edit.setPlaceholderText("gpt-4.1-mini")
 
-        self.api_timeout_spin = QSpinBox(tab)
+        self.api_timeout_spin = _NoWheelSpinBox(tab)
         self.api_timeout_spin.setRange(1, 600)
         self.api_timeout_spin.setSuffix(" 秒")
         self.api_timeout_spin.setValue(settings.timeout_seconds)
@@ -938,7 +965,7 @@ class SettingsDialog(QDialog):
         self.tts_enabled_check = QCheckBox("启用 TTS 语音", tab)
         self.tts_enabled_check.setChecked(settings.enabled)
 
-        self.tts_provider_combo = QComboBox(tab)
+        self.tts_provider_combo = _NoWheelComboBox(tab)
         self.tts_provider_combo.addItem("GPT-SoVITS 整合包（GPU）", TTS_PROVIDER_GPT_SOVITS)
         self.tts_provider_combo.addItem("Genie TTS 整合包（CPU）", TTS_PROVIDER_GENIE)
         self.tts_provider_combo.addItem("自定义 GPT-SoVITS（macOS/Linux）", TTS_PROVIDER_CUSTOM_GPT_SOVITS)
@@ -964,7 +991,7 @@ class SettingsDialog(QDialog):
         self.ref_lang_edit = QLineEdit(settings.ref_lang, tab)
         self.text_lang_edit = QLineEdit(settings.text_lang, tab)
 
-        self.tts_timeout_spin = QSpinBox(tab)
+        self.tts_timeout_spin = _NoWheelSpinBox(tab)
         self.tts_timeout_spin.setRange(1, 600)
         self.tts_timeout_spin.setSuffix(" 秒")
         self.tts_timeout_spin.setValue(settings.timeout_seconds)
@@ -1006,7 +1033,7 @@ class SettingsDialog(QDialog):
             proactive_care_settings.screen_context_enabled
         )
 
-        self.proactive_check_interval_spin = QSpinBox(tab)
+        self.proactive_check_interval_spin = _NoWheelSpinBox(tab)
         self.proactive_check_interval_spin.setRange(
             PROACTIVE_MIN_CHECK_INTERVAL_MINUTES,
             PROACTIVE_MAX_CHECK_INTERVAL_MINUTES,
@@ -1016,7 +1043,7 @@ class SettingsDialog(QDialog):
             proactive_care_settings.normalized().check_interval_minutes
         )
 
-        self.proactive_cooldown_spin = QSpinBox(tab)
+        self.proactive_cooldown_spin = _NoWheelSpinBox(tab)
         self.proactive_cooldown_spin.setRange(
             PROACTIVE_MIN_COOLDOWN_MINUTES,
             PROACTIVE_MAX_COOLDOWN_MINUTES,
@@ -1026,7 +1053,7 @@ class SettingsDialog(QDialog):
             proactive_care_settings.normalized().cooldown_minutes
         )
 
-        self.proactive_batch_limit_spin = QSpinBox(tab)
+        self.proactive_batch_limit_spin = _NoWheelSpinBox(tab)
         self.proactive_batch_limit_spin.setRange(
             PROACTIVE_MIN_SCREEN_CONTEXT_BATCH_LIMIT,
             PROACTIVE_MAX_SCREEN_CONTEXT_BATCH_LIMIT,
@@ -1245,7 +1272,7 @@ class SettingsDialog(QDialog):
         self.debug_file_enabled_check = QCheckBox("输出文件运行日志", tab)
         self.debug_file_enabled_check.setChecked(debug_settings.file_enabled)
 
-        self.subtitle_typing_interval_spin = QSpinBox(tab)
+        self.subtitle_typing_interval_spin = _NoWheelSpinBox(tab)
         self.subtitle_typing_interval_spin.setRange(
             SUBTITLE_TYPING_INTERVAL_MIN_MS,
             SUBTITLE_TYPING_INTERVAL_MAX_MS,
@@ -1253,7 +1280,7 @@ class SettingsDialog(QDialog):
         self.subtitle_typing_interval_spin.setSuffix(" 毫秒")
         self.subtitle_typing_interval_spin.setValue(self.subtitle_typing_interval_ms)
 
-        self.reply_segment_pause_spin = QSpinBox(tab)
+        self.reply_segment_pause_spin = _NoWheelSpinBox(tab)
         self.reply_segment_pause_spin.setRange(
             REPLY_SEGMENT_PAUSE_MIN_MS,
             REPLY_SEGMENT_PAUSE_MAX_MS,
@@ -1263,7 +1290,7 @@ class SettingsDialog(QDialog):
 
         self.bubble_auto_hide_check = QCheckBox("气泡无操作后自动隐藏", tab)
         self.bubble_auto_hide_check.setChecked(bubble_settings.auto_hide_enabled)
-        self.bubble_auto_hide_delay_spin = QSpinBox(tab)
+        self.bubble_auto_hide_delay_spin = _NoWheelSpinBox(tab)
         self.bubble_auto_hide_delay_spin.setRange(
             BUBBLE_AUTO_HIDE_MIN_DELAY_SECONDS,
             BUBBLE_AUTO_HIDE_MAX_DELAY_SECONDS,

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -7,8 +7,8 @@ from pathlib import Path
 from typing import Callable, Literal
 from urllib.parse import urlparse
 
-from PySide6.QtCore import QObject, QStringListModel, Qt, QThread, QTimer, Signal, Slot
-from PySide6.QtGui import QAction, QBrush, QColor, QPainterPath, QRegion
+from PySide6.QtCore import QObject, QSize, QStringListModel, Qt, QThread, QTimer, Signal, Slot
+from PySide6.QtGui import QAction, QBrush, QColor, QPainterPath, QPalette, QRegion
 from PySide6.QtWidgets import (
     QAbstractItemView,
     QApplication,
@@ -144,6 +144,7 @@ from app.ui.theme import (
     normalize_hex_color,
     mix,
     parse_ai_theme_response,
+    rgba,
 )
 from app.ui.window_backdrop import VisualEffectMode
 from app.voice.tts_bundle import default_provider_bundle_work_dir, is_provider_bundle_work_dir
@@ -152,6 +153,8 @@ from sdk.types import SettingsPanelContribution, ToolsTabContribution
 
 MEMORY_READING_TEXT = "正在读取长期记忆..."
 MEMORY_DEPENDENCY_LOADING_TEXT = "长期记忆系统正在初始化，首次启动可能需要下载本地嵌入模型，请稍等。"
+SETTINGS_COMBO_POPUP_ITEM_HEIGHT = 28
+SETTINGS_COMBO_POPUP_PADDING = 0
 
 
 def _prepare_combo_popup_view(combo: QComboBox) -> None:
@@ -171,6 +174,88 @@ def _prepare_popup_menu(menu: QMenu) -> None:
         | Qt.WindowType.NoDropShadowWindowHint
     )
     menu.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
+
+
+def _apply_combo_popup_palette(widget: QWidget, settings: ThemeSettings) -> None:
+    """给自绘下拉/补全弹层显式同步调色板，避免沿用旧的全局主题色。"""
+    theme = settings.normalized()
+    background = QColor(theme.input_background_color)
+    text = QColor(theme.text_color)
+    selected = QColor(theme.primary_color)
+    palette = widget.palette()
+    for role in (
+        QPalette.ColorRole.Window,
+        QPalette.ColorRole.Base,
+        QPalette.ColorRole.AlternateBase,
+    ):
+        palette.setColor(role, background)
+    palette.setColor(QPalette.ColorRole.Text, text)
+    palette.setColor(QPalette.ColorRole.WindowText, text)
+    palette.setColor(QPalette.ColorRole.Highlight, selected)
+    palette.setColor(QPalette.ColorRole.HighlightedText, text)
+    widget.setPalette(palette)
+    widget.setAutoFillBackground(True)
+    widget.setStyleSheet(_combo_popup_stylesheet(theme))
+    viewport = getattr(widget, "viewport", lambda: None)()
+    if isinstance(viewport, QWidget):
+        viewport.setPalette(palette)
+        viewport.setAutoFillBackground(True)
+
+
+def _combo_popup_stylesheet(settings: ThemeSettings) -> str:
+    theme = settings.normalized()
+    return f"""
+QFrame#{SETTINGS_COMBO_POPUP_CONTAINER_OBJECT_NAME} {{
+    background: {rgba(theme.input_background_color, 246)};
+    border: none;
+    border-radius: 7px;
+    padding: 0;
+}}
+QAbstractItemView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME},
+QListView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME},
+QListWidget#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME} {{
+    background: {rgba(theme.input_background_color, 246)};
+    border: none;
+    border-radius: 7px;
+    color: {theme.text_color};
+    outline: 0;
+    padding: 0;
+    selection-background-color: {rgba(theme.primary_color, 72)};
+    selection-color: {theme.text_color};
+}}
+QAbstractItemView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME} QWidget#qt_scrollarea_viewport,
+QListView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME} QWidget#qt_scrollarea_viewport,
+QListWidget#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME} QWidget#qt_scrollarea_viewport {{
+    background: {rgba(theme.input_background_color, 246)};
+}}
+QAbstractItemView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item,
+QListView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item,
+QListWidget#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item {{
+    min-height: 22px;
+    padding: 3px 8px;
+    border: 1px solid transparent;
+    border-radius: 5px;
+}}
+QAbstractItemView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:hover,
+QListView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:hover,
+QListWidget#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:hover {{
+    background: {rgba(theme.primary_color, 34)};
+    border: 1px solid {rgba(theme.primary_color, 58)};
+}}
+QAbstractItemView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected,
+QAbstractItemView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected:active,
+QAbstractItemView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected:!active,
+QListView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected,
+QListView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected:active,
+QListView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected:!active,
+QListWidget#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected,
+QListWidget#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected:active,
+QListWidget#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected:!active {{
+    background: {rgba(theme.primary_color, 72)};
+    border: 1px solid {rgba(theme.primary_color, 118)};
+    color: {theme.text_color};
+}}
+"""
 
 
 class ApiConnectionTestWorker(QObject):
@@ -223,24 +308,35 @@ class SettingsComboBox(QComboBox):
         _prepare_combo_popup_view(self)
         self._popup_frame: QFrame | None = None
         self._popup_list: QListWidget | None = None
+        self._popup_theme = DEFAULT_THEME_SETTINGS
+
+    def set_popup_theme(self, settings: ThemeSettings) -> None:
+        self._popup_theme = settings.normalized()
+        if self._popup_frame is not None:
+            _apply_combo_popup_palette(self._popup_frame, self._popup_theme)
+        if self._popup_list is not None:
+            _apply_combo_popup_palette(self._popup_list, self._popup_theme)
 
     def showPopup(self) -> None:  # noqa: N802 - Qt 虚函数命名。
         if not self.isEnabled() or self.count() <= 0:
             return
         popup, popup_list = self._ensure_popup()
+        self.set_popup_theme(self._popup_theme)
         popup_list.clear()
         for index in range(self.count()):
             item = QListWidgetItem(self.itemText(index))
             item.setData(Qt.ItemDataRole.UserRole, index)
+            item.setSizeHint(QSize(0, SETTINGS_COMBO_POPUP_ITEM_HEIGHT))
             popup_list.addItem(item)
         if self.currentIndex() >= 0:
             popup_list.setCurrentRow(self.currentIndex())
 
-        row_height = popup_list.sizeHintForRow(0)
-        if row_height <= 0:
-            row_height = 28
         visible_rows = min(max(self.count(), 1), 10)
-        popup_height = row_height * visible_rows + 4
+        popup_height = (
+            SETTINGS_COMBO_POPUP_ITEM_HEIGHT * visible_rows
+            + SETTINGS_COMBO_POPUP_PADDING
+        )
+        popup_list.setFixedHeight(popup_height)
         bottom_left = self.mapToGlobal(self.rect().bottomLeft())
         popup.setGeometry(bottom_left.x(), bottom_left.y(), self.width(), popup_height)
         path = QPainterPath()
@@ -274,6 +370,8 @@ class SettingsComboBox(QComboBox):
             popup_list.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
             popup_list.itemClicked.connect(self._select_popup_item)
             popup_list.itemActivated.connect(self._select_popup_item)
+            _apply_combo_popup_palette(popup, self._popup_theme)
+            _apply_combo_popup_palette(popup_list, self._popup_theme)
 
             layout = QVBoxLayout()
             layout.setContentsMargins(0, 0, 0, 0)
@@ -307,9 +405,15 @@ class ModelComboBox(SettingsComboBox):
         completer.setPopup(completion_popup)
         completer.setCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
         completer.setFilterMode(Qt.MatchFlag.MatchContains)
+        self._completion_popup = completion_popup
         self.setEditable(True)
         self.setInsertPolicy(QComboBox.InsertPolicy.NoInsert)
         self.setCompleter(completer)
+        self.set_popup_theme(DEFAULT_THEME_SETTINGS)
+
+    def set_popup_theme(self, settings: ThemeSettings) -> None:
+        super().set_popup_theme(settings)
+        _apply_combo_popup_palette(self._completion_popup, self._popup_theme)
 
     def setText(self, text: str) -> None:
         self.setEditText(text)
@@ -816,7 +920,7 @@ class SettingsDialog(QDialog):
         self.theme_text_edit = self.theme_color_edits["text_color"]
         self.theme_text_button = self.theme_color_buttons["text_color"]
         # 外观效果模式下拉框
-        self.theme_visual_effect_combo = QComboBox(tab)
+        self.theme_visual_effect_combo = SettingsComboBox(tab)
         for mode_id in VisualEffectMode.available_modes():
             label = {
                 VisualEffectMode.SOLID: "纯色块",
@@ -2036,6 +2140,8 @@ class SettingsDialog(QDialog):
         self.theme_settings = theme
         self.setStyleSheet(build_settings_dialog_stylesheet(theme))
         self._apply_app_chrome_stylesheet()
+        for combo in self.findChildren(SettingsComboBox):
+            combo.set_popup_theme(theme)
         inline_styles = {
             "theme_status_label": f"color: {theme.muted_text_color};",
             "memory_status_label": f"color: {theme.muted_text_color};",

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -145,6 +145,7 @@ from app.ui.theme import (
     mix,
     parse_ai_theme_response,
 )
+from app.ui.window_backdrop import VisualEffectMode
 from app.voice.tts_bundle import default_provider_bundle_work_dir, is_provider_bundle_work_dir
 from sdk.types import SettingsPanelContribution, ToolsTabContribution
 
@@ -812,6 +813,20 @@ class SettingsDialog(QDialog):
         self.theme_accent_button = self.theme_color_buttons["accent_color"]
         self.theme_text_edit = self.theme_color_edits["text_color"]
         self.theme_text_button = self.theme_color_buttons["text_color"]
+        # 外观效果模式下拉框
+        self.theme_visual_effect_combo = QComboBox(tab)
+        for mode_id in VisualEffectMode.available_modes():
+            label = {
+                VisualEffectMode.SOLID: "纯色块",
+                VisualEffectMode.GAUSSIAN_BLUR: "高斯模糊",
+                VisualEffectMode.WINDOWS_ACRYLIC: "Windows 亚克力模糊",
+                VisualEffectMode.MACOS_VISUAL_EFFECT: "macOS 原生毛玻璃",
+            }.get(mode_id, mode_id)
+            self.theme_visual_effect_combo.addItem(label, mode_id)
+        self.theme_visual_effect_combo.currentIndexChanged.connect(
+            self._handle_visual_effect_changed
+        )
+        form_layout.addRow("输入栏外观效果", self.theme_visual_effect_combo)
         form_layout.addRow("", button_row)
         form_layout.addRow("状态", self.theme_status_label)
         tab.setLayout(form_layout)
@@ -2044,6 +2059,12 @@ class SettingsDialog(QDialog):
             return
         edit.setText(color.name())
 
+    def _handle_visual_effect_changed(self, _index: int) -> None:
+        """外观效果下拉框切换时标记主题为手动修改。"""
+        if not self._syncing_theme_controls:
+            self._theme_ai_enabled = False
+            self._theme_write_mode = "manual"
+
     def _handle_theme_color_changed(self, edit: QLineEdit) -> None:
         if not self._syncing_theme_controls:
             self._theme_ai_enabled = False
@@ -2075,9 +2096,14 @@ class SettingsDialog(QDialog):
                     QMessageBox.warning(self, "主题颜色无效", f"{label}必须是 #RRGGBB 格式。")
                 return None
             normalized_values[field] = normalized
+        visual_effect_mode = VisualEffectMode.DEFAULT
+        combo = getattr(self, "theme_visual_effect_combo", None)
+        if combo is not None and combo.currentData() is not None:
+            visual_effect_mode = str(combo.currentData())
         return ThemeSettings(
             **normalized_values,
             ai_enabled=self._theme_ai_enabled,
+            visual_effect_mode=visual_effect_mode,
         ).normalized()
 
     def _set_theme_controls(self, settings: ThemeSettings) -> None:
@@ -2089,6 +2115,12 @@ class SettingsDialog(QDialog):
                 self.theme_color_buttons[field].setStyleSheet(
                     build_color_button_stylesheet(getattr(theme, field))
                 )
+            # 视觉效果下拉框
+            combo = getattr(self, "theme_visual_effect_combo", None)
+            if combo is not None:
+                idx = combo.findData(theme.visual_effect_mode)
+                if idx >= 0:
+                    combo.setCurrentIndex(idx)
         finally:
             self._syncing_theme_controls = False
         self._theme_ai_enabled = theme.ai_enabled

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -219,15 +219,21 @@ class _NoWheelDoubleSpinBox(_NoWheelMixin, QDoubleSpinBox):
     pass
 
 
-class _NoWheelComboBox(_NoWheelMixin, QComboBox):
-    pass
+class _NoWheelComboBox(QComboBox):
+    """仅弹出列表打开时响应滚轮，避免未展开时滚动意外切换选项。"""
+
+    def wheelEvent(self, event):  # type: ignore[no-untyped-def]
+        if self.view().isVisible():
+            super().wheelEvent(event)
+        else:
+            event.ignore()
 
 
 class _NoWheelSlider(_NoWheelMixin, QSlider):
     pass
 
 
-class ModelComboBox(_NoWheelMixin, QComboBox):
+class ModelComboBox(_NoWheelComboBox):
     """可编辑模型选择框，保留 QLineEdit 风格的 text/setText 兼容接口。"""
 
     def __init__(self, parent: QWidget | None = None) -> None:

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -667,7 +667,7 @@ class SettingsDialog(QDialog):
         self._capture_initial_tts_settings_from_controls()
         self._apply_theme_stylesheet(self.theme_settings)
         # 初始化外观效果下拉框等控件为当前主题值
-        self._set_theme_controls(self.theme_settings)
+        self._set_theme_controls(self.theme_settings, sync_visual_effect=True)
 
     def _capture_initial_tts_settings_from_controls(self) -> None:
         settings = self._validated_tts_settings(
@@ -2108,7 +2108,14 @@ class SettingsDialog(QDialog):
             visual_effect_mode=visual_effect_mode,
         ).normalized()
 
-    def _set_theme_controls(self, settings: ThemeSettings) -> None:
+    def _set_theme_controls(
+        self, settings: ThemeSettings, *, sync_visual_effect: bool = False
+    ) -> None:
+        """将主题控件的颜色值同步到界面，可选择性同步视觉效果下拉框。
+
+        sync_visual_effect 默认为 False：切换角色/AI配色/重置时不覆盖用户手动选择的视觉效果。
+        仅在对话框初始化（__init__）和点击"恢复默认配色"时传 True。
+        """
         theme = settings.normalized()
         self._syncing_theme_controls = True
         try:
@@ -2117,12 +2124,12 @@ class SettingsDialog(QDialog):
                 self.theme_color_buttons[field].setStyleSheet(
                     build_color_button_stylesheet(getattr(theme, field))
                 )
-            # 视觉效果下拉框
-            combo = getattr(self, "theme_visual_effect_combo", None)
-            if combo is not None:
-                idx = combo.findData(theme.visual_effect_mode)
-                if idx >= 0:
-                    combo.setCurrentIndex(idx)
+            if sync_visual_effect:
+                combo = getattr(self, "theme_visual_effect_combo", None)
+                if combo is not None:
+                    idx = combo.findData(theme.visual_effect_mode)
+                    if idx >= 0:
+                        combo.setCurrentIndex(idx)
         finally:
             self._syncing_theme_controls = False
         self._theme_ai_enabled = theme.ai_enabled
@@ -2133,10 +2140,10 @@ class SettingsDialog(QDialog):
     def _reset_theme_colors(self) -> None:
         profile = self._selected_character_profile()
         if profile is None:
-            self._set_theme_controls(ThemeSettings())
+            self._set_theme_controls(ThemeSettings(), sync_visual_effect=True)
             self.theme_status_label.setText("已恢复默认 Sakura 粉色配色。")
         else:
-            self._set_theme_controls(profile.theme_settings or DEFAULT_THEME_SETTINGS)
+            self._set_theme_controls(profile.theme_settings or DEFAULT_THEME_SETTINGS, sync_visual_effect=True)
             if profile.theme_source == THEME_SOURCE_COMPAT_DEFAULT:
                 self.theme_status_label.setText("已恢复默认 Sakura 粉色配色。")
             else:

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -666,6 +666,8 @@ class SettingsDialog(QDialog):
         self.setLayout(layout)
         self._capture_initial_tts_settings_from_controls()
         self._apply_theme_stylesheet(self.theme_settings)
+        # 初始化外观效果下拉框等控件为当前主题值
+        self._set_theme_controls(self.theme_settings)
 
     def _capture_initial_tts_settings_from_controls(self) -> None:
         settings = self._validated_tts_settings(

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import base64
 import mimetypes
-from dataclasses import replace
 from datetime import datetime
 from pathlib import Path
 from typing import Callable, Literal
@@ -135,6 +134,7 @@ from app.ui.theme import (
     ThemeSettings,
     build_color_button_stylesheet,
     build_settings_dialog_stylesheet,
+    merge_theme_with_character,
     normalize_hex_color,
     mix,
     parse_ai_theme_response,
@@ -420,7 +420,7 @@ class SettingsDialog(QDialog):
         self._initial_api_settings = api_settings
         self._initial_tts_settings = tts_settings
         self._initial_character_id = current_character.id if current_character is not None else None
-        self.theme_settings = _theme_settings_for_character(
+        self.theme_settings = merge_theme_with_character(
             theme_settings or DEFAULT_THEME_SETTINGS,
             current_character,
         )
@@ -2024,6 +2024,8 @@ class SettingsDialog(QDialog):
                 combo = getattr(self, "theme_visual_effect_combo", None)
                 if combo is not None:
                     idx = combo.findData(theme.visual_effect_mode)
+                    if idx < 0:
+                        idx = combo.findData(VisualEffectMode.GAUSSIAN_BLUR)
                     if idx >= 0:
                         combo.setCurrentIndex(idx)
         finally:
@@ -3057,19 +3059,6 @@ class SettingsDialog(QDialog):
 def _is_http_url(url: str) -> bool:
     parsed_url = urlparse(url)
     return parsed_url.scheme in {"http", "https"} and bool(parsed_url.netloc)
-
-
-def _theme_settings_for_character(
-    settings: ThemeSettings,
-    profile: CharacterProfile | None,
-) -> ThemeSettings:
-    saved = settings.normalized()
-    if profile is not None and profile.theme_source == THEME_SOURCE_PACKAGE:
-        # 角色包主题只贡献配色；visual_effect_mode 是用户级偏好
-        # （character.json 不存储该键），沿用已保存的视觉效果。
-        theme = (profile.theme_settings or DEFAULT_THEME_SETTINGS).normalized()
-        return replace(theme, visual_effect_mode=saved.visual_effect_mode)
-    return saved
 
 
 def _default_tts_api_url(provider: str) -> str:

--- a/app/ui/theme.py
+++ b/app/ui/theme.py
@@ -234,6 +234,11 @@ def build_pet_window_stylesheet(settings: ThemeSettings) -> str:
     background: transparent;
     border: none;
 }}
+#inputBar[visualEffectMode="solid"] {{
+    background: {rgba(theme.bubble_background_color, 238)};
+    border: 1px solid {rgba(theme.border_color, 170)};
+    border-radius: 22px;
+}}
 #petInput {{
     background: {rgba(theme.input_background_color, 55)};
     border: 1px solid rgba(255, 255, 255, 218);
@@ -244,8 +249,16 @@ def build_pet_window_stylesheet(settings: ThemeSettings) -> str:
     padding: 3px 16px;
     selection-background-color: {rgba(theme.primary_color, 92)};
 }}
+#petInput[visualEffectMode="solid"] {{
+    background: {rgba(theme.input_background_color, 235)};
+    border: 1px solid {rgba(theme.border_color, 148)};
+}}
 #petInput:focus {{
     background: {rgba(theme.input_background_color, 90)};
+    border: 1px solid {rgba(theme.primary_color, 210)};
+}}
+#petInput[visualEffectMode="solid"]:focus {{
+    background: {theme.input_background_color};
     border: 1px solid {rgba(theme.primary_color, 210)};
 }}
 #petInput:disabled {{

--- a/app/ui/theme.py
+++ b/app/ui/theme.py
@@ -32,9 +32,6 @@ THEME_COLOR_FIELDS: tuple[tuple[str, str, str], ...] = (
     ("bubble_background_color", "气泡背景色", DEFAULT_BUBBLE_BACKGROUND_COLOR),
     ("border_color", "边框色", DEFAULT_BORDER_COLOR),
 )
-SETTINGS_COMBO_POPUP_CONTAINER_OBJECT_NAME = "settingsComboPopupContainer"
-SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME = "settingsComboPopupView"
-
 _HEX_COLOR_RE = re.compile(r"^#[0-9a-fA-F]{6}$")
 
 
@@ -465,6 +462,7 @@ QLineEdit[readOnly="true"] {{
     selection-background-color: transparent;
 }}
 QComboBox {{
+    combobox-popup: 0;
     padding: 6px 30px 6px 8px;
 }}
 QComboBox::drop-down {{
@@ -488,24 +486,9 @@ QComboBox::down-arrow {{
     width: 12px;
     height: 12px;
 }}
-QComboBoxPrivateContainer {{
-    background: transparent;
-    border: none;
-    padding: 0;
-    margin: 0;
-}}
-QFrame#{SETTINGS_COMBO_POPUP_CONTAINER_OBJECT_NAME} {{
+QComboBox QAbstractItemView {{
     background: {rgba(theme.input_background_color, 246)};
-    border: none;
-    border-radius: 7px;
-    padding: 2px;
-}}
-QComboBox QAbstractItemView,
-QAbstractItemView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME},
-QListView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME},
-QListWidget#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME} {{
-    background: {rgba(theme.input_background_color, 246)};
-    border: none;
+    border: 1px solid {rgba(theme.border_color, 158)};
     border-radius: 7px;
     color: {theme.text_color};
     font-size: 14px;
@@ -514,43 +497,17 @@ QListWidget#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME} {{
     selection-background-color: {rgba(theme.panel_background_color, 220)};
     selection-color: {theme.text_color};
 }}
-QFrame#{SETTINGS_COMBO_POPUP_CONTAINER_OBJECT_NAME} QListWidget#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME} {{
-    background: transparent;
-}}
-QAbstractItemView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME} QWidget#qt_scrollarea_viewport,
-QListView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME} QWidget#qt_scrollarea_viewport,
-QListWidget#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME} QWidget#qt_scrollarea_viewport {{
-    background: {rgba(theme.input_background_color, 246)};
-}}
-QFrame#{SETTINGS_COMBO_POPUP_CONTAINER_OBJECT_NAME} QListWidget#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME} QWidget#qt_scrollarea_viewport {{
-    background: transparent;
-}}
-QComboBox QAbstractItemView::item,
-QAbstractItemView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item,
-QListView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item,
-QListWidget#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item {{
+QComboBox QAbstractItemView::item {{
     min-height: 22px;
     padding: 3px 8px;
     border-radius: 5px;
 }}
-QComboBox QAbstractItemView::item:hover,
-QAbstractItemView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:hover,
-QListView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:hover,
-QListWidget#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:hover {{
+QComboBox QAbstractItemView::item:hover {{
     background: {rgba(theme.panel_background_color, 185)};
 }}
 QComboBox QAbstractItemView::item:selected,
 QComboBox QAbstractItemView::item:selected:active,
-QComboBox QAbstractItemView::item:selected:!active,
-QAbstractItemView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected,
-QAbstractItemView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected:active,
-QAbstractItemView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected:!active,
-QListView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected,
-QListView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected:active,
-QListView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected:!active,
-QListWidget#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected,
-QListWidget#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected:active,
-QListWidget#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected:!active {{
+QComboBox QAbstractItemView::item:selected:!active {{
     background: {rgba(theme.primary_color, 43)};
     color: {theme.text_color};
 }}
@@ -643,11 +600,7 @@ QPushButton:disabled {{
 
 
 def build_app_chrome_stylesheet(settings: ThemeSettings) -> str:
-    """全局应用级样式：美化下拉弹窗(QComboBox 弹出列表)与滚动条。
-
-    这些控件的弹出/绘制是独立顶层，对话框级 setStyleSheet 传播不到；且 main.py 用 Fusion 风格
-    后系统原生外观失效。所以必须在 QApplication 级统一设置，才能让它们跟随主题。
-    """
+    """全局应用级样式：美化滚动条与菜单等独立顶层控件。"""
     theme = settings.normalized()
     return f"""
 QScrollBar:vertical {{
@@ -714,71 +667,6 @@ QMenu::separator {{
     height: 1px;
     background: {rgba(theme.border_color, 105)};
     margin: 3px 7px;
-}}
-QComboBoxPrivateContainer {{
-    background: transparent;
-    border: none;
-    padding: 0;
-    margin: 0;
-}}
-QFrame#{SETTINGS_COMBO_POPUP_CONTAINER_OBJECT_NAME} {{
-    background: {rgba(theme.input_background_color, 246)};
-    border: none;
-    border-radius: 7px;
-    padding: 2px;
-}}
-QComboBox QAbstractItemView,
-QAbstractItemView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME},
-QListView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME},
-QListWidget#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME} {{
-    background: {rgba(theme.input_background_color, 246)};
-    border: none;
-    border-radius: 7px;
-    color: {theme.text_color};
-    outline: 0;
-    padding: 2px;
-    selection-background-color: {rgba(theme.panel_background_color, 220)};
-    selection-color: {theme.text_color};
-}}
-QFrame#{SETTINGS_COMBO_POPUP_CONTAINER_OBJECT_NAME} QListWidget#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME} {{
-    background: transparent;
-}}
-QAbstractItemView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME} QWidget#qt_scrollarea_viewport,
-QListView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME} QWidget#qt_scrollarea_viewport,
-QListWidget#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME} QWidget#qt_scrollarea_viewport {{
-    background: {rgba(theme.input_background_color, 246)};
-}}
-QFrame#{SETTINGS_COMBO_POPUP_CONTAINER_OBJECT_NAME} QListWidget#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME} QWidget#qt_scrollarea_viewport {{
-    background: transparent;
-}}
-QComboBox QAbstractItemView::item,
-QAbstractItemView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item,
-QListView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item,
-QListWidget#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item {{
-    min-height: 22px;
-    padding: 3px 8px;
-    border-radius: 5px;
-}}
-QComboBox QAbstractItemView::item:hover,
-QAbstractItemView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:hover,
-QListView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:hover,
-QListWidget#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:hover {{
-    background: {rgba(theme.panel_background_color, 185)};
-}}
-QComboBox QAbstractItemView::item:selected,
-QComboBox QAbstractItemView::item:selected:active,
-QComboBox QAbstractItemView::item:selected:!active,
-QAbstractItemView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected,
-QAbstractItemView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected:active,
-QAbstractItemView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected:!active,
-QListView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected,
-QListView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected:active,
-QListView#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected:!active,
-QListWidget#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected,
-QListWidget#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected:active,
-QListWidget#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}::item:selected:!active {{
-    background: {rgba(theme.primary_color, 70)};
-    color: {theme.text_color};
 }}
 """
 

--- a/app/ui/theme.py
+++ b/app/ui/theme.py
@@ -54,8 +54,11 @@ class ThemeSettings:
     bubble_background_color: str = DEFAULT_BUBBLE_BACKGROUND_COLOR
     border_color: str = DEFAULT_BORDER_COLOR
     ai_enabled: bool = False
+    visual_effect_mode: str = "gaussian_blur"
 
     def normalized(self) -> "ThemeSettings":
+        from app.ui.window_backdrop import VisualEffectMode
+
         return ThemeSettings(
             primary_color=normalize_hex_color(self.primary_color, DEFAULT_PRIMARY_COLOR),
             primary_hover_color=normalize_hex_color(self.primary_hover_color, DEFAULT_PRIMARY_HOVER_COLOR),
@@ -69,6 +72,7 @@ class ThemeSettings:
             bubble_background_color=normalize_hex_color(self.bubble_background_color, DEFAULT_BUBBLE_BACKGROUND_COLOR),
             border_color=normalize_hex_color(self.border_color, DEFAULT_BORDER_COLOR),
             ai_enabled=bool(self.ai_enabled),
+            visual_effect_mode=VisualEffectMode.validate(self.visual_effect_mode),
         )
 
 
@@ -94,18 +98,26 @@ def normalize_hex_color(value: object, default: str) -> str:
 
 
 def theme_from_mapping(data: Any) -> ThemeSettings:
+    from app.ui.window_backdrop import VisualEffectMode
+
     if not isinstance(data, dict):
         return DEFAULT_THEME_SETTINGS
     values = {
         field: normalize_hex_color(data.get(field), default)
         for field, _label, default in THEME_COLOR_FIELDS
     }
-    return ThemeSettings(**values, ai_enabled=_bool_value(data.get("ai_enabled"), False))
+    return ThemeSettings(
+        **values,
+        ai_enabled=_bool_value(data.get("ai_enabled"), False),
+        visual_effect_mode=VisualEffectMode.validate(str(data.get("visual_effect_mode", VisualEffectMode.DEFAULT))),
+    )
 
 
 def theme_to_mapping(settings: ThemeSettings) -> dict[str, object]:
     data = theme_colors_to_mapping(settings)
-    data["ai_enabled"] = bool(settings.normalized().ai_enabled)
+    normalized = settings.normalized()
+    data["ai_enabled"] = bool(normalized.ai_enabled)
+    data["visual_effect_mode"] = normalized.visual_effect_mode
     return data
 
 

--- a/app/ui/theme.py
+++ b/app/ui/theme.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import json
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from app.config.character_loader import CharacterProfile
 
 
 DEFAULT_PRIMARY_COLOR = "#d55b91"
@@ -116,6 +119,28 @@ def theme_to_mapping(settings: ThemeSettings) -> dict[str, object]:
     data["ai_enabled"] = bool(normalized.ai_enabled)
     data["visual_effect_mode"] = normalized.visual_effect_mode
     return data
+
+
+def merge_theme_with_character(
+    saved_settings: ThemeSettings,
+    profile: CharacterProfile | None,
+) -> ThemeSettings:
+    """合并已保存主题与角色包主题，保留用户级偏好字段。
+
+    角色包主题只贡献配色；visual_effect_mode 和 ai_enabled 是用户级偏好
+    （character.json 不序列化这两个字段），始终沿用已保存的值。
+    """
+    from app.config.character_loader import THEME_SOURCE_PACKAGE
+
+    saved = saved_settings.normalized()
+    if profile is not None and profile.theme_source == THEME_SOURCE_PACKAGE:
+        theme = (profile.theme_settings or DEFAULT_THEME_SETTINGS).normalized()
+        return replace(
+            theme,
+            visual_effect_mode=saved.visual_effect_mode,
+            ai_enabled=saved.ai_enabled,
+        )
+    return saved
 
 
 def theme_colors_to_mapping(settings: ThemeSettings) -> dict[str, object]:

--- a/app/ui/window_backdrop.py
+++ b/app/ui/window_backdrop.py
@@ -68,16 +68,28 @@ class MacOSVisualEffectBackdrop:
     PyObjC 内置完整的 Objective-C 类型编码支持，能够正确处理所有 struct 传参。
 
     参照 pyqt-liquidglass (https://github.com/kotikotprojects/pyqt-liquidglass) 方案：
-    1. 用 objc.objc_object 获取 Qt 窗口的 NSView/NSWindow
-    2. 创建 NSVisualEffectView 并添加到 contentView
-    3. 配置窗口透明属性（setOpaque, clearColor, titlebarAppearsTransparent）
-    4. 把 effect view 放在 Qt 内容之下
+
+    **为什么要用 Content Swap 而不是直接改 NSWindow 透明属性？**
+
+    如果直接设置 NSWindow.setOpaque_(False) + setBackgroundColor_(clearColor())，
+    整个窗口的 backing store 进入 ARGB 全透明模式。Qt 在 macOS 上通过 CoreText/Metal
+    渲染文字和控件时，依赖窗口背景做 alpha 混合。背景全透明 → premultiplied alpha
+    全部归零 → 所有内容肉眼不可见（毛玻璃可见，内容消失）。
+
+    Content Swap 方案：
+    1. 创建一个新的透明 NSView 作为容器
+    2. 替换 NSWindow 的 contentView
+    3. 把 Qt 的 root_view 和 NSVisualEffectView 都加入容器
+    4. effect view 放在 root_view 下面（sibling 关系，不是父子）
+    5. 容器自身透明，但 NSWindow 不透明 → Qt 渲染正常
 
     任何调用失败都静默降级到 FallbackTintBackdrop。
     """
 
     def __init__(self) -> None:
         self._effect_view: object | None = None
+        self._container: object | None = None
+        self._original_content_view: object | None = None
         self._fallback = FallbackTintBackdrop()
 
     def apply(self, window: QWidget, tint: QColor) -> None:
@@ -92,57 +104,78 @@ class MacOSVisualEffectBackdrop:
             import objc  # pyobjc-core
             from AppKit import (
                 NSColor,
+                NSView,
                 NSVisualEffectBlendingModeBehindWindow,
-                NSVisualEffectMaterialPopover,
+                NSVisualEffectMaterialUnderWindowBackground,
                 NSVisualEffectStateActive,
                 NSVisualEffectView,
             )
             from Foundation import NSMakeRect
 
-            # 1. 用 PyObjC 获取 Qt 窗口的 NSView
+            # 1. 用 PyObjC 获取 Qt 窗口的 NSView（root_view）
             win_id = int(window.winId())
-            ns_view = objc.objc_object(c_void_p=c_void_p(win_id))
+            root_view = objc.objc_object(c_void_p=c_void_p(win_id))
 
-            # 2. 获取 NSWindow
-            ns_window = ns_view.window()
+            # 2. 获取 NSWindow 和 contentView
+            ns_window = root_view.window()
             if ns_window is None:
                 self._fallback.apply(window, tint)
                 return
 
-            # 3. 获取 contentView
             content_view = ns_window.contentView()
             if content_view is None:
                 self._fallback.apply(window, tint)
                 return
 
-            # 4. 创建 NSVisualEffectView，使用窗口尺寸
+            # ── Content Swap ──
+            # 创建一个新的透明容器，替换 NSWindow 的 contentView，
+            # 然后把 Qt 的 root_view 和 NSVisualEffectView 都加入新容器。
+            from Foundation import NSMakeRect
+
             frame_w = float(window.width())
             frame_h = float(window.height())
-            frame = NSMakeRect(0.0, 0.0, frame_w, frame_h)
+            container_frame = NSMakeRect(0.0, 0.0, frame_w, frame_h)
 
-            effect_view = NSVisualEffectView.alloc().initWithFrame_(frame)
+            container = NSView.alloc().initWithFrame_(container_frame)
+            if container is None:
+                self._fallback.apply(window, tint)
+                return
+
+            container.setAutoresizingMask_(2 | 16)  # NSViewWidthSizable | NSViewHeightSizable
+            container.setWantsLayer_(True)
+
+            # 保存原始 contentView，用于 remove 时恢复
+            self._original_content_view = content_view
+
+            # 替换 contentView
+            ns_window.setContentView_(container)
+
+            # 把 Qt 的 root_view 加入容器（撑满）
+            root_view.setFrame_(container.bounds())
+            root_view.setAutoresizingMask_(2 | 16)
+            container.addSubview_(root_view)
+
+            # ── 创建 NSVisualEffectView ──
+            effect_frame = NSMakeRect(0.0, 0.0, frame_w, frame_h)
+            effect_view = NSVisualEffectView.alloc().initWithFrame_(effect_frame)
             if effect_view is None:
                 self._fallback.apply(window, tint)
                 return
 
-            effect_view.setMaterial_(NSVisualEffectMaterialPopover)
+            # 使用 UnderWindowBackground 材质（窗口背景毛玻璃），
+            # 比 Popover 更适合作为窗口底色。
+            effect_view.setMaterial_(NSVisualEffectMaterialUnderWindowBackground)
             effect_view.setBlendingMode_(NSVisualEffectBlendingModeBehindWindow)
             effect_view.setState_(NSVisualEffectStateActive)
-            effect_view.setAutoresizingMask_(2 | 16)  # NSViewWidthSizable | NSViewHeightSizable
+            effect_view.setAutoresizingMask_(2 | 16)
 
-            # 5. 配置 NSWindow 透明属性（让毛玻璃可以透过窗口显示）
-            ns_window.setOpaque_(False)
-            ns_window.setBackgroundColor_(NSColor.clearColor())
-            ns_window.setTitlebarAppearsTransparent_(True)
-            # 启用全屏内容视图 (NSFullSizeContentViewWindowMask = 1 << 15)
-            current_mask = ns_window.styleMask()
-            ns_window.setStyleMask_(current_mask | (1 << 15))
-
-            # 6. 把 effect view 放在 contentView 最底层（Qt 内容在上面）
-            # NSViewBelow = -1 (NSWindowBelow), 0 = nil
-            content_view.addSubview_positioned_relativeTo_(effect_view, -1, None)
+            # ── 关键：effect view 放在 root_view 下面 ──
+            # 使用 sibling 关系：effect view 是 container 的子视图，排在 root_view 之下。
+            # NSWindowBelow = -1
+            container.addSubview_positioned_relativeTo_(effect_view, -1, root_view)
 
             self._effect_view = effect_view
+            self._container = container
 
         except Exception as exc:  # noqa: BLE001
             debug_log("UI", "macOS NSVisualEffectView 创建失败，降级为半透明", {"error": str(exc)})
@@ -157,6 +190,18 @@ class MacOSVisualEffectBackdrop:
                 pass
             finally:
                 self._effect_view = None
+        # 恢复原始 contentView
+        if self._original_content_view is not None and self._container is not None:
+            try:
+                # 从 container 中找到 NSWindow
+                ns_window = self._container.window()
+                if ns_window is not None:
+                    ns_window.setContentView_(self._original_content_view)
+            except Exception:  # noqa: BLE001
+                pass
+            finally:
+                self._container = None
+                self._original_content_view = None
 
     def supports_native_blur(self) -> bool:
         return True

--- a/app/ui/window_backdrop.py
+++ b/app/ui/window_backdrop.py
@@ -134,6 +134,7 @@ class MacOSVisualEffectBackdrop:
         self._effect_view: object | None = None
         self._container: object | None = None
         self._original_content_view: object | None = None
+        self._root_view: object | None = None  # Qt 的 NSView，remove 时需要重新挂回原始 contentView
         self._fallback = FallbackTintBackdrop()
 
     def apply(self, window: QWidget, tint: QColor) -> None:
@@ -170,6 +171,9 @@ class MacOSVisualEffectBackdrop:
             if content_view is None:
                 self._fallback.apply(window, tint)
                 return
+
+            # 保存 root_view 供 remove 时重新挂回
+            self._root_view = root_view
 
             # ── Content Swap ──
             # 创建一个新的透明容器，替换 NSWindow 的 contentView，
@@ -234,18 +238,24 @@ class MacOSVisualEffectBackdrop:
                 pass
             finally:
                 self._effect_view = None
-        # 恢复原始 contentView
+        # 恢复原始 contentView，并重新挂回 Qt 的 root_view
         if self._original_content_view is not None and self._container is not None:
             try:
-                # 从 container 中找到 NSWindow
                 ns_window = self._container.window()
                 if ns_window is not None:
+                    # 先把 Qt 的 root_view 从容器里移回原始 contentView，
+                    # 否则恢复 contentView 后 root_view 没有 window → 后续
+                    # apply 拿到的 root_view.window() 为 None → 静默降级。
+                    if self._root_view is not None:
+                        self._root_view.removeFromSuperview()  # 从容器移除
+                        self._original_content_view.addSubview_(self._root_view)
                     ns_window.setContentView_(self._original_content_view)
             except Exception:  # noqa: BLE001
                 pass
             finally:
                 self._container = None
                 self._original_content_view = None
+                self._root_view = None
 
     def supports_native_blur(self) -> bool:
         return True

--- a/app/ui/window_backdrop.py
+++ b/app/ui/window_backdrop.py
@@ -200,6 +200,7 @@ class WindowsAcrylicBackdrop:
     _ACCENT_ENABLE_ACRYLICBLURBEHIND = 4
     _ACCENT_DISABLED = 0
     _DWMWA_WINDOW_CORNER_PREFERENCE = 33
+    _DWMWCP_DONOTROUND = 1
     _DWMWCP_ROUND = 2
 
     def __init__(self, *, rounded: bool) -> None:
@@ -216,7 +217,10 @@ class WindowsAcrylicBackdrop:
 
     def remove(self, window: QWidget) -> None:
         try:
-            self._set_accent(int(window.winId()), self._ACCENT_DISABLED, QColor(0, 0, 0, 0))
+            hwnd = int(window.winId())
+            self._set_accent(hwnd, self._ACCENT_DISABLED, QColor(0, 0, 0, 0))
+            if self._rounded:
+                self._set_corner_preference(hwnd, self._DWMWCP_DONOTROUND)
         except Exception as exc:
             debug_log("UI", "Windows 亚克力背景移除失败", {"error": str(exc)})
 
@@ -255,8 +259,11 @@ class WindowsAcrylicBackdrop:
         ctypes.windll.user32.SetWindowCompositionAttribute(hwnd, ctypes.pointer(data))
 
     def _set_round_corners(self, hwnd: int) -> None:
+        self._set_corner_preference(hwnd, self._DWMWCP_ROUND)
+
+    def _set_corner_preference(self, hwnd: int, preference_value: int) -> None:
         import ctypes
-        preference = ctypes.c_int(self._DWMWCP_ROUND)
+        preference = ctypes.c_int(preference_value)
         ctypes.windll.dwmapi.DwmSetWindowAttribute(
             hwnd, self._DWMWA_WINDOW_CORNER_PREFERENCE,
             ctypes.byref(preference), ctypes.sizeof(preference),

--- a/app/ui/window_backdrop.py
+++ b/app/ui/window_backdrop.py
@@ -150,7 +150,6 @@ class MacOSVisualEffectBackdrop:
 
             import objc  # pyobjc-core
             from AppKit import (
-                NSColor,
                 NSView,
                 NSVisualEffectBlendingModeBehindWindow,
                 NSVisualEffectMaterialUnderWindowBackground,
@@ -180,8 +179,6 @@ class MacOSVisualEffectBackdrop:
             # ── Content Swap ──
             # 创建一个新的透明容器，替换 NSWindow 的 contentView，
             # 然后把 Qt 的 root_view 和 NSVisualEffectView 都加入新容器。
-            from Foundation import NSMakeRect
-
             frame_w = float(window.width())
             frame_h = float(window.height())
             container_frame = NSMakeRect(0.0, 0.0, frame_w, frame_h)
@@ -233,28 +230,27 @@ class MacOSVisualEffectBackdrop:
 
     def remove(self, window: QWidget) -> None:
         del window
+        # 移除 effect view
         if self._effect_view is not None:
             try:
                 self._effect_view.removeFromSuperview()
             except Exception:  # noqa: BLE001
                 pass
-            finally:
-                self._effect_view = None
-        # 恢复原始 contentView，并重新挂回 Qt 的 root_view
+        # 恢复原始 contentView（将 root_view 从容器移回）
         try:
             if self._container is not None and self._original_content_view is not None:
                 ns_window = self._container.window()
-                if ns_window is not None:
-                    if self._root_view is not None:
-                        self._root_view.removeFromSuperview()
-                        self._original_content_view.addSubview_(self._root_view)
+                if ns_window is not None and self._root_view is not None:
+                    self._root_view.removeFromSuperview()
+                    self._original_content_view.addSubview_(self._root_view)
                     ns_window.setContentView_(self._original_content_view)
         except Exception:  # noqa: BLE001
             pass
-        finally:
-            self._container = None
-            self._original_content_view = None
-            self._root_view = None
+        # 始终清空所有状态
+        self._effect_view = None
+        self._container = None
+        self._original_content_view = None
+        self._root_view = None
 
     def supports_native_blur(self) -> bool:
         return True

--- a/app/ui/window_backdrop.py
+++ b/app/ui/window_backdrop.py
@@ -103,7 +103,8 @@ class MacOSVisualEffectBackdrop:
 
     _MATERIAL = 13  # NSVisualEffectMaterialHUDWindow — 显著的暗色毛玻璃
     _BLENDING = 0   # NSVisualEffectBlendingModeBehindWindow
-    _STATE = 0      # NSVisualEffectStateActive
+    _STATE = 1      # NSVisualEffectStateActive — 强制始终 active；0 是 FollowsWindowActiveState，
+                    # 会在窗口非 key 时渲染为扁平灰白色（不采样背景模糊）
     _NS_WINDOW_BELOW = -1
 
     def __init__(self) -> None:

--- a/app/ui/window_backdrop.py
+++ b/app/ui/window_backdrop.py
@@ -241,23 +241,20 @@ class MacOSVisualEffectBackdrop:
             finally:
                 self._effect_view = None
         # 恢复原始 contentView，并重新挂回 Qt 的 root_view
-        if self._original_content_view is not None and self._container is not None:
-            try:
+        try:
+            if self._container is not None and self._original_content_view is not None:
                 ns_window = self._container.window()
                 if ns_window is not None:
-                    # 先把 Qt 的 root_view 从容器里移回原始 contentView，
-                    # 否则恢复 contentView 后 root_view 没有 window → 后续
-                    # apply 拿到的 root_view.window() 为 None → 静默降级。
                     if self._root_view is not None:
-                        self._root_view.removeFromSuperview()  # 从容器移除
+                        self._root_view.removeFromSuperview()
                         self._original_content_view.addSubview_(self._root_view)
                     ns_window.setContentView_(self._original_content_view)
-            except Exception:  # noqa: BLE001
-                pass
-            finally:
-                self._container = None
-                self._original_content_view = None
-                self._root_view = None
+        except Exception:  # noqa: BLE001
+            pass
+        finally:
+            self._container = None
+            self._original_content_view = None
+            self._root_view = None
 
     def supports_native_blur(self) -> bool:
         return True

--- a/app/ui/window_backdrop.py
+++ b/app/ui/window_backdrop.py
@@ -24,15 +24,59 @@ class WindowBackdrop(Protocol):
     def supports_native_blur(self) -> bool: ...
 
 
-def create_window_backdrop() -> WindowBackdrop:
-    """按当前平台与系统版本探测，返回最合适的背景模糊实现。"""
-    if sys.platform == "win32":
+class VisualEffectMode:
+    """输入框/卡片窗口的视觉效果模式。"""
+
+    SOLID = "solid"
+    GAUSSIAN_BLUR = "gaussian_blur"
+    WINDOWS_ACRYLIC = "windows_acrylic"
+    MACOS_VISUAL_EFFECT = "macos_visual_effect"
+
+    _ALL = (SOLID, GAUSSIAN_BLUR, WINDOWS_ACRYLIC, MACOS_VISUAL_EFFECT)
+    DEFAULT = GAUSSIAN_BLUR
+
+    @classmethod
+    def available_modes(cls) -> list[str]:
+        """当前平台可用的模式列表。"""
+        modes = [cls.SOLID, cls.GAUSSIAN_BLUR]
+        if sys.platform == "win32" and _windows_build() >= 17134:
+            modes.append(cls.WINDOWS_ACRYLIC)
+        if sys.platform == "darwin":
+            modes.append(cls.MACOS_VISUAL_EFFECT)
+        return modes
+
+    @classmethod
+    def validate(cls, value: str) -> str:
+        if value in cls._ALL:
+            return value
+        return cls.DEFAULT
+
+
+def create_window_backdrop(mode: str | None = None) -> WindowBackdrop:
+    """按指定模式（或平台探测）返回最合适的背景实现。
+
+    mode 为空时走平台自动探测（旧行为，保持兼容）。
+    """
+    if mode is None:
+        # 平台自动探测：mac → VisualEffect, win → Acrylic, 其他 → Fallback
+        if sys.platform == "win32":
+            build = _windows_build()
+            if build >= 17134:
+                return WindowsAcrylicBackdrop(rounded=build >= 22000)
+        if sys.platform == "darwin":
+            return MacOSVisualEffectBackdrop()
+        return FallbackTintBackdrop()
+
+    mode = VisualEffectMode.validate(mode)
+    if mode == VisualEffectMode.SOLID:
+        return FallbackTintBackdrop()
+    if mode == VisualEffectMode.GAUSSIAN_BLUR:
+        return SoftwareBlurBackdrop()
+    if mode == VisualEffectMode.WINDOWS_ACRYLIC:
         build = _windows_build()
-        if build >= 17134:  # Windows 10 1803+ 起支持亚克力
-            return WindowsAcrylicBackdrop(rounded=build >= 22000)
-    if sys.platform == "darwin":
-        return MacOSVisualEffectBackdrop()
-    # Linux/旧 Windows 降级占位
+        return WindowsAcrylicBackdrop(rounded=build >= 22000) if build >= 17134 else FallbackTintBackdrop()
+    if mode == VisualEffectMode.MACOS_VISUAL_EFFECT:
+        return MacOSVisualEffectBackdrop() if sys.platform == "darwin" else FallbackTintBackdrop()
     return FallbackTintBackdrop()
 
 

--- a/app/ui/window_backdrop.py
+++ b/app/ui/window_backdrop.py
@@ -11,11 +11,7 @@ from app.core.debug_log import debug_log
 
 @runtime_checkable
 class WindowBackdrop(Protocol):
-    """跨平台窗口背景模糊能力接口。
-
-    apply 把系统级背景模糊（如 Windows 亚克力）施加到一个**已显示**的顶层窗口，
-    让窗口透明区透出并模糊背后的真实桌面。不支持的平台用降级实现，保证调用统一、不报错。
-    """
+    """跨平台窗口背景模糊能力接口。"""
 
     def apply(self, window: QWidget, tint: QColor) -> None: ...
 
@@ -23,6 +19,8 @@ class WindowBackdrop(Protocol):
 
     def supports_native_blur(self) -> bool: ...
 
+
+# ── 视觉效果模式枚举 ────────────────────────────────────────────────
 
 class VisualEffectMode:
     """输入框/卡片窗口的视觉效果模式。"""
@@ -37,7 +35,6 @@ class VisualEffectMode:
 
     @classmethod
     def available_modes(cls) -> list[str]:
-        """当前平台可用的模式列表。"""
         modes = [cls.SOLID, cls.GAUSSIAN_BLUR]
         if sys.platform == "win32" and _windows_build() >= 17134:
             modes.append(cls.WINDOWS_ACRYLIC)
@@ -47,18 +44,13 @@ class VisualEffectMode:
 
     @classmethod
     def validate(cls, value: str) -> str:
-        if value in cls._ALL:
-            return value
-        return cls.DEFAULT
+        return value if value in cls._ALL else cls.DEFAULT
 
+
+# ── 工厂 ─────────────────────────────────────────────────────────────
 
 def create_window_backdrop(mode: str | None = None) -> WindowBackdrop:
-    """按指定模式（或平台探测）返回最合适的背景实现。
-
-    mode 为空时走平台自动探测（旧行为，保持兼容）。
-    """
     if mode is None:
-        # 平台自动探测：mac → VisualEffect, win → Acrylic, 其他 → Fallback
         if sys.platform == "win32":
             build = _windows_build()
             if build >= 17134:
@@ -87,200 +79,113 @@ def _windows_build() -> int:
         return 0
 
 
-class FallbackTintBackdrop:
-    """无系统级模糊的平台（Mac/Linux/旧 Windows）降级占位。
+# ── 实现 ──────────────────────────────────────────────────────────────
 
-    不做真模糊：卡片自身的半透明 QSS 背景即降级效果，这里只作为接口占位，
-    apply/remove 为空操作，保证上层调用统一、不报错。
-    """
+class FallbackTintBackdrop:
+    """无系统级模糊的平台降级：apply/remove 为空操作。"""
 
     def apply(self, window: QWidget, tint: QColor) -> None:
-        del window, tint
+        pass
 
     def remove(self, window: QWidget) -> None:
-        del window
+        pass
 
     def supports_native_blur(self) -> bool:
         return False
 
 
 class MacOSVisualEffectBackdrop:
-    """macOS 原生 NSVisualEffectView 毛玻璃背景。
+    """macOS 原生毛玻璃（NSVisualEffectView with HUDWindow material）。
 
-    使用 PyObjC 桥接 AppKit（而非 ctypes），因为 ctypes 在 arm64 上无法正确按值
-    传递 NSRect（HFA-4）等 AppKit struct 给 objc_msgSend。
-    PyObjC 内置完整的 Objective-C 类型编码支持，能够正确处理所有 struct 传参。
-
-    参照 pyqt-liquidglass (https://github.com/kotikotprojects/pyqt-liquidglass) 方案：
-
-    **为什么要用 Content Swap 而不是直接改 NSWindow 透明属性？**
-
-    如果直接设置 NSWindow.setOpaque_(False) + setBackgroundColor_(clearColor())，
-    整个窗口的 backing store 进入 ARGB 全透明模式。Qt 在 macOS 上通过 CoreText/Metal
-    渲染文字和控件时，依赖窗口背景做 alpha 混合。背景全透明 → premultiplied alpha
-    全部归零 → 所有内容肉眼不可见（毛玻璃可见，内容消失）。
-
-    Content Swap 方案：
-    1. 创建一个新的透明 NSView 作为容器
-    2. 替换 NSWindow 的 contentView
-    3. 把 Qt 的 root_view 和 NSVisualEffectView 都加入容器
-    4. effect view 放在 root_view 下面（sibling 关系，不是父子）
-    5. 容器自身透明，但 NSWindow 不透明 → Qt 渲染正常
-
-    任何调用失败都静默降级到 FallbackTintBackdrop。
+    直接将 NSVisualEffectView 添加到 NSWindow.contentView 最底层。
+    使用 HUDWindow 材质提供显著可见的暗色毛玻璃效果。
     """
+
+    _MATERIAL = 13  # NSVisualEffectMaterialHUDWindow — 显著的暗色毛玻璃
+    _BLENDING = 0   # NSVisualEffectBlendingModeBehindWindow
+    _STATE = 0      # NSVisualEffectStateActive
+    _NS_WINDOW_BELOW = -1
 
     def __init__(self) -> None:
         self._effect_view: object | None = None
-        self._container: object | None = None
-        self._original_content_view: object | None = None
-        self._root_view: object | None = None  # Qt 的 NSView，remove 时需要重新挂回原始 contentView
         self._fallback = FallbackTintBackdrop()
 
     def apply(self, window: QWidget, tint: QColor) -> None:
         if sys.platform != "darwin":
             return
-        # 幂等：已创建过就不再重复添加。
-        # 注意：_refresh_input_blur_background 在非高斯模糊模式时不会 hide 窗口，
-        # 因此 effect view 不会因 Qt hide/show 而被意外销毁。
         if self._effect_view is not None:
             return
         try:
             from ctypes import c_void_p
 
-            import objc  # pyobjc-core
-            from AppKit import (
-                NSView,
-                NSVisualEffectBlendingModeBehindWindow,
-                NSVisualEffectMaterialUnderWindowBackground,
-                NSVisualEffectStateActive,
-                NSVisualEffectView,
-            )
+            import objc
+            from AppKit import NSVisualEffectView
             from Foundation import NSMakeRect
 
-            # 1. 用 PyObjC 获取 Qt 窗口的 NSView（root_view）
             win_id = int(window.winId())
             root_view = objc.objc_object(c_void_p=c_void_p(win_id))
-
-            # 2. 获取 NSWindow 和 contentView
             ns_window = root_view.window()
             if ns_window is None:
                 self._fallback.apply(window, tint)
                 return
-
             content_view = ns_window.contentView()
             if content_view is None:
                 self._fallback.apply(window, tint)
                 return
 
-            # 保存 root_view 供 remove 时重新挂回
-            self._root_view = root_view
-
-            # ── Content Swap ──
-            # 创建一个新的透明容器，替换 NSWindow 的 contentView，
-            # 然后把 Qt 的 root_view 和 NSVisualEffectView 都加入新容器。
-            frame_w = float(window.width())
-            frame_h = float(window.height())
-            container_frame = NSMakeRect(0.0, 0.0, frame_w, frame_h)
-
-            container = NSView.alloc().initWithFrame_(container_frame)
-            if container is None:
-                self._fallback.apply(window, tint)
-                return
-
-            container.setAutoresizingMask_(2 | 16)  # NSViewWidthSizable | NSViewHeightSizable
-            container.setWantsLayer_(True)
-
-            # 保存原始 contentView，用于 remove 时恢复
-            self._original_content_view = content_view
-
-            # 替换 contentView
-            ns_window.setContentView_(container)
-
-            # 把 Qt 的 root_view 加入容器（撑满）
-            root_view.setFrame_(container.bounds())
-            root_view.setAutoresizingMask_(2 | 16)
-            container.addSubview_(root_view)
-
-            # ── 创建 NSVisualEffectView ──
-            effect_frame = NSMakeRect(0.0, 0.0, frame_w, frame_h)
-            effect_view = NSVisualEffectView.alloc().initWithFrame_(effect_frame)
+            frame = NSMakeRect(0, 0, float(window.width()), float(window.height()))
+            effect_view = NSVisualEffectView.alloc().initWithFrame_(frame)
             if effect_view is None:
                 self._fallback.apply(window, tint)
                 return
 
-            # 使用 UnderWindowBackground 材质（窗口背景毛玻璃），
-            # 比 Popover 更适合作为窗口底色。
-            effect_view.setMaterial_(NSVisualEffectMaterialUnderWindowBackground)
-            effect_view.setBlendingMode_(NSVisualEffectBlendingModeBehindWindow)
-            effect_view.setState_(NSVisualEffectStateActive)
+            effect_view.setMaterial_(self._MATERIAL)
+            effect_view.setBlendingMode_(self._BLENDING)
+            effect_view.setState_(self._STATE)
             effect_view.setAutoresizingMask_(2 | 16)
+            effect_view.setWantsLayer_(True)
 
-            # ── 关键：effect view 放在 root_view 下面 ──
-            # 使用 sibling 关系：effect view 是 container 的子视图，排在 root_view 之下。
-            # NSWindowBelow = -1
-            container.addSubview_positioned_relativeTo_(effect_view, -1, root_view)
+            # 直接添加到 contentView 最底层
+            content_view.addSubview_positioned_relativeTo_(
+                effect_view, self._NS_WINDOW_BELOW, None,
+            )
 
             self._effect_view = effect_view
-            self._container = container
 
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             debug_log("UI", "macOS NSVisualEffectView 创建失败，降级为半透明", {"error": str(exc)})
             self._fallback.apply(window, tint)
 
     def remove(self, window: QWidget) -> None:
-        del window
-        # 移除 effect view
         if self._effect_view is not None:
             try:
                 self._effect_view.removeFromSuperview()
-            except Exception:  # noqa: BLE001
+            except Exception:
                 pass
-        # 恢复原始 contentView（将 root_view 从容器移回）
-        try:
-            if self._container is not None and self._original_content_view is not None:
-                ns_window = self._container.window()
-                if ns_window is not None and self._root_view is not None:
-                    self._root_view.removeFromSuperview()
-                    self._original_content_view.addSubview_(self._root_view)
-                    ns_window.setContentView_(self._original_content_view)
-        except Exception:  # noqa: BLE001
-            pass
-        # 始终清空所有状态
         self._effect_view = None
-        self._container = None
-        self._original_content_view = None
-        self._root_view = None
 
     def supports_native_blur(self) -> bool:
         return True
 
 
 class SoftwareBlurBackdrop:
-    """软件截图模糊背景标记：不施加任何系统级模糊。
+    """软件截图模糊标记：不施加任何系统级模糊。
 
-    输入栏改用软件自截图 + 高斯模糊 + 自绘大圆角（见 app/ui/input_blur_background.py），
-    DWM 亚克力是窗口级合成、做不出大圆角，故这里把窗口从亚克力路径摘下：apply/remove 均为空操作，
-    圆角与背景完全由 InputBlurBackground 负责。supports_native_blur 返回 False（它是静态截图，非实时）。
+    apply/remove 均为空操作。圆角与背景完全由 InputBlurBackground 负责。
     """
 
     def apply(self, window: QWidget, tint: QColor) -> None:
-        del window, tint
+        pass
 
     def remove(self, window: QWidget) -> None:
-        del window
+        pass
 
     def supports_native_blur(self) -> bool:
         return False
 
 
 class WindowsAcrylicBackdrop:
-    """Windows 亚克力背景模糊（DWM 合成器实时模糊窗口背后的真实桌面）。
-
-    主路径：user32.SetWindowCompositionAttribute + ACCENT_ENABLE_ACRYLICBLURBEHIND，
-    Win10 1803+ / Win11 通用；Win11 额外用 DwmSetWindowAttribute 设原生圆角。
-    任何调用失败都静默降级（不影响窗口正常显示）。
-    """
+    """Windows 亚克力背景模糊（DWM 合成器实时模糊）。"""
 
     _WCA_ACCENT_POLICY = 19
     _ACCENT_ENABLE_ACRYLICBLURBEHIND = 4
@@ -292,20 +197,18 @@ class WindowsAcrylicBackdrop:
         self._rounded = rounded
 
     def apply(self, window: QWidget, tint: QColor) -> None:
-        # 亚克力是 DWM 窗口级合成，无视 Qt setMask/SetWindowRgn，圆角只能交给 DWM 原生圆角。
         try:
             hwnd = int(window.winId())
             self._set_accent(hwnd, self._ACCENT_ENABLE_ACRYLICBLURBEHIND, tint)
             if self._rounded:
                 self._set_round_corners(hwnd)
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             debug_log("UI", "Windows 亚克力背景应用失败，降级为半透明", {"error": str(exc)})
 
     def remove(self, window: QWidget) -> None:
         try:
-            hwnd = int(window.winId())
-            self._set_accent(hwnd, self._ACCENT_DISABLED, QColor(0, 0, 0, 0))
-        except Exception as exc:  # noqa: BLE001
+            self._set_accent(int(window.winId()), self._ACCENT_DISABLED, QColor(0, 0, 0, 0))
+        except Exception as exc:
             debug_log("UI", "Windows 亚克力背景移除失败", {"error": str(exc)})
 
     def supports_native_blur(self) -> bool:
@@ -344,18 +247,14 @@ class WindowsAcrylicBackdrop:
 
     def _set_round_corners(self, hwnd: int) -> None:
         import ctypes
-
         preference = ctypes.c_int(self._DWMWCP_ROUND)
         ctypes.windll.dwmapi.DwmSetWindowAttribute(
-            hwnd,
-            self._DWMWA_WINDOW_CORNER_PREFERENCE,
-            ctypes.byref(preference),
-            ctypes.sizeof(preference),
+            hwnd, self._DWMWA_WINDOW_CORNER_PREFERENCE,
+            ctypes.byref(preference), ctypes.sizeof(preference),
         )
 
 
 def _gradient_color(tint: QColor) -> int:
-    """QColor → 亚克力 GradientColor 的 0xAABBGGRR 整数（磨砂底色 + alpha）。"""
     return (
         (tint.alpha() << 24)
         | (tint.blue() << 16)

--- a/app/ui/window_backdrop.py
+++ b/app/ui/window_backdrop.py
@@ -65,6 +65,10 @@ class MacOSVisualEffectBackdrop:
 
     通过 ctypes 调用 Objective-C runtime 创建 NSVisualEffectView 并添加到窗口内容视图。
     material 使用 Popover（弹出窗口风格），blendingMode 使用 BehindWindow（模糊窗口后方内容）。
+
+    注意：arm64 macOS 上 NSRect 是 HFA-4（4×double），ctypes 不支持 HFA 调用约定，
+    传 NSRect struct 给 objc_msgSend 会被错误地当作指针传递。
+    因此这里使用 init（无参）+ NSLayoutConstraint 固定四边来避免任何 NSRect 传参。
     任何调用失败都静默降级到 FallbackTintBackdrop。
     """
 
@@ -78,6 +82,9 @@ class MacOSVisualEffectBackdrop:
 
     def apply(self, window: QWidget, tint: QColor) -> None:
         if sys.platform != "darwin":
+            return
+        # 幂等：已创建过就不再重复添加
+        if self._effect_view is not None:
             return
         try:
             import ctypes
@@ -124,28 +131,18 @@ class MacOSVisualEffectBackdrop:
                 self._fallback.apply(window, tint)
                 return
 
-            # alloc + initWithFrame:
+            # alloc + init（不用 initWithFrame:，因为 NSRect 在 arm64 上是 HFA-4，
+            # ctypes 无法正确按值传递 HFA struct 给 objc_msgSend）
             alloc = msg_send(ns_visual_effect_class, "alloc")
-            # 使用窗口的 bounds 作为 frame
-            bounds = msg_send(ctypes.c_void_p(content_view), "bounds")
-            # bounds 是 NSRect (struct)，需要特殊处理
-            # 简化：使用 initWithFrame:NSZeroRect，然后 setAutoresizingMask
-            zero_rect = (ctypes.c_double * 4)(0, 0, 0, 0)
-            objc.objc_msgSend.restype = ctypes.c_void_p
-            objc.objc_msgSend.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p]
-            effect_view = objc.objc_msgSend(
-                alloc,
-                objc.sel_registerName(b"initWithFrame:"),
-                zero_rect,
-            )
+            effect_view = msg_send(alloc, "init")
             if not effect_view:
                 self._fallback.apply(window, tint)
                 return
 
             self._effect_view = ctypes.c_void_p(effect_view)
 
-            # setAutoresizingMask: NSViewWidthSizable | NSViewHeightSizable
-            msg_send(self._effect_view, "setAutoresizingMask:", ctypes.c_ulong(2 | 16))
+            # 关闭 autoresizing mask，改用 NSLayoutConstraint 固定四边
+            msg_send(self._effect_view, "setTranslatesAutoresizingMaskIntoConstraints:", ctypes.c_bool(False))
 
             # setMaterial: NSVisualEffectMaterialPopover
             msg_send(
@@ -171,7 +168,44 @@ class MacOSVisualEffectBackdrop:
             # addSubview: 添加到 contentView
             msg_send(ctypes.c_void_p(content_view), "addSubview:", self._effect_view)
 
-            # 确保 effect view 在最底层（其他内容在上）
+            # ── NSLayoutConstraint 固定四边 ──
+            # 所有参数都是 c_void_p / c_long，无 NSRect/NSSize/NSPoint struct 传参。
+            constraint_class = objc.objc_getClass(b"NSLayoutConstraint")
+            if constraint_class:
+                ev = self._effect_view
+                cv = ctypes.c_void_p(content_view)
+                c_long = ctypes.c_long
+
+                # 创建四条 edge 约束: effectView.edge = contentView.edge
+                constraints = []
+                for attr in (1, 2, 3, 4):  # Leading, Trailing, Top, Bottom
+                    c = msg_send(
+                        constraint_class,
+                        "constraintWithItem:attribute:relatedBy:toItem:attribute:multiplier:constant:",
+                        ev, c_long(attr), c_long(0), cv, c_long(attr), ctypes.c_double(1.0), ctypes.c_double(0.0),
+                    )
+                    if c:
+                        constraints.append(c)
+
+                if constraints:
+                    # NSArray arrayWithObjects:count: — 纯标量参数，arm64 安全
+                    n = len(constraints)
+                    ArrT = ctypes.c_void_p * n
+                    arr = ArrT(*constraints)
+                    arr_ptr = ctypes.cast(arr, ctypes.c_void_p)
+                    ns_array = msg_send(
+                        objc.objc_getClass(b"NSArray"),
+                        "arrayWithObjects:count:",
+                        arr_ptr, ctypes.c_ulong(n),
+                    )
+                    if ns_array:
+                        msg_send(
+                            constraint_class,
+                            "activateConstraints:",
+                            ctypes.c_void_p(ns_array),
+                        )
+
+            # 确保 effect view 启用 layer
             msg_send(self._effect_view, "setWantsLayer:", ctypes.c_bool(True))
 
         except Exception as exc:  # noqa: BLE001

--- a/app/ui/window_backdrop.py
+++ b/app/ui/window_backdrop.py
@@ -30,7 +30,9 @@ def create_window_backdrop() -> WindowBackdrop:
         build = _windows_build()
         if build >= 17134:  # Windows 10 1803+ 起支持亚克力
             return WindowsAcrylicBackdrop(rounded=build >= 22000)
-    # Mac/Linux/旧 Windows 本次只做降级占位，原生模糊以后再接。
+    if sys.platform == "darwin":
+        return MacOSVisualEffectBackdrop()
+    # Linux/旧 Windows 降级占位
     return FallbackTintBackdrop()
 
 
@@ -56,6 +58,143 @@ class FallbackTintBackdrop:
 
     def supports_native_blur(self) -> bool:
         return False
+
+
+class MacOSVisualEffectBackdrop:
+    """macOS 原生 NSVisualEffectView 毛玻璃背景。
+
+    通过 ctypes 调用 Objective-C runtime 创建 NSVisualEffectView 并添加到窗口内容视图。
+    material 使用 Popover（弹出窗口风格），blendingMode 使用 BehindWindow（模糊窗口后方内容）。
+    任何调用失败都静默降级到 FallbackTintBackdrop。
+    """
+
+    _NS_VISUAL_EFFECT_MATERIAL_POPOVER = 10
+    _NS_VISUAL_EFFECT_BLENDING_BEHIND_WINDOW = 0
+    _NS_VISUAL_EFFECT_STATE_ACTIVE = 0
+
+    def __init__(self) -> None:
+        self._effect_view: object | None = None
+        self._fallback = FallbackTintBackdrop()
+
+    def apply(self, window: QWidget, tint: QColor) -> None:
+        if sys.platform != "darwin":
+            return
+        try:
+            import ctypes
+            import ctypes.util
+
+            objc = ctypes.CDLL(ctypes.util.find_library("objc") or "/usr/lib/libobjc.A.dylib")
+
+            # 设置 objc_msgSend 签名
+            objc.objc_getClass.restype = ctypes.c_void_p
+            objc.objc_getClass.argtypes = [ctypes.c_char_p]
+            objc.sel_registerName.restype = ctypes.c_void_p
+            objc.sel_registerName.argtypes = [ctypes.c_char_p]
+
+            def msg_send(obj, sel_name, *args):
+                sel = objc.sel_registerName(sel_name.encode())
+                if not args:
+                    objc.objc_msgSend.restype = ctypes.c_void_p
+                    objc.objc_msgSend.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+                    return objc.objc_msgSend(obj, sel)
+                else:
+                    argtypes = [ctypes.c_void_p, ctypes.c_void_p] + [type(a) for a in args]
+                    objc.objc_msgSend.restype = ctypes.c_void_p
+                    objc.objc_msgSend.argtypes = argtypes
+                    return objc.objc_msgSend(obj, sel, *args)
+
+            # 获取窗口的 NSWindow
+            win_id = int(window.winId())
+            # Qt 的 winId() 在 macOS 上返回 NSView*，需要获取其 window
+            ns_view = ctypes.c_void_p(win_id)
+            ns_window = msg_send(ns_view, "window")
+            if not ns_window:
+                self._fallback.apply(window, tint)
+                return
+
+            # 获取 contentView
+            content_view = msg_send(ctypes.c_void_p(ns_window), "contentView")
+            if not content_view:
+                self._fallback.apply(window, tint)
+                return
+
+            # 创建 NSVisualEffectView
+            ns_visual_effect_class = objc.objc_getClass(b"NSVisualEffectView")
+            if not ns_visual_effect_class:
+                self._fallback.apply(window, tint)
+                return
+
+            # alloc + initWithFrame:
+            alloc = msg_send(ns_visual_effect_class, "alloc")
+            # 使用窗口的 bounds 作为 frame
+            bounds = msg_send(ctypes.c_void_p(content_view), "bounds")
+            # bounds 是 NSRect (struct)，需要特殊处理
+            # 简化：使用 initWithFrame:NSZeroRect，然后 setAutoresizingMask
+            zero_rect = (ctypes.c_double * 4)(0, 0, 0, 0)
+            objc.objc_msgSend.restype = ctypes.c_void_p
+            objc.objc_msgSend.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p]
+            effect_view = objc.objc_msgSend(
+                alloc,
+                objc.sel_registerName(b"initWithFrame:"),
+                zero_rect,
+            )
+            if not effect_view:
+                self._fallback.apply(window, tint)
+                return
+
+            self._effect_view = ctypes.c_void_p(effect_view)
+
+            # setAutoresizingMask: NSViewWidthSizable | NSViewHeightSizable
+            msg_send(self._effect_view, "setAutoresizingMask:", ctypes.c_ulong(2 | 16))
+
+            # setMaterial: NSVisualEffectMaterialPopover
+            msg_send(
+                self._effect_view,
+                "setMaterial:",
+                ctypes.c_long(self._NS_VISUAL_EFFECT_MATERIAL_POPOVER),
+            )
+
+            # setBlendingMode: NSVisualEffectBlendingModeBehindWindow
+            msg_send(
+                self._effect_view,
+                "setBlendingMode:",
+                ctypes.c_long(self._NS_VISUAL_EFFECT_BLENDING_BEHIND_WINDOW),
+            )
+
+            # setState: NSVisualEffectStateActive
+            msg_send(
+                self._effect_view,
+                "setState:",
+                ctypes.c_long(self._NS_VISUAL_EFFECT_STATE_ACTIVE),
+            )
+
+            # addSubview: 添加到 contentView
+            msg_send(ctypes.c_void_p(content_view), "addSubview:", self._effect_view)
+
+            # 确保 effect view 在最底层（其他内容在上）
+            msg_send(self._effect_view, "setWantsLayer:", ctypes.c_bool(True))
+
+        except Exception as exc:  # noqa: BLE001
+            debug_log("UI", "macOS NSVisualEffectView 创建失败，降级为半透明", {"error": str(exc)})
+            self._fallback.apply(window, tint)
+
+    def remove(self, window: QWidget) -> None:
+        if self._effect_view is not None:
+            try:
+                import ctypes
+                objc = ctypes.CDLL(ctypes.util.find_library("objc") or "/usr/lib/libobjc.A.dylib")
+                objc.sel_registerName.restype = ctypes.c_void_p
+                objc.sel_registerName.argtypes = [ctypes.c_char_p]
+                objc.objc_msgSend.restype = ctypes.c_void_p
+                objc.objc_msgSend.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+                sel = objc.sel_registerName(b"removeFromSuperview")
+                objc.objc_msgSend(self._effect_view, sel)
+                self._effect_view = None
+            except Exception:  # noqa: BLE001
+                pass
+
+    def supports_native_blur(self) -> bool:
+        return sys.platform == "darwin"
 
 
 class SoftwareBlurBackdrop:

--- a/app/ui/window_backdrop.py
+++ b/app/ui/window_backdrop.py
@@ -140,7 +140,9 @@ class MacOSVisualEffectBackdrop:
     def apply(self, window: QWidget, tint: QColor) -> None:
         if sys.platform != "darwin":
             return
-        # 幂等：已创建过就不再重复添加
+        # 幂等：已创建过就不再重复添加。
+        # 注意：_refresh_input_blur_background 在非高斯模糊模式时不会 hide 窗口，
+        # 因此 effect view 不会因 Qt hide/show 而被意外销毁。
         if self._effect_view is not None:
             return
         try:

--- a/app/ui/window_backdrop.py
+++ b/app/ui/window_backdrop.py
@@ -63,18 +63,18 @@ class FallbackTintBackdrop:
 class MacOSVisualEffectBackdrop:
     """macOS 原生 NSVisualEffectView 毛玻璃背景。
 
-    通过 ctypes 调用 Objective-C runtime 创建 NSVisualEffectView 并添加到窗口内容视图。
-    material 使用 Popover（弹出窗口风格），blendingMode 使用 BehindWindow（模糊窗口后方内容）。
+    使用 PyObjC 桥接 AppKit（而非 ctypes），因为 ctypes 在 arm64 上无法正确按值
+    传递 NSRect（HFA-4）等 AppKit struct 给 objc_msgSend。
+    PyObjC 内置完整的 Objective-C 类型编码支持，能够正确处理所有 struct 传参。
 
-    注意：arm64 macOS 上 NSRect 是 HFA-4（4×double），ctypes 不支持 HFA 调用约定，
-    传 NSRect struct 给 objc_msgSend 会被错误地当作指针传递。
-    因此这里使用 init（无参）+ NSLayoutConstraint 固定四边来避免任何 NSRect 传参。
+    参照 pyqt-liquidglass (https://github.com/kotikotprojects/pyqt-liquidglass) 方案：
+    1. 用 objc.objc_object 获取 Qt 窗口的 NSView/NSWindow
+    2. 创建 NSVisualEffectView 并添加到 contentView
+    3. 配置窗口透明属性（setOpaque, clearColor, titlebarAppearsTransparent）
+    4. 把 effect view 放在 Qt 内容之下
+
     任何调用失败都静默降级到 FallbackTintBackdrop。
     """
-
-    _NS_VISUAL_EFFECT_MATERIAL_POPOVER = 10
-    _NS_VISUAL_EFFECT_BLENDING_BEHIND_WINDOW = 0
-    _NS_VISUAL_EFFECT_STATE_ACTIVE = 0
 
     def __init__(self) -> None:
         self._effect_view: object | None = None
@@ -87,149 +87,79 @@ class MacOSVisualEffectBackdrop:
         if self._effect_view is not None:
             return
         try:
-            import ctypes
-            import ctypes.util
+            from ctypes import c_void_p
 
-            objc = ctypes.CDLL(ctypes.util.find_library("objc") or "/usr/lib/libobjc.A.dylib")
+            import objc  # pyobjc-core
+            from AppKit import (
+                NSColor,
+                NSVisualEffectBlendingModeBehindWindow,
+                NSVisualEffectMaterialPopover,
+                NSVisualEffectStateActive,
+                NSVisualEffectView,
+            )
+            from Foundation import NSMakeRect
 
-            # 设置 objc_msgSend 签名
-            objc.objc_getClass.restype = ctypes.c_void_p
-            objc.objc_getClass.argtypes = [ctypes.c_char_p]
-            objc.sel_registerName.restype = ctypes.c_void_p
-            objc.sel_registerName.argtypes = [ctypes.c_char_p]
-
-            # Objective-C runtime: ivar 直接写入（绕过 HFA-4 struct 传参问题）
-            objc.class_getInstanceVariable.restype = ctypes.c_void_p
-            objc.class_getInstanceVariable.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
-            objc.ivar_getOffset.restype = ctypes.c_size_t
-            objc.ivar_getOffset.argtypes = [ctypes.c_void_p]
-
-            def msg_send(obj, sel_name, *args):
-                sel = objc.sel_registerName(sel_name.encode())
-                if not args:
-                    objc.objc_msgSend.restype = ctypes.c_void_p
-                    objc.objc_msgSend.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
-                    return objc.objc_msgSend(obj, sel)
-                else:
-                    argtypes = [ctypes.c_void_p, ctypes.c_void_p] + [type(a) for a in args]
-                    objc.objc_msgSend.restype = ctypes.c_void_p
-                    objc.objc_msgSend.argtypes = argtypes
-                    return objc.objc_msgSend(obj, sel, *args)
-
-            # 获取窗口的 NSWindow
+            # 1. 用 PyObjC 获取 Qt 窗口的 NSView
             win_id = int(window.winId())
-            # Qt 的 winId() 在 macOS 上返回 NSView*，需要获取其 window
-            ns_view = ctypes.c_void_p(win_id)
-            ns_window = msg_send(ns_view, "window")
-            if not ns_window:
+            ns_view = objc.objc_object(c_void_p=c_void_p(win_id))
+
+            # 2. 获取 NSWindow
+            ns_window = ns_view.window()
+            if ns_window is None:
                 self._fallback.apply(window, tint)
                 return
 
-            # 获取 contentView
-            content_view = msg_send(ctypes.c_void_p(ns_window), "contentView")
-            if not content_view:
+            # 3. 获取 contentView
+            content_view = ns_window.contentView()
+            if content_view is None:
                 self._fallback.apply(window, tint)
                 return
 
-            # 创建 NSVisualEffectView
-            ns_visual_effect_class = objc.objc_getClass(b"NSVisualEffectView")
-            if not ns_visual_effect_class:
-                self._fallback.apply(window, tint)
-                return
-
-            # ── alloc + init ──
-            # 不用 initWithFrame:，因为 NSRect 在 arm64 上是 HFA-4（4×double），
-            # ctypes (Python ≤3.12) 不支持 HFA 调用约定，会把数组当指针传，
-            # 导致 NSVisualEffectView 收到垃圾 frame。
-            # 改用 init 创建零 frame，再通过 _frame ivar 直接写入正确尺寸。
-            alloc = msg_send(ns_visual_effect_class, "alloc")
-            effect_view = msg_send(alloc, "init")
-            if not effect_view:
-                self._fallback.apply(window, tint)
-                return
-
-            self._effect_view = ctypes.c_void_p(effect_view)
-
-            # ── 通过 _frame ivar 直接写入 frame（绕过 objc_msgSend 的 HFA-4 限制）──
-            # 从 Qt widget 获取尺寸（纯标量调用，无 struct 传参）
+            # 4. 创建 NSVisualEffectView，使用窗口尺寸
             frame_w = float(window.width())
             frame_h = float(window.height())
+            frame = NSMakeRect(0.0, 0.0, frame_w, frame_h)
 
-            nsview_class = objc.objc_getClass(b"NSView")
-            frame_ivar = objc.class_getInstanceVariable(nsview_class, b"_frame")
-            frame_offset = objc.ivar_getOffset(frame_ivar)
+            effect_view = NSVisualEffectView.alloc().initWithFrame_(frame)
+            if effect_view is None:
+                self._fallback.apply(window, tint)
+                return
 
-            # NSRect = { origin.x, origin.y, size.width, size.height } = 4 doubles
-            # 直接写入对象内存中 _frame ivar 的位置
-            obj_base = ctypes.cast(ctypes.c_void_p(effect_view), ctypes.POINTER(ctypes.c_byte))
-            frame_ptr = ctypes.cast(
-                ctypes.addressof(obj_base.contents) + frame_offset,
-                ctypes.POINTER(ctypes.c_double),
-            )
-            frame_ptr[0] = 0.0  # origin.x
-            frame_ptr[1] = 0.0  # origin.y
-            frame_ptr[2] = frame_w  # size.width
-            frame_ptr[3] = frame_h  # size.height
+            effect_view.setMaterial_(NSVisualEffectMaterialPopover)
+            effect_view.setBlendingMode_(NSVisualEffectBlendingModeBehindWindow)
+            effect_view.setState_(NSVisualEffectStateActive)
+            effect_view.setAutoresizingMask_(2 | 16)  # NSViewWidthSizable | NSViewHeightSizable
 
-            # setAutoresizingMask: NSViewWidthSizable | NSViewHeightizable
-            msg_send(self._effect_view, "setAutoresizingMask:", ctypes.c_ulong(2 | 16))
+            # 5. 配置 NSWindow 透明属性（让毛玻璃可以透过窗口显示）
+            ns_window.setOpaque_(False)
+            ns_window.setBackgroundColor_(NSColor.clearColor())
+            ns_window.setTitlebarAppearsTransparent_(True)
+            # 启用全屏内容视图 (NSFullSizeContentViewWindowMask = 1 << 15)
+            current_mask = ns_window.styleMask()
+            ns_window.setStyleMask_(current_mask | (1 << 15))
 
-            # setMaterial: NSVisualEffectMaterialPopover
-            msg_send(
-                self._effect_view,
-                "setMaterial:",
-                ctypes.c_long(self._NS_VISUAL_EFFECT_MATERIAL_POPOVER),
-            )
+            # 6. 把 effect view 放在 contentView 最底层（Qt 内容在上面）
+            # NSViewBelow = -1 (NSWindowBelow), 0 = nil
+            content_view.addSubview_positioned_relativeTo_(effect_view, -1, None)
 
-            # setBlendingMode: NSVisualEffectBlendingModeBehindWindow
-            msg_send(
-                self._effect_view,
-                "setBlendingMode:",
-                ctypes.c_long(self._NS_VISUAL_EFFECT_BLENDING_BEHIND_WINDOW),
-            )
-
-            # setState: NSVisualEffectStateActive
-            msg_send(
-                self._effect_view,
-                "setState:",
-                ctypes.c_long(self._NS_VISUAL_EFFECT_STATE_ACTIVE),
-            )
-
-            # addSubview:positioned:relativeTo: — 把 effect view 放在最底层，
-            # Qt 渲染的内容在上，frosted glass 效果透过 Qt 的透明区域显示。
-            # NSViewBelow = 1
-            msg_send(
-                ctypes.c_void_p(content_view),
-                "addSubview:positioned:relativeTo:",
-                self._effect_view,
-                ctypes.c_long(1),
-                ctypes.c_void_p(0),
-            )
-
-            # 确保 effect view 启用 layer
-            msg_send(self._effect_view, "setWantsLayer:", ctypes.c_bool(True))
+            self._effect_view = effect_view
 
         except Exception as exc:  # noqa: BLE001
             debug_log("UI", "macOS NSVisualEffectView 创建失败，降级为半透明", {"error": str(exc)})
             self._fallback.apply(window, tint)
 
     def remove(self, window: QWidget) -> None:
+        del window
         if self._effect_view is not None:
             try:
-                import ctypes
-                objc = ctypes.CDLL(ctypes.util.find_library("objc") or "/usr/lib/libobjc.A.dylib")
-                objc.sel_registerName.restype = ctypes.c_void_p
-                objc.sel_registerName.argtypes = [ctypes.c_char_p]
-                objc.objc_msgSend.restype = ctypes.c_void_p
-                objc.objc_msgSend.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
-                sel = objc.sel_registerName(b"removeFromSuperview")
-                objc.objc_msgSend(self._effect_view, sel)
-                self._effect_view = None
+                self._effect_view.removeFromSuperview()
             except Exception:  # noqa: BLE001
                 pass
+            finally:
+                self._effect_view = None
 
     def supports_native_blur(self) -> bool:
-        return sys.platform == "darwin"
+        return True
 
 
 class SoftwareBlurBackdrop:

--- a/app/ui/window_backdrop.py
+++ b/app/ui/window_backdrop.py
@@ -165,8 +165,17 @@ class MacOSVisualEffectBackdrop:
                 ctypes.c_long(self._NS_VISUAL_EFFECT_STATE_ACTIVE),
             )
 
-            # addSubview: 添加到 contentView
-            msg_send(ctypes.c_void_p(content_view), "addSubview:", self._effect_view)
+            # addSubview:positioned:relativeTo: — 把 effect view 放在最底层，
+            # Qt 渲染的内容在上，frosted glass 效果透过 Qt 的透明区域显示。
+            # 普通 addSubview: 会放在最顶层，盖住 Qt 内容导致白色方块。
+            # NSViewBelow = 1
+            msg_send(
+                ctypes.c_void_p(content_view),
+                "addSubview:positioned:relativeTo:",
+                self._effect_view,
+                ctypes.c_long(1),
+                ctypes.c_void_p(0),
+            )
 
             # ── NSLayoutConstraint 固定四边 ──
             # 所有参数都是 c_void_p / c_long，无 NSRect/NSSize/NSPoint struct 传参。

--- a/app/ui/window_backdrop.py
+++ b/app/ui/window_backdrop.py
@@ -98,6 +98,12 @@ class MacOSVisualEffectBackdrop:
             objc.sel_registerName.restype = ctypes.c_void_p
             objc.sel_registerName.argtypes = [ctypes.c_char_p]
 
+            # Objective-C runtime: ivar 直接写入（绕过 HFA-4 struct 传参问题）
+            objc.class_getInstanceVariable.restype = ctypes.c_void_p
+            objc.class_getInstanceVariable.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+            objc.ivar_getOffset.restype = ctypes.c_size_t
+            objc.ivar_getOffset.argtypes = [ctypes.c_void_p]
+
             def msg_send(obj, sel_name, *args):
                 sel = objc.sel_registerName(sel_name.encode())
                 if not args:
@@ -131,8 +137,11 @@ class MacOSVisualEffectBackdrop:
                 self._fallback.apply(window, tint)
                 return
 
-            # alloc + init（不用 initWithFrame:，因为 NSRect 在 arm64 上是 HFA-4，
-            # ctypes 无法正确按值传递 HFA struct 给 objc_msgSend）
+            # ── alloc + init ──
+            # 不用 initWithFrame:，因为 NSRect 在 arm64 上是 HFA-4（4×double），
+            # ctypes (Python ≤3.12) 不支持 HFA 调用约定，会把数组当指针传，
+            # 导致 NSVisualEffectView 收到垃圾 frame。
+            # 改用 init 创建零 frame，再通过 _frame ivar 直接写入正确尺寸。
             alloc = msg_send(ns_visual_effect_class, "alloc")
             effect_view = msg_send(alloc, "init")
             if not effect_view:
@@ -141,8 +150,29 @@ class MacOSVisualEffectBackdrop:
 
             self._effect_view = ctypes.c_void_p(effect_view)
 
-            # 关闭 autoresizing mask，改用 NSLayoutConstraint 固定四边
-            msg_send(self._effect_view, "setTranslatesAutoresizingMaskIntoConstraints:", ctypes.c_bool(False))
+            # ── 通过 _frame ivar 直接写入 frame（绕过 objc_msgSend 的 HFA-4 限制）──
+            # 从 Qt widget 获取尺寸（纯标量调用，无 struct 传参）
+            frame_w = float(window.width())
+            frame_h = float(window.height())
+
+            nsview_class = objc.objc_getClass(b"NSView")
+            frame_ivar = objc.class_getInstanceVariable(nsview_class, b"_frame")
+            frame_offset = objc.ivar_getOffset(frame_ivar)
+
+            # NSRect = { origin.x, origin.y, size.width, size.height } = 4 doubles
+            # 直接写入对象内存中 _frame ivar 的位置
+            obj_base = ctypes.cast(ctypes.c_void_p(effect_view), ctypes.POINTER(ctypes.c_byte))
+            frame_ptr = ctypes.cast(
+                ctypes.addressof(obj_base.contents) + frame_offset,
+                ctypes.POINTER(ctypes.c_double),
+            )
+            frame_ptr[0] = 0.0  # origin.x
+            frame_ptr[1] = 0.0  # origin.y
+            frame_ptr[2] = frame_w  # size.width
+            frame_ptr[3] = frame_h  # size.height
+
+            # setAutoresizingMask: NSViewWidthSizable | NSViewHeightizable
+            msg_send(self._effect_view, "setAutoresizingMask:", ctypes.c_ulong(2 | 16))
 
             # setMaterial: NSVisualEffectMaterialPopover
             msg_send(
@@ -167,7 +197,6 @@ class MacOSVisualEffectBackdrop:
 
             # addSubview:positioned:relativeTo: — 把 effect view 放在最底层，
             # Qt 渲染的内容在上，frosted glass 效果透过 Qt 的透明区域显示。
-            # 普通 addSubview: 会放在最顶层，盖住 Qt 内容导致白色方块。
             # NSViewBelow = 1
             msg_send(
                 ctypes.c_void_p(content_view),
@@ -176,43 +205,6 @@ class MacOSVisualEffectBackdrop:
                 ctypes.c_long(1),
                 ctypes.c_void_p(0),
             )
-
-            # ── NSLayoutConstraint 固定四边 ──
-            # 所有参数都是 c_void_p / c_long，无 NSRect/NSSize/NSPoint struct 传参。
-            constraint_class = objc.objc_getClass(b"NSLayoutConstraint")
-            if constraint_class:
-                ev = self._effect_view
-                cv = ctypes.c_void_p(content_view)
-                c_long = ctypes.c_long
-
-                # 创建四条 edge 约束: effectView.edge = contentView.edge
-                constraints = []
-                for attr in (1, 2, 3, 4):  # Leading, Trailing, Top, Bottom
-                    c = msg_send(
-                        constraint_class,
-                        "constraintWithItem:attribute:relatedBy:toItem:attribute:multiplier:constant:",
-                        ev, c_long(attr), c_long(0), cv, c_long(attr), ctypes.c_double(1.0), ctypes.c_double(0.0),
-                    )
-                    if c:
-                        constraints.append(c)
-
-                if constraints:
-                    # NSArray arrayWithObjects:count: — 纯标量参数，arm64 安全
-                    n = len(constraints)
-                    ArrT = ctypes.c_void_p * n
-                    arr = ArrT(*constraints)
-                    arr_ptr = ctypes.cast(arr, ctypes.c_void_p)
-                    ns_array = msg_send(
-                        objc.objc_getClass(b"NSArray"),
-                        "arrayWithObjects:count:",
-                        arr_ptr, ctypes.c_ulong(n),
-                    )
-                    if ns_array:
-                        msg_send(
-                            constraint_class,
-                            "activateConstraints:",
-                            ctypes.c_void_p(ns_array),
-                        )
 
             # 确保 effect view 启用 layer
             msg_send(self._effect_view, "setWantsLayer:", ctypes.c_bool(True))

--- a/app/ui/window_backdrop.py
+++ b/app/ui/window_backdrop.py
@@ -124,16 +124,22 @@ class MacOSVisualEffectBackdrop:
 
             win_id = int(window.winId())
             root_view = objc.objc_object(c_void_p=c_void_p(win_id))
-            ns_window = root_view.window()
-            if ns_window is None:
-                self._fallback.apply(window, tint)
-                return
-            content_view = ns_window.contentView()
-            if content_view is None:
+
+            # root_view (QNSView) 自身就是 contentView。
+            # 若把 NSVisualEffectView 添加为 contentView 的子视图，它在 Qt 直接绘制
+            # 内容之上会遮挡所有文字和控件。
+            # 必须添加到 root_view 的父视图（NSNextStepFrame），排在 root_view 之下。
+            superview = root_view.superview()
+            if superview is None:
                 self._fallback.apply(window, tint)
                 return
 
-            frame = NSMakeRect(0, 0, float(window.width()), float(window.height()))
+            # 对齐 root_view 在其父视图中的位置和尺寸（root_view 可能不在 (0,0)）
+            rv_frame = root_view.frame()
+            frame = NSMakeRect(
+                rv_frame.origin.x, rv_frame.origin.y,
+                rv_frame.size.width, rv_frame.size.height,
+            )
             effect_view = NSVisualEffectView.alloc().initWithFrame_(frame)
             if effect_view is None:
                 self._fallback.apply(window, tint)
@@ -145,9 +151,10 @@ class MacOSVisualEffectBackdrop:
             effect_view.setAutoresizingMask_(2 | 16)
             effect_view.setWantsLayer_(True)
 
-            # 直接添加到 contentView 最底层
-            content_view.addSubview_positioned_relativeTo_(
-                effect_view, self._NS_WINDOW_BELOW, None,
+            # sibling injection: 插入到 root_view 下面，Qt 内容透过
+            # WA_TranslucentBackground 的透明区域可见毛玻璃
+            superview.addSubview_positioned_relativeTo_(
+                effect_view, self._NS_WINDOW_BELOW, root_view,
             )
 
             self._effect_view = effect_view

--- a/app/ui/window_backdrop.py
+++ b/app/ui/window_backdrop.py
@@ -150,6 +150,8 @@ class MacOSVisualEffectBackdrop:
             effect_view.setState_(self._STATE)
             effect_view.setAutoresizingMask_(2 | 16)
             effect_view.setWantsLayer_(True)
+            # 与 InputBlurBackground 的 corner_radius 保持一致
+            effect_view.setCornerRadius_(22.0)
 
             # sibling injection: 插入到 root_view 下面，Qt 内容透过
             # WA_TranslucentBackground 的透明区域可见毛玻璃

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ import ctypes
 from dataclasses import replace
 from pathlib import Path
 
-from PySide6.QtCore import QObject, QThread, QTimer, Qt, Signal, Slot
+from PySide6.QtCore import QObject, QThread, QTimer, Qt, Signal, Slot, QtMsgType, qInstallMessageHandler
 from PySide6.QtGui import QGuiApplication, QPalette, QColor
 from PySide6.QtWidgets import QApplication, QDialog, QLabel, QMessageBox, QProgressBar, QPushButton, QVBoxLayout, QStyleFactory
 
@@ -40,6 +40,15 @@ from app.voice.tts_bundle import (
 
 
 BASE_DIR = Path(__file__).resolve().parent
+
+
+def _qt_message_handler(msg_type: QtMsgType, context: object, msg: str) -> None:
+    # Windows 无边框透明窗口触发的无害 DWM 边框设置警告，直接丢弃
+    if "setDarkBorderToWindow" in msg:
+        return
+    print(msg, file=sys.stderr)
+    if msg_type == QtMsgType.QtFatalMsg:
+        sys.exit(1)
 
 
 def _force_light_palette(app: QApplication) -> None:
@@ -240,6 +249,7 @@ class TTSBundleMigrationDialog(QDialog):
 
 
 def main() -> int:
+    qInstallMessageHandler(_qt_message_handler)
     _configure_windows_high_dpi()
     app = QApplication(sys.argv)
     app.setApplicationName("Sakura Desktop Pet")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 PySide6>=6.7
 PySide6-Addons>=6.7
+pyobjc-core>=12.0; sys_platform == "darwin"
+pyobjc-framework-Cocoa>=12.0; sys_platform == "darwin"
 mcp>=1.9
 uv>=0.7.0
 PyYAML>=6.0

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -7413,3 +7413,84 @@ def test_subtitle_segment_pulse_creates_bubble_animation() -> None:
     controller.set_speech("一段台词", pulse=True)
 
     assert controller._bubble_fade_anim is not None
+
+
+def _make_character_profile(theme_settings: ThemeSettings | None, theme_source: str):  # type: ignore[no-untyped-def]
+    from app.config.character_loader import CharacterProfile
+
+    return CharacterProfile(
+        id="test",
+        display_name="Test",
+        package_dir=Path("."),
+        card_path=Path("card.md"),
+        initial_message="",
+        default_portrait_path=Path("portrait.png"),
+        theme_settings=theme_settings,
+        theme_source=theme_source,  # type: ignore[arg-type]
+    )
+
+
+def test_theme_settings_for_character_keeps_user_visual_effect_mode() -> None:
+    # 角色包主题只贡献配色；visual_effect_mode 是用户级偏好，必须沿用已保存值。
+    from app.config.character_loader import THEME_SOURCE_PACKAGE
+    from app.ui.pet_window import _theme_settings_for_character
+
+    saved = ThemeSettings(visual_effect_mode="macos_visual_effect", primary_color="#aa11bb")
+    package_theme = ThemeSettings(primary_color="#123456")
+    profile = _make_character_profile(package_theme, THEME_SOURCE_PACKAGE)
+
+    merged = _theme_settings_for_character(saved, profile)
+
+    assert merged.visual_effect_mode == "macos_visual_effect"
+    assert merged.primary_color == "#123456"
+
+
+def test_theme_settings_for_character_compat_default_returns_saved() -> None:
+    from app.config.character_loader import THEME_SOURCE_COMPAT_DEFAULT
+    from app.ui.pet_window import _theme_settings_for_character
+
+    saved = ThemeSettings(visual_effect_mode="windows_acrylic", primary_color="#aa11bb")
+    profile = _make_character_profile(ThemeSettings(), THEME_SOURCE_COMPAT_DEFAULT)
+
+    merged = _theme_settings_for_character(saved, profile)
+
+    assert merged.visual_effect_mode == "windows_acrylic"
+    assert merged.primary_color == "#aa11bb"
+
+
+def test_settings_dialog_theme_settings_for_character_keeps_user_visual_effect_mode() -> None:
+    from app.config.character_loader import THEME_SOURCE_PACKAGE
+    from app.ui.settings_dialog import _theme_settings_for_character
+
+    saved = ThemeSettings(visual_effect_mode="macos_visual_effect")
+    package_theme = ThemeSettings(primary_color="#123456")
+    profile = _make_character_profile(package_theme, THEME_SOURCE_PACKAGE)
+
+    merged = _theme_settings_for_character(saved, profile)
+
+    assert merged.visual_effect_mode == "macos_visual_effect"
+    assert merged.primary_color == "#123456"
+
+
+def test_settings_dialog_theme_settings_for_character_without_profile() -> None:
+    from app.ui.settings_dialog import _theme_settings_for_character
+
+    saved = ThemeSettings(visual_effect_mode="solid")
+
+    assert _theme_settings_for_character(saved, None).visual_effect_mode == "solid"
+
+
+def test_character_theme_round_trip_never_stores_visual_effect_mode() -> None:
+    # character.json 的 theme 块设计上不携带 visual_effect_mode（用户级/角色级分离）。
+    from app.config.character_loader import character_theme_from_mapping, character_theme_to_mapping
+
+    theme = ThemeSettings(primary_color="#123456", visual_effect_mode="macos_visual_effect")
+    mapping = character_theme_to_mapping(theme)
+
+    assert "visual_effect_mode" not in mapping
+
+    restored, source, missing = character_theme_from_mapping(mapping)
+    assert restored.visual_effect_mode == "gaussian_blur"
+    assert restored.primary_color == "#123456"
+    assert source == "package"
+    assert missing is False

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -19,10 +19,7 @@ from app.llm.chat_reply import ChatSegment
 from app.ui.portrait_utils import portrait_kind_key, should_crossfade_portrait
 from app.ui.theme import (
     DEFAULT_THEME_SETTINGS,
-    SETTINGS_COMBO_POPUP_CONTAINER_OBJECT_NAME,
-    SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME,
     ThemeSettings,
-    build_app_chrome_stylesheet,
     build_message_box_stylesheet,
     build_pet_window_stylesheet,
 )
@@ -1459,23 +1456,17 @@ priority: 10
 
 def test_settings_dialog_uses_grouped_top_level_tabs() -> None:
     os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
-    qtcore = pytest.importorskip("PySide6.QtCore")
     qtwidgets = pytest.importorskip("PySide6.QtWidgets")
-    if not all(hasattr(qtwidgets, name) for name in ("QApplication", "QFrame", "QTabWidget")):
+    if not all(hasattr(qtwidgets, name) for name in ("QApplication", "QComboBox", "QTabWidget")):
         pytest.skip("当前测试环境只提供了 PySide6 stub。")
 
-    from app.ui.settings_dialog import (
-        SETTINGS_COMBO_POPUP_ITEM_HEIGHT,
-        SETTINGS_COMBO_POPUP_PADDING,
-        SettingsComboBox,
-        SettingsDialog,
-    )
+    from app.ui.settings_dialog import SettingsDialog
 
-    Qt = qtcore.Qt
     QApplication = qtwidgets.QApplication
-    QFrame = qtwidgets.QFrame
+    QComboBox = qtwidgets.QComboBox
     QTabWidget = qtwidgets.QTabWidget
     app = QApplication.instance() or QApplication([])
+    app_stylesheet_before = app.styleSheet()
     root = _ui_runtime_root("grouped_settings_tabs")
     dialog = SettingsDialog(
         api_settings=ApiSettings(
@@ -1505,13 +1496,14 @@ def test_settings_dialog_uses_grouped_top_level_tabs() -> None:
     assert dialog.height() >= 640
     assert "QWidget#settingsScrollViewport" in dialog.styleSheet()
     assert "QWidget#settingsPluginTab" in dialog.styleSheet()
+    assert "combobox-popup: 0;" in dialog.styleSheet()
     assert "QComboBox::drop-down" in dialog.styleSheet()
     assert "QComboBox::down-arrow" in dialog.styleSheet()
     assert "QComboBox QAbstractItemView" in dialog.styleSheet()
-    assert f"QFrame#{SETTINGS_COMBO_POPUP_CONTAINER_OBJECT_NAME}" in dialog.styleSheet()
-    assert f"QListWidget#{SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME}" in dialog.styleSheet()
     assert "QComboBox QAbstractItemView::item:selected" in dialog.styleSheet()
     assert "QComboBox QAbstractItemView::item:selected:!active" in dialog.styleSheet()
+    assert "QComboBoxPrivateContainer" not in dialog.styleSheet()
+    assert "settingsComboPopup" not in dialog.styleSheet()
     assert "QSpinBox::up-button" in dialog.styleSheet()
     assert "QSpinBox::down-button" in dialog.styleSheet()
     assert "QLineEdit:disabled" in dialog.styleSheet()
@@ -1519,43 +1511,18 @@ def test_settings_dialog_uses_grouped_top_level_tabs() -> None:
     assert "QComboBox:disabled" in dialog.styleSheet()
     assert "QSpinBox::up-button:disabled" in dialog.styleSheet()
     assert "QGroupBox QWidget" not in dialog.styleSheet()
-    assert dialog.character_combo.view().objectName() == SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME
-    assert dialog.model_edit.view().objectName() == SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME
-    assert dialog.model_edit.completer().popup().objectName() == SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME
-    assert dialog.tts_provider_combo.view().objectName() == SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME
-    assert isinstance(dialog.theme_visual_effect_combo, SettingsComboBox)
-    assert dialog.theme_visual_effect_combo.view().objectName() == SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME
-    assert app.styleSheet() == build_app_chrome_stylesheet(dialog.theme_settings)
+    assert type(dialog.character_combo) is QComboBox
+    assert isinstance(dialog.model_edit, QComboBox)
+    assert type(dialog.tts_provider_combo) is QComboBox
+    assert type(dialog.theme_visual_effect_combo) is QComboBox
+    assert not hasattr(dialog.character_combo, "_popup_frame")
+    assert not hasattr(dialog.model_edit, "_popup_frame")
+    assert app.styleSheet() == app_stylesheet_before
 
+    combo_bottom = dialog.character_combo.mapToGlobal(dialog.character_combo.rect().bottomLeft()).y()
     dialog.character_combo.showPopup()
     app.processEvents()
-    popup_container = dialog.character_combo._popup_frame
-    popup_list = dialog.character_combo._popup_list
-    assert popup_container is not None
-    assert popup_list is not None
-    assert popup_container.objectName() == SETTINGS_COMBO_POPUP_CONTAINER_OBJECT_NAME
-    assert popup_container.frameShape() == QFrame.Shape.NoFrame
-    dialog.character_combo.hidePopup()
-
-    dialog.theme_visual_effect_combo.showPopup()
-    app.processEvents()
-    effect_popup_container = dialog.theme_visual_effect_combo._popup_frame
-    effect_popup_list = dialog.theme_visual_effect_combo._popup_list
-    assert effect_popup_container is not None
-    assert effect_popup_list is not None
-    assert effect_popup_container.objectName() == SETTINGS_COMBO_POPUP_CONTAINER_OBJECT_NAME
-    assert effect_popup_list.objectName() == SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME
-    expected_effect_popup_height = (
-        SETTINGS_COMBO_POPUP_ITEM_HEIGHT * dialog.theme_visual_effect_combo.count()
-        + SETTINGS_COMBO_POPUP_PADDING
-    )
-    assert effect_popup_container.height() == expected_effect_popup_height
-    assert effect_popup_list.height() == expected_effect_popup_height
-    assert effect_popup_list.item(0).sizeHint().height() == SETTINGS_COMBO_POPUP_ITEM_HEIGHT
-    dialog.theme_visual_effect_combo.hidePopup()
-    assert bool(popup_container.windowFlags() & Qt.WindowType.FramelessWindowHint)
-    assert bool(popup_container.windowFlags() & Qt.WindowType.NoDropShadowWindowHint)
-    assert popup_list.objectName() == SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME
+    assert dialog.character_combo.view().window().geometry().top() >= combo_bottom
     dialog.character_combo.hidePopup()
 
     dialog.deleteLater()
@@ -2344,11 +2311,7 @@ def test_settings_dialog_model_probe_populates_candidates_and_selects_first(monk
 
     assert dialog.model_edit.currentText() == "z-model"
     assert [dialog.model_edit.itemText(index) for index in range(dialog.model_edit.count())] == ["z-model", "a-model"]
-    dialog.model_edit.showPopup()
-    app.processEvents()
-    assert dialog.model_edit._popup_list is not None
-    assert dialog.model_edit._popup_list.count() == 2
-    dialog.model_edit.hidePopup()
+    assert not hasattr(dialog.model_edit, "_popup_list")
     assert infos and "2" in infos[0]
     dialog.deleteLater()
     app.processEvents()
@@ -2386,21 +2349,18 @@ def test_settings_dialog_model_popups_follow_current_theme_stylesheet() -> None:
     )
 
     dialog.model_edit.set_model_names(["alpha-model", "beta-model"])
-    dialog.model_edit.showPopup()
-    app.processEvents()
-    popup_list = dialog.model_edit._popup_list
-    completion_popup = dialog.model_edit.completer().popup()
+    stylesheet = dialog.styleSheet()
 
-    assert popup_list is not None
-    assert rgba("#102030", 246) in popup_list.styleSheet()
-    assert rgba(themed.primary_color, 34) in popup_list.styleSheet()
-    assert rgba(themed.primary_color, 72) in popup_list.styleSheet()
-    assert "#ddeeff" in popup_list.styleSheet()
-    assert rgba("#102030", 246) in completion_popup.styleSheet()
-    assert rgba(themed.primary_color, 72) in completion_popup.styleSheet()
-    assert "#ddeeff" in completion_popup.styleSheet()
+    assert "QComboBox QAbstractItemView" in stylesheet
+    assert rgba("#102030", 246) in stylesheet
+    assert rgba(themed.primary_color, 43) in stylesheet
+    assert "#ddeeff" in stylesheet
+    assert [dialog.model_edit.itemText(index) for index in range(dialog.model_edit.count())] == [
+        "alpha-model",
+        "beta-model",
+    ]
+    assert not hasattr(dialog.model_edit, "_popup_list")
 
-    dialog.model_edit.hidePopup()
     dialog.deleteLater()
     app.processEvents()
 

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -1464,7 +1464,12 @@ def test_settings_dialog_uses_grouped_top_level_tabs() -> None:
     if not all(hasattr(qtwidgets, name) for name in ("QApplication", "QFrame", "QTabWidget")):
         pytest.skip("当前测试环境只提供了 PySide6 stub。")
 
-    from app.ui.settings_dialog import SettingsDialog
+    from app.ui.settings_dialog import (
+        SETTINGS_COMBO_POPUP_ITEM_HEIGHT,
+        SETTINGS_COMBO_POPUP_PADDING,
+        SettingsComboBox,
+        SettingsDialog,
+    )
 
     Qt = qtcore.Qt
     QApplication = qtwidgets.QApplication
@@ -1518,6 +1523,8 @@ def test_settings_dialog_uses_grouped_top_level_tabs() -> None:
     assert dialog.model_edit.view().objectName() == SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME
     assert dialog.model_edit.completer().popup().objectName() == SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME
     assert dialog.tts_provider_combo.view().objectName() == SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME
+    assert isinstance(dialog.theme_visual_effect_combo, SettingsComboBox)
+    assert dialog.theme_visual_effect_combo.view().objectName() == SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME
     assert app.styleSheet() == build_app_chrome_stylesheet(dialog.theme_settings)
 
     dialog.character_combo.showPopup()
@@ -1528,6 +1535,24 @@ def test_settings_dialog_uses_grouped_top_level_tabs() -> None:
     assert popup_list is not None
     assert popup_container.objectName() == SETTINGS_COMBO_POPUP_CONTAINER_OBJECT_NAME
     assert popup_container.frameShape() == QFrame.Shape.NoFrame
+    dialog.character_combo.hidePopup()
+
+    dialog.theme_visual_effect_combo.showPopup()
+    app.processEvents()
+    effect_popup_container = dialog.theme_visual_effect_combo._popup_frame
+    effect_popup_list = dialog.theme_visual_effect_combo._popup_list
+    assert effect_popup_container is not None
+    assert effect_popup_list is not None
+    assert effect_popup_container.objectName() == SETTINGS_COMBO_POPUP_CONTAINER_OBJECT_NAME
+    assert effect_popup_list.objectName() == SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME
+    expected_effect_popup_height = (
+        SETTINGS_COMBO_POPUP_ITEM_HEIGHT * dialog.theme_visual_effect_combo.count()
+        + SETTINGS_COMBO_POPUP_PADDING
+    )
+    assert effect_popup_container.height() == expected_effect_popup_height
+    assert effect_popup_list.height() == expected_effect_popup_height
+    assert effect_popup_list.item(0).sizeHint().height() == SETTINGS_COMBO_POPUP_ITEM_HEIGHT
+    dialog.theme_visual_effect_combo.hidePopup()
     assert bool(popup_container.windowFlags() & Qt.WindowType.FramelessWindowHint)
     assert bool(popup_container.windowFlags() & Qt.WindowType.NoDropShadowWindowHint)
     assert popup_list.objectName() == SETTINGS_COMBO_POPUP_VIEW_OBJECT_NAME
@@ -2325,6 +2350,57 @@ def test_settings_dialog_model_probe_populates_candidates_and_selects_first(monk
     assert dialog.model_edit._popup_list.count() == 2
     dialog.model_edit.hidePopup()
     assert infos and "2" in infos[0]
+    dialog.deleteLater()
+    app.processEvents()
+
+
+def test_settings_dialog_model_popups_follow_current_theme_stylesheet() -> None:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    if not hasattr(qtwidgets, "QApplication"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+
+    from app.ui.settings_dialog import SettingsDialog
+    from app.ui.theme import rgba
+
+    themed = ThemeSettings(
+        input_background_color="#102030",
+        panel_background_color="#203040",
+        text_color="#ddeeff",
+    )
+    QApplication = qtwidgets.QApplication
+    app = QApplication.instance() or QApplication([])
+    root = _ui_runtime_root("api_model_popup_theme")
+    dialog = SettingsDialog(
+        api_settings=ApiSettings(
+            base_url="https://api.example.com/v1",
+            api_key="test-key",
+            model="",
+        ),
+        tts_settings=_minimal_tts_settings(),
+        base_dir=root,
+        **_settings_dialog_character_kwargs(root),
+        proactive_care_settings=ProactiveCareSettings(screen_context_enabled=True),
+        mcp_settings=MCPRuntimeSettings(windows_enabled=False),
+        theme_settings=themed,
+    )
+
+    dialog.model_edit.set_model_names(["alpha-model", "beta-model"])
+    dialog.model_edit.showPopup()
+    app.processEvents()
+    popup_list = dialog.model_edit._popup_list
+    completion_popup = dialog.model_edit.completer().popup()
+
+    assert popup_list is not None
+    assert rgba("#102030", 246) in popup_list.styleSheet()
+    assert rgba(themed.primary_color, 34) in popup_list.styleSheet()
+    assert rgba(themed.primary_color, 72) in popup_list.styleSheet()
+    assert "#ddeeff" in popup_list.styleSheet()
+    assert rgba("#102030", 246) in completion_popup.styleSheet()
+    assert rgba(themed.primary_color, 72) in completion_popup.styleSheet()
+    assert "#ddeeff" in completion_popup.styleSheet()
+
+    dialog.model_edit.hidePopup()
     dialog.deleteLater()
     app.processEvents()
 
@@ -7179,6 +7255,83 @@ def test_pet_input_stylesheet_reduces_white_overlay() -> None:
     # 普通态/聚焦态白底 alpha 应明显低于原始厚白（96/132），靠背后强模糊提供玻璃质感。
     assert ", 55)" in normal_block
     assert ", 90)" in focus_block
+
+
+def test_pet_input_stylesheet_has_solid_visual_effect_state() -> None:
+    stylesheet = build_pet_window_stylesheet(DEFAULT_THEME_SETTINGS)
+
+    assert '#inputBar[visualEffectMode="solid"]' in stylesheet
+    assert '#petInput[visualEffectMode="solid"]' in stylesheet
+    assert '#petInput[visualEffectMode="solid"]:focus' in stylesheet
+
+
+def test_pet_window_applies_visual_effect_dynamic_property() -> None:
+    _qt_app_or_skip()
+    from PySide6.QtWidgets import QFrame, QLineEdit
+
+    from app.ui.pet_window import PetWindow
+    from app.ui.window_backdrop import VisualEffectMode
+
+    window = PetWindow.__new__(PetWindow)
+    window.input_bar = QFrame()
+    window.input_edit = QLineEdit(window.input_bar)
+
+    PetWindow._apply_input_bar_visual_effect_property(window, VisualEffectMode.SOLID)
+
+    assert window.input_bar.property("visualEffectMode") == VisualEffectMode.SOLID
+    assert window.input_edit.property("visualEffectMode") == VisualEffectMode.SOLID
+
+    window.input_bar.deleteLater()
+
+
+def test_pet_window_removes_old_backdrop_before_hiding_visible_input_window(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    import app.ui.pet_window as pet_window_module
+    from app.ui.pet_window import PetWindow
+    from app.ui.theme import ThemeSettings
+    from app.ui.window_backdrop import VisualEffectMode
+
+    events: list[tuple[str, bool]] = []
+
+    class OldBackdrop:
+        def remove(self, window) -> None:  # type: ignore[no-untyped-def]
+            events.append(("remove", window.hidden))
+
+    class InputWindowStub:
+        def __init__(self) -> None:
+            self.hidden = False
+            self._backdrop = OldBackdrop()
+            self._background_layer = None
+
+        def isVisible(self) -> bool:  # noqa: N802 - Qt API 兼容命名。
+            return True
+
+        def hide(self) -> None:
+            self.hidden = True
+            events.append(("hide", self.hidden))
+
+        def show(self) -> None:
+            events.append(("show", self.hidden))
+
+    input_window = InputWindowStub()
+    window = PetWindow.__new__(PetWindow)
+    window.theme_settings = ThemeSettings(visual_effect_mode=VisualEffectMode.SOLID)
+    window.input_window = input_window
+    window.input_blur_background = None
+    window.input_bar_animator = None
+    monkeypatch.setattr(
+        pet_window_module.QApplication,
+        "processEvents",
+        lambda *args, **_kwargs: events.append(("process", input_window.hidden)),
+    )
+
+    PetWindow._sync_input_bar_backdrop(window)
+
+    assert events == [
+        ("remove", False),
+        ("hide", True),
+        ("process", True),
+        ("show", True),
+    ]
 
 
 def test_local_rect_to_global_keeps_size_and_uses_main_window_origin() -> None:

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -6267,6 +6267,12 @@ def test_pet_window_apply_window_flags_syncs_native_topmost_state() -> None:
         def _schedule_native_topmost_sync(self) -> None:
             self.sync_count += 1
 
+        def _sync_card_window_topmost_flags(self) -> None:
+            pass
+
+        def _raise_foreground_controls(self) -> None:
+            pass
+
     window = MinimalWindow()
 
     window._apply_window_flags()
@@ -6300,6 +6306,12 @@ def test_pet_window_apply_window_flags_does_not_sync_native_state_before_visible
 
         def _schedule_native_topmost_sync(self) -> None:
             self.sync_count += 1
+
+        def _sync_card_window_topmost_flags(self) -> None:
+            pass
+
+        def _raise_foreground_controls(self) -> None:
+            pass
 
     window = MinimalWindow()
 

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -7430,54 +7430,41 @@ def _make_character_profile(theme_settings: ThemeSettings | None, theme_source: 
     )
 
 
-def test_theme_settings_for_character_keeps_user_visual_effect_mode() -> None:
-    # 角色包主题只贡献配色；visual_effect_mode 是用户级偏好，必须沿用已保存值。
+def test_merge_theme_with_character_keeps_user_level_fields() -> None:
+    # 角色包主题只贡献配色；visual_effect_mode 和 ai_enabled 是用户级偏好，必须沿用已保存值。
     from app.config.character_loader import THEME_SOURCE_PACKAGE
-    from app.ui.pet_window import _theme_settings_for_character
+    from app.ui.theme import merge_theme_with_character
 
-    saved = ThemeSettings(visual_effect_mode="macos_visual_effect", primary_color="#aa11bb")
+    saved = ThemeSettings(visual_effect_mode="macos_visual_effect", primary_color="#aa11bb", ai_enabled=True)
     package_theme = ThemeSettings(primary_color="#123456")
     profile = _make_character_profile(package_theme, THEME_SOURCE_PACKAGE)
 
-    merged = _theme_settings_for_character(saved, profile)
+    merged = merge_theme_with_character(saved, profile)
 
     assert merged.visual_effect_mode == "macos_visual_effect"
+    assert merged.ai_enabled is True
     assert merged.primary_color == "#123456"
 
 
-def test_theme_settings_for_character_compat_default_returns_saved() -> None:
+def test_merge_theme_with_character_compat_default_returns_saved() -> None:
     from app.config.character_loader import THEME_SOURCE_COMPAT_DEFAULT
-    from app.ui.pet_window import _theme_settings_for_character
+    from app.ui.theme import merge_theme_with_character
 
     saved = ThemeSettings(visual_effect_mode="windows_acrylic", primary_color="#aa11bb")
     profile = _make_character_profile(ThemeSettings(), THEME_SOURCE_COMPAT_DEFAULT)
 
-    merged = _theme_settings_for_character(saved, profile)
+    merged = merge_theme_with_character(saved, profile)
 
     assert merged.visual_effect_mode == "windows_acrylic"
     assert merged.primary_color == "#aa11bb"
 
 
-def test_settings_dialog_theme_settings_for_character_keeps_user_visual_effect_mode() -> None:
-    from app.config.character_loader import THEME_SOURCE_PACKAGE
-    from app.ui.settings_dialog import _theme_settings_for_character
-
-    saved = ThemeSettings(visual_effect_mode="macos_visual_effect")
-    package_theme = ThemeSettings(primary_color="#123456")
-    profile = _make_character_profile(package_theme, THEME_SOURCE_PACKAGE)
-
-    merged = _theme_settings_for_character(saved, profile)
-
-    assert merged.visual_effect_mode == "macos_visual_effect"
-    assert merged.primary_color == "#123456"
-
-
-def test_settings_dialog_theme_settings_for_character_without_profile() -> None:
-    from app.ui.settings_dialog import _theme_settings_for_character
+def test_merge_theme_with_character_without_profile() -> None:
+    from app.ui.theme import merge_theme_with_character
 
     saved = ThemeSettings(visual_effect_mode="solid")
 
-    assert _theme_settings_for_character(saved, None).visual_effect_mode == "solid"
+    assert merge_theme_with_character(saved, None).visual_effect_mode == "solid"
 
 
 def test_character_theme_round_trip_never_stores_visual_effect_mode() -> None:

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -1511,10 +1511,10 @@ def test_settings_dialog_uses_grouped_top_level_tabs() -> None:
     assert "QComboBox:disabled" in dialog.styleSheet()
     assert "QSpinBox::up-button:disabled" in dialog.styleSheet()
     assert "QGroupBox QWidget" not in dialog.styleSheet()
-    assert type(dialog.character_combo) is QComboBox
+    assert isinstance(dialog.character_combo, QComboBox)
     assert isinstance(dialog.model_edit, QComboBox)
-    assert type(dialog.tts_provider_combo) is QComboBox
-    assert type(dialog.theme_visual_effect_combo) is QComboBox
+    assert isinstance(dialog.tts_provider_combo, QComboBox)
+    assert isinstance(dialog.theme_visual_effect_combo, QComboBox)
     assert not hasattr(dialog.character_combo, "_popup_frame")
     assert not hasattr(dialog.model_edit, "_popup_frame")
     assert app.styleSheet() == app_stylesheet_before

--- a/tests/ui/test_window_backdrop.py
+++ b/tests/ui/test_window_backdrop.py
@@ -76,6 +76,32 @@ def test_software_blur_backdrop_is_not_native() -> None:
     assert backdrop.supports_native_blur() is False
 
 
+def test_windows_acrylic_remove_resets_native_corner_preference(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    class WindowStub:
+        def winId(self) -> int:  # noqa: N802 - Qt API 兼容命名。
+            return 12345
+
+    calls: list[tuple[str, int, int]] = []
+    backdrop = wb.WindowsAcrylicBackdrop(rounded=True)
+    monkeypatch.setattr(
+        backdrop,
+        "_set_accent",
+        lambda hwnd, state, _tint: calls.append(("accent", hwnd, state)),
+    )
+    monkeypatch.setattr(
+        backdrop,
+        "_set_corner_preference",
+        lambda hwnd, value: calls.append(("corner", hwnd, value)),
+    )
+
+    backdrop.remove(WindowStub())  # type: ignore[arg-type]
+
+    assert calls == [
+        ("accent", 12345, backdrop._ACCENT_DISABLED),  # noqa: SLF001
+        ("corner", 12345, backdrop._DWMWCP_DONOTROUND),  # noqa: SLF001
+    ]
+
+
 def test_acrylic_card_window_background_layer_fills_and_lowers() -> None:
     from PySide6.QtWidgets import QWidget
 


### PR DESCRIPTION
# macOS 毛玻璃 + 统一外观效果

## 背景

原作者引入 `AcrylicCardWindow` + `WindowBackdrop` 体系，将气泡和输入栏重构为独立的顶层子窗口，配合系统级背景模糊效果。但存在两个问题：

1. **气泡被立绘遮挡** — macOS 上 `Qt.Tool` 子窗口 `show()` 后不会自动浮于父窗口之上，拖动时子窗口层级丢失
2. **视觉效果 Windows 独占** — 只有 `WindowsAcrylicBackdrop`（DWM 亚克力），macOS 没有任何等效实现，`FallbackTintBackdrop` 不做任何模糊

---

## 解决方案

### 问题 1：气泡 z-order

**启动时**：`showEvent` 中 `QTimer.singleShot(0)` 延迟一帧 raise 不够 — macOS WindowServer 合成器提交 `Qt.Tool` 子窗口需要多帧。追加 `singleShot(100)` 补发。

**拖动时**：`moveEvent` → `setGeometry` 重定位子窗口 → macOS 窗口服务器丢失 `Qt.Tool` 层级关系。在 `moveEvent` 和 `_finish_drag_resume` 中补 `_raise_foreground_controls()`。

**改动**：`app/ui/pet_window.py`

### 问题 2：macOS 毛玻璃 + 统一外观管线

**实现 `MacOSVisualEffectBackdrop`**，使用 `NSVisualEffectView` + HUDWindow 材质提供原生毛玻璃。

关键技术决策：**PyObjC 而非 ctypes**。经测试，arm64 macOS 上 Python 3.12 的 ctypes 不支持 AAPCS64 HFA（Homogeneous Floating-point Aggregate）调用约定，NSRect/NSSize/NSPoint 作为 struct 传给 `objc_msgSend` 时全部退化为指针，`initWithFrame:` 收到垃圾 frame → 毛玻璃永远不可见。PyObjC 内置 ObjC 类型编码，自动处理所有 struct 按值传递。

实际渲染采用 **sibling injection** 策略：将 `NSVisualEffectView` 添加到 Qt 的 `NSNextStepFrame`（`root_view.superview()`），排在 `QNSView` 之下。Qt 的 `WA_TranslucentBackground` 让 QNSView 背景透明，毛玻璃透过显示，而控件正常渲染在上层。

```
NSWindow
  └─ NSNextStepFrame
       ├─ [0] NSVisualEffectView ← 毛玻璃，cornerRadius=22
       └─ [1] QNSView             ← Qt 内容，WA_TranslucentBackground
```

**重构视觉效果管线**：将输入栏外观从"硬编码高斯模糊"改为四个平等的独立模式：

| 模式 | 实现 | 平台 |
|------|------|------|
| 纯色块 | `FallbackTintBackdrop` | 全平台 |
| 高斯模糊 | `SoftwareBlurBackdrop` + `InputBlurBackground` 截图 | 全平台（默认） |
| Windows 亚克力 | `WindowsAcrylicBackdrop` (DWM) | Windows 10 1803+ |
| macOS 毛玻璃 | `MacOSVisualEffectBackdrop` (NSVisualEffectView) | macOS |

每个模式通过 `_backdrop_for_input_bar()` → `(backdrop, needs_bg, before_show_callback)` 对称映射，`_sync_input_bar_backdrop()` 统一同步三个维度。`InputBarAnimator` 新增 `set_before_show()` 供模式切换时动态绑定/清除截图回调。

**前端设置**：设置 → 角色与外观 → 主题 → 新增"输入栏外观效果"下拉框（仅显示当前平台支持的选项）。

---

## 改动清单

| 文件 | 改动 |
|------|------|
| `app/ui/window_backdrop.py` | 新增 `VisualEffectMode` 枚举；`MacOSVisualEffectBackdrop` (PyObjC + sibling injection)；重构 `create_window_backdrop(mode)` 工厂 |
| `app/ui/pet_window.py` | 输入栏按 mode 应用效果；气泡退回纯色 `FallbackTintBackdrop`；对称管线 `_backdrop_for_input_bar()` / `_sync_input_bar_backdrop()`；拖动/启动 z-order 修复 |
| `app/ui/theme.py` | `ThemeSettings` 新增 `visual_effect_mode` 字段 + 序列化 |
| `app/ui/settings_dialog.py` | 主题 tab 新增"输入栏外观效果"下拉框 |
| `app/ui/input_bar_animator.py` | 新增 `set_before_show()` 公共方法 |
| `app/ui/acrylic_card_window.py` | 文档注释同步 |
| `requirements.txt` | 添加 `pyobjc-core>=12.0` + `pyobjc-framework-Cocoa>=12.0` (macOS only) |

---

## 附：ctypes arm64 HFA 测试结论

在 arm64 macOS Python 3.12 上，用 ctypes 通过 `objc_msgSend` 传递 AppKit struct 参数进行了统一测试：

```
HFA-4 NSRect   initWithFrame(10,20,400,300) → (5e-324, -1.0, 7.95e-275, 0.0)  FAIL (garbage)
HFA-2 NSSize   setFrameSize(350,250)        → (0.0, 0.0, 5e-324, 0.0)         FAIL (garbage)
HFA-2 NSPoint  setFrameOrigin(50,60)        → (5e-324, -1.0, 0.0, 0.0)        FAIL (garbage)

scalar c_double setAlphaValue(0.75)         → OK                                PASS
```

**结论**：Python 3.12 ctypes 不支持 AAPCS64 HFA 调用约定。**所有** HFA struct 参数（NSRect/NSSize/NSPoint，无论 2/3/4 个 double）均被 ctypes 退化为指针传入整数寄存器，而 `objc_msgSend` 从 VFP 寄存器读取 struct 值 — 永远读到垃圾数据。只有标量类型（`c_void_p`、`c_long`、`c_bool`、`c_double`）能正确传递。

这意味着任何访问 AppKit API 的路径（`initWithFrame:`、`setFrameSize:`、`setFrameOrigin:`、`bounds`、`frame` 等）在纯 ctypes 下全部不可用。PyObjC 是唯一可行方案，它通过完整的 Objective-C type encoding 自动将 HFA struct 映射到正确的 VFP 寄存器。
