### PR TITLE
fix: 气泡高度自适应回复文本长度，避免长回复被裁剪

### DIFF
--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -115,6 +115,8 @@ from app.ui.control_panel_layout import (
     DEFAULT_CONTROL_PANEL_WIDTH,
     DEFAULT_INPUT_BAR_OFFSET,
     INPUT_BAR_HEIGHT,
+    MAX_BUBBLE_HEIGHT,
+    MIN_BUBBLE_HEIGHT,
     MIN_CONTROL_PANEL_WIDTH,
     normalize_bubble_height,
     normalize_control_panel_vertical_offset,
@@ -394,6 +396,8 @@ class PetWindow(QWidget):
         self.bubble_height = self._load_bubble_height()
         self.control_panel_vertical_offset = self._load_control_panel_vertical_offset()
         self.input_bar_offset = self._load_input_bar_offset()
+        # 自适应文本气泡高度（None = 使用用户设置的 bubble_height）
+        self._auto_fit_bubble_height: int | None = None
         (
             self.subtitle_typing_interval_ms,
             self.reply_segment_pause_ms,
@@ -571,6 +575,7 @@ class PetWindow(QWidget):
             typing_interval_ms=self.subtitle_typing_interval_ms,
             segment_pause_ms=self.reply_segment_pause_ms,
             bubble_opacity_effect=self.bubble_opacity_effect,
+            on_speech_text_shown=self._auto_fit_bubble_for_text,
         )
         self.speech_timer = self.subtitle_controller.speech_timer
         if not self.startup_initializing:
@@ -1140,6 +1145,62 @@ class PetWindow(QWidget):
             return
         self.speech_label.setFont(_rounded_japanese_font(15, QFont.Weight.Medium))
 
+    def _compute_text_bubble_height(self, text: str) -> int:
+        """计算 word-wrap 后文本需要的气泡高度（含内边距/间距开销）。"""
+        # 文本可用宽度 = 气泡宽度 - 左右 margin (22 + 18 = 40)
+        bw = min(self.control_panel_width, max(MIN_CONTROL_PANEL_WIDTH, self.width() - 32))
+        text_width = max(1, bw - 40)
+
+        fm = self.speech_label.fontMetrics()
+        text_rect = fm.boundingRect(
+            QRect(0, 0, text_width, 0),
+            Qt.TextFlag.TextWordWrap,
+            text,
+        )
+        text_height = text_rect.height()
+
+        # 纵向开销：
+        #   bubble_layout top margin(12) + name_label + spacing(6) + bottom margin(14)
+        name_h = self.name_label.sizeHint().height()
+        overhead = 12 + name_h + 6 + 14
+
+        # 留少量余量防止边缘裁剪
+        needed = text_height + overhead + 4
+        return max(needed, MIN_BUBBLE_HEIGHT)
+
+    def _auto_fit_bubble_for_text(self, text: str) -> None:
+        """根据台词全文自适应气泡高度（不低于用户设置、不超最大值，不持久化）。"""
+        if not text:
+            return
+
+        needed = self._compute_text_bubble_height(text)
+        effective = max(self.bubble_height, needed)
+        effective = max(MIN_BUBBLE_HEIGHT, min(MAX_BUBBLE_HEIGHT, effective))
+
+        if effective == self.bubble_height:
+            # 无需额外空间：复位自适应高度，使用用户设置
+            self._auto_fit_bubble_height = None
+        else:
+            self._auto_fit_bubble_height = effective
+
+        # 确保舞台尺寸与有效气泡高度匹配（自适应变大或回退到用户设置时都会处理）
+        self._ensure_stage_for_bubble_height(effective)
+        self._layout_stage()
+
+    def _ensure_stage_for_bubble_height(self, bubble_height: int) -> None:
+        """必要时调整舞台尺寸以容纳指定气泡高度。"""
+        new_size = _stage_size_for_layout(
+            self.portrait_scale_percent,
+            self.control_panel_width,
+            bubble_height,
+            self.input_bar_offset,
+        )
+        if self.stage_size == new_size:
+            return
+        self.stage_size = new_size
+        self.portrait_controller.set_stage_size(new_size)
+        self.resize(*new_size)
+
     def _layout_stage(self) -> None:
         width = self.width()
         height = self.height()
@@ -1154,7 +1215,12 @@ class PetWindow(QWidget):
         )
 
         bubble_width = min(self.control_panel_width, max(MIN_CONTROL_PANEL_WIDTH, width - 32))
-        bubble_height = self.bubble_height
+        # 优先使用自适应文本高度的气泡高度，回退到用户设置
+        bubble_height = (
+            self._auto_fit_bubble_height
+            if self._auto_fit_bubble_height is not None
+            else self.bubble_height
+        )
         bubble_x = (width - bubble_width) // 2
         # vertical_offset 正值向上抬升整组（减小 y），负值向下沉。
         bubble_y = (

--- a/app/ui/subtitle_controller.py
+++ b/app/ui/subtitle_controller.py
@@ -46,6 +46,7 @@ class SubtitleController(QObject):
         typing_interval_ms: int = SPEECH_TYPING_INTERVAL_MS,
         segment_pause_ms: int = REPLY_SEGMENT_PAUSE_MS,
         bubble_opacity_effect: Any = None,
+        on_speech_text_shown: Callable[[str], None] | None = None,
     ) -> None:
         super().__init__(parent)
         self.speech_label = speech_label
@@ -59,6 +60,8 @@ class SubtitleController(QObject):
         # 气泡淡入脉冲：用于每段台词浮现，None 时退化为无动画（测试/历史窗口单独构造安全）。
         self._bubble_opacity_effect = bubble_opacity_effect
         self._bubble_fade_anim: QSequentialAnimationGroup | None = None
+        # 台词文本已准备好时回调（用于自适应气泡高度等布局调整）
+        self._on_speech_text_shown = on_speech_text_shown
 
         self.speech_text = ""
         self.speech_index = 0
@@ -164,6 +167,9 @@ class SubtitleController(QObject):
         self.speech_index = 0
         self.speech_label.clear()
         if self.speech_text:
+            # 通知父级调整气泡高度（在逐字显示动画开始前），确保全文可容纳
+            if self._on_speech_text_shown is not None:
+                self._on_speech_text_shown(cleaned)
             self.speech_timer.start()
             if pulse:
                 self._pulse_bubble()
@@ -200,6 +206,8 @@ class SubtitleController(QObject):
         self.speech_timer.stop()
         self.speech_text = cleaned
         self.speech_index = len(cleaned)
+        if self._on_speech_text_shown is not None:
+            self._on_speech_text_shown(cleaned)
         self.speech_label.setText(cleaned)
         self._log_stage("speech_text_shown_immediately", {"text": cleaned})
 


### PR DESCRIPTION
问题
模型回复较长时，气泡会因 Qt QLabel word-wrap + 固定高度容器被动裁剪文字。例如模型回复 「这是一句回复，但由于气泡显示有限，可能会被截断」，在默认 128px 气泡高度下只能显示约 3 行，超出部分被 Qt 直接切掉——没有 ... 提示，没有滚动，无声无息。

根因：系统没有任何显式的文字截断函数（非 QFontMetrics.elidedText、非 setMaximumBlockCount、非字符数限制）。文字被"截断"纯粹是 QLabel.setWordWrap(True) 放在固定尺寸 QFrame 里的副作用。Commit 86b9d69（feat: 支持调整对话框尺寸与气泡上下位置）将 bubble_height 从硬编码 128px 改为用户可调（96~260px），但文字显示逻辑没有随之适配，用户甚至可以缩小气泡到 96px（仅约 2 行）让截断更严重。

解决方案
每段台词显示前，根据全文预计算 word-wrap 后实际需要的高度，自适应扩展气泡。

不低于用户设置高度（不去压低用户偏好）
不超最大 260px（MAX_BUBBLE_HEIGHT）
自适应高度不持久化到 system_config.yaml（不影响用户保存的配置）
下一条短回复自动缩回用户设置
改动
2 个文件，+75 行

app/ui/subtitle_controller.py（+7 行）
新增 on_speech_text_shown: Callable[[str], None] 可选参数（默认 None，现有测试不受影响）
set_speech() 和 show_text_immediately() 在文本准备就绪后调用此回调
app/ui/pet_window.py（+68 行）
_compute_text_bubble_height(text) — 用 QFontMetrics.boundingRect 在指定宽度下计算 word-wrap 后文字实际高度，加上气泡内边距/间距开销
_auto_fit_bubble_for_text(text) — 回调入口：effective = max(用户设置, 文字需求)，夹在 [MIN, MAX] 内；如需调整则设 _auto_fit_bubble_height 并触发阶段重算
_ensure_stage_for_bubble_height(h) — 必要时扩展主窗口舞台以容纳变高的气泡
_layout_stage — 气泡高度改为 self._auto_fit_bubble_height or self.bubble_height，自适应优先
调用链：


模型回复 → SubtitleController._start_segment_speech()
         → set_speech(text)
         → on_speech_text_shown(text)        ← 新增
         → PetWindow._auto_fit_bubble_for_text(text)
         → 计算需求高度 → 调整舞台 → 重新布局
         → 开始逐字打字动画（气泡已预扩到正确大小）