### PR TITLE
fix: 将 TTS 临时缓存迁移到数据目录

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ data/runtime_events/
 data/notes/
 data/tts_bundles/
 data/logs/
+data/cache/
 tts/
 data/config/api.yaml
 data/config/characters.yaml

--- a/app/core/bootstrap.py
+++ b/app/core/bootstrap.py
@@ -27,6 +27,7 @@ from app.voice.tts import (
     NullTTSProvider,
     TTSConfigError,
     TTSProvider,
+    purge_tts_cache,
 )
 from app.storage.visual_observation import VisualObservationStore
 from app.core.plugin_manager import SakuraPluginManager
@@ -213,6 +214,12 @@ def build_deferred_services(base_dir: Path, context: AppContext) -> DeferredStar
     settings_service = context.settings_service
     character_profile = context.character_profile
 
+    # 启动时清空 data/cache/tts 残留（崩溃/强退遗留的临时 wav），失败不影响启动
+    try:
+        purge_tts_cache(base_dir)
+    except OSError as exc:
+        debug_log("Startup", "TTS 缓存启动清理失败，已忽略", {"error": str(exc)})
+
     try:
         tts_settings = settings_service.load_tts_settings(
             character_profile=character_profile,
@@ -220,9 +227,9 @@ def build_deferred_services(base_dir: Path, context: AppContext) -> DeferredStar
         if not tts_settings.enabled:
             tts_provider = NullTTSProvider()
         elif tts_settings.provider == TTS_PROVIDER_GENIE:
-            tts_provider = GenieTTSProvider(tts_settings)
+            tts_provider = GenieTTSProvider(tts_settings, base_dir=base_dir)
         else:
-            tts_provider = GPTSoVITSTTSProvider(tts_settings)
+            tts_provider = GPTSoVITSTTSProvider(tts_settings, base_dir=base_dir)
     except TTSConfigError as exc:
         print(f"[TTS] 配置无效，已禁用 TTS：{exc}")
         debug_log("TTS", "配置无效，已禁用 TTS", {"error": str(exc)})

--- a/app/voice/tts.py
+++ b/app/voice/tts.py
@@ -58,6 +58,35 @@ _SUPPORTED_TTS_PROVIDERS = {
 }
 
 
+def _resolve_tts_cache_dir(base_dir: Path | None = None) -> Path:
+    """返回 TTS 临时音频缓存目录（data/cache/tts），并确保存在。
+
+    不再写入系统 Temp，改用 Sakura 自有数据目录，便于集中管理与启动清理。
+    base_dir 为空时基于 __file__ 推算项目根（app/voice/tts.py → 项目根），
+    与 main.py 的路径惯例一致。
+    """
+    root = Path(base_dir) if base_dir is not None else Path(__file__).resolve().parents[2]
+    cache_dir = root / "data" / "cache" / "tts"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir
+
+
+def purge_tts_cache(base_dir: Path | None = None) -> None:
+    """启动时清空 data/cache/tts 残留（崩溃/强退遗留的临时 wav）。
+
+    该目录完全归 Sakura 所有、仅存放 TTS 临时音频，清空安全。
+    逐个删除并忽略个别占用错误，不影响启动。
+    """
+    cache_dir = _resolve_tts_cache_dir(base_dir)
+    for entry in cache_dir.iterdir():
+        if not entry.is_file():
+            continue
+        try:
+            entry.unlink()
+        except OSError as exc:
+            debug_log("TTS", "启动清理缓存文件失败，已跳过", {"path": str(entry), "error": str(exc)})
+
+
 @dataclass
 class TTSPreparedAudio:
     """一段已提交预生成的 TTS 音频句柄。"""
@@ -364,11 +393,16 @@ class GPTSoVITSTTSProvider(QObject):
         self,
         settings: GPTSoVITSTTSSettings,
         *,
+        base_dir: Path | None = None,
         adopt_existing_service: bool = True,
     ) -> None:
         super().__init__()
         settings.validate()
         self.settings = settings
+        # TTS 临时音频缓存目录（data/cache/tts）。由调用方注入 base_dir，
+        # 与启动清理 purge_tts_cache(base_dir) 同源，避免写入目录与清理目录错位。
+        # base_dir 为空时退回 _resolve_tts_cache_dir 的 __file__ 推算，保持向后兼容。
+        self._tts_cache_dir = _resolve_tts_cache_dir(base_dir)
         self._pending_audio: list[
             tuple[Path, TTSCallback | None, TTSCallback | None, TTSPreparedAudio | None]
         ] = []
@@ -693,6 +727,7 @@ class GPTSoVITSTTSProvider(QObject):
                 prefix="sakura_tts_",
                 suffix=".wav",
                 delete=False,
+                dir=str(self._tts_cache_dir),
             ) as audio_file:
                 audio_file.write(audio_data)
                 audio_path = audio_file.name
@@ -1523,9 +1558,14 @@ class GenieTTSProvider(GPTSoVITSTTSProvider):
         self,
         settings: GPTSoVITSTTSSettings,
         *,
+        base_dir: Path | None = None,
         adopt_existing_service: bool = True,
     ) -> None:
-        super().__init__(settings, adopt_existing_service=adopt_existing_service)
+        super().__init__(
+            settings,
+            base_dir=base_dir,
+            adopt_existing_service=adopt_existing_service,
+        )
         self._loaded_character_name: str | None = None
         self._reference_audio_key: str | None = None
 
@@ -1585,6 +1625,7 @@ class GenieTTSProvider(GPTSoVITSTTSProvider):
                 prefix="sakura_genie_tts_",
                 suffix=".wav",
                 delete=False,
+                dir=str(self._tts_cache_dir),
             ) as audio_file:
                 audio_path = Path(audio_file.name)
             try:

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -51,6 +51,7 @@ def test_build_deferred_services_loads_injectable_runtime_services(
     context = bootstrap.build_initial_app_context(root)
     tts_provider = object()
     mcp_provider = object()
+    provider_base_dirs: list[Path | None] = []
 
     monkeypatch.setattr(
         type(context.settings_service),
@@ -66,7 +67,11 @@ def test_build_deferred_services_loads_injectable_runtime_services(
             timeout_seconds=1,
         ),
     )
-    monkeypatch.setattr(bootstrap, "GPTSoVITSTTSProvider", lambda _settings: tts_provider)
+    def fake_gpt_provider(_settings, *, base_dir: Path | None = None):  # type: ignore[no-untyped-def]
+        provider_base_dirs.append(base_dir)
+        return tts_provider
+
+    monkeypatch.setattr(bootstrap, "GPTSoVITSTTSProvider", fake_gpt_provider)
 
     def fake_load_plugins(self, registry):  # type: ignore[no-untyped-def]
         registry.register(Tool(name="plugin_demo", description="plugin"))
@@ -85,6 +90,7 @@ def test_build_deferred_services_loads_injectable_runtime_services(
     assert services.tool_registry.get("plugin_demo") is not None
     assert services.tool_registry.get("mcp_demo") is not None
     assert services.errors == ()
+    assert provider_base_dirs == [root]
 
 
 def test_build_deferred_services_creates_genie_tts_provider(
@@ -96,6 +102,7 @@ def test_build_deferred_services_creates_genie_tts_provider(
     root = _build_startup_root()
     context = bootstrap.build_initial_app_context(root)
     genie_provider = object()
+    provider_base_dirs: list[Path | None] = []
 
     monkeypatch.setattr(
         type(context.settings_service),
@@ -112,13 +119,18 @@ def test_build_deferred_services_creates_genie_tts_provider(
             timeout_seconds=1,
         ),
     )
-    monkeypatch.setattr(bootstrap, "GenieTTSProvider", lambda _settings: genie_provider)
+    def fake_genie_provider(_settings, *, base_dir: Path | None = None):  # type: ignore[no-untyped-def]
+        provider_base_dirs.append(base_dir)
+        return genie_provider
+
+    monkeypatch.setattr(bootstrap, "GenieTTSProvider", fake_genie_provider)
     monkeypatch.setattr(bootstrap.SakuraPluginManager, "load_from_config", lambda *_args: None)
     monkeypatch.setattr(bootstrap, "register_mcp_tools_from_config", lambda *_args, **_kwargs: None)
 
     services = bootstrap.build_deferred_services(root, context)
 
     assert services.tts_provider is genie_provider
+    assert provider_base_dirs == [root]
 
 
 def test_build_deferred_services_disables_tts_for_voice_less_character(

--- a/tests/unit/test_tts.py
+++ b/tests/unit/test_tts.py
@@ -83,7 +83,9 @@ from app.voice.tts import (
     _load_tone_references,
     _local_tts_subprocess_env,
     _resolve_request_text_lang,
+    _resolve_tts_cache_dir,
     _write_genie_audio,
+    purge_tts_cache,
 )
 from app.voice import VoicePlaybackController
 from app.voice.text_language_guard import should_skip_tts_text
@@ -1543,3 +1545,31 @@ def test_playback_backend_is_configurable() -> None:
     sink_settings = dc_replace(settings, playback_backend=TTS_PLAYBACK_BACKEND_AUDIO_SINK)
     sink_provider = GPTSoVITSTTSProvider(sink_settings)
     assert sink_provider._playback_backend == TTS_PLAYBACK_BACKEND_AUDIO_SINK
+
+
+# === 新增：TTS 缓存目录（data/cache/tts）测试 ===
+
+def test_resolve_tts_cache_dir_creates_data_cache_tts() -> None:
+    """缓存目录应位于 base_dir/data/cache/tts 且被自动创建。"""
+    root = _runtime_root("tts_cache_resolve")
+
+    cache_dir = _resolve_tts_cache_dir(root)
+
+    assert cache_dir == root / "data" / "cache" / "tts"
+    assert cache_dir.is_dir()
+
+
+def test_purge_tts_cache_removes_residual_files_keeps_dir() -> None:
+    """启动清理应删除残留临时文件，但保留缓存目录与其中的子目录。"""
+    root = _runtime_root("tts_cache_purge")
+    cache_dir = _resolve_tts_cache_dir(root)
+    (cache_dir / "sakura_tts_a.wav").write_bytes(b"x")
+    (cache_dir / "sakura_genie_tts_b.wav").write_bytes(b"y")
+    sub_dir = cache_dir / "keep"
+    sub_dir.mkdir()
+
+    purge_tts_cache(root)
+
+    assert cache_dir.is_dir()
+    assert sub_dir.is_dir()  # 非文件项不应被删除
+    assert not any(entry.is_file() for entry in cache_dir.iterdir())


### PR DESCRIPTION
## Summary
- 将 GPT-SoVITS / Genie TTS 临时 wav 写入 data/cache/tts，避免落到系统 Temp。
- 启动时清理 data/cache/tts 残留文件，并忽略单文件占用错误。
- 在启动装配中显式传入 base_dir，并补充 TTS 缓存与 bootstrap 覆盖测试。

## Tests
- runtime\\python.exe -m pytest tests/unit/test_bootstrap.py
- runtime\\python.exe -m pytest tests/unit/test_tts.py
- runtime\\python.exe -m pytest tests/unit --basetemp __pycache__\\pytest-temp