### PR TITLE
fix: 将记忆管理页面的排序换为时间倒序排列

### DIFF
--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -1538,7 +1538,7 @@ class SettingsDialog(QDialog):
 
     @Slot(list)
     def _handle_memory_load_success(self, memories: list[dict[str, object]]) -> None:
-        self._all_memories = list(memories)
+        self._all_memories = _sort_memories_by_latest_time(memories)
         all_ids = {str(memory.get("id", "")) for memory in self._all_memories}
         self._selected_memory_ids &= all_ids
         if self._editing_memory_id and self._editing_memory_id not in all_ids:
@@ -3157,6 +3157,32 @@ def _memory_row_background_color(row: int, checked: bool, theme: ThemeSettings) 
     if row % 2:
         return mix(theme.page_background_color, "#ffffff", 0.35)
     return mix(theme.page_background_color, "#ffffff", 0.70)
+
+
+def _sort_memories_by_latest_time(
+    memories: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    """按更新时间倒序排列记忆，缺少更新时间时使用创建时间。"""
+    return sorted(memories, key=_memory_latest_time_sort_key, reverse=True)
+
+
+def _memory_latest_time_sort_key(memory: dict[str, object]) -> float:
+    for field in ("updated_at", "created_at"):
+        parsed = _parse_memory_time(str(memory.get(field) or ""))
+        if parsed is not None:
+            return parsed
+    return float("-inf")
+
+
+def _parse_memory_time(value: str) -> float | None:
+    text = value.strip()
+    if not text:
+        return None
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).timestamp()
+    except (OSError, ValueError):
+        return None
+
 
 def _format_memory_time(value: str) -> str:
     text = value.strip()

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -3151,6 +3151,65 @@ def test_settings_dialog_loads_memory_on_open_in_background() -> None:
     app.processEvents()
 
 
+def test_settings_dialog_sorts_memory_by_latest_time_on_top() -> None:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    if not hasattr(qtwidgets, "QApplication"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+
+    from app.ui.settings_dialog import SettingsDialog
+
+    class MemoryStoreStub:
+        def __init__(self) -> None:
+            self.list_calls = 0
+
+        def list_memories(self, *, limit: int = 20):  # type: ignore[no-untyped-def]
+            self.list_calls += 1
+            return [
+                {
+                    "id": "memory-old",
+                    "content": "较旧记忆",
+                    "updated_at": "2026-06-01T10:00:00+08:00",
+                },
+                {"id": "memory-missing-time", "content": "缺少时间记忆"},
+                {
+                    "id": "memory-created",
+                    "content": "按创建时间兜底的记忆",
+                    "created_at": "2026-06-02T09:00:00+08:00",
+                },
+                {
+                    "id": "memory-new",
+                    "content": "最新记忆",
+                    "updated_at": "2026-06-03T12:00:00+08:00",
+                },
+            ]
+
+    QApplication = qtwidgets.QApplication
+    app = QApplication.instance() or QApplication([])
+    dialog = SettingsDialog(
+        api_settings=ApiSettings(
+            base_url="https://api.example.com/v1",
+            api_key="test-key",
+            model="test-model",
+        ),
+        tts_settings=_minimal_tts_settings(),
+        base_dir=Path("."),
+        proactive_care_settings=ProactiveCareSettings(screen_context_enabled=True),
+        mcp_settings=MCPRuntimeSettings(windows_enabled=False),
+        memory_store=MemoryStoreStub(),  # type: ignore[arg-type]
+    )
+
+    assert _process_events_until(app, lambda: dialog._memory_list_thread is None)
+    assert [dialog.memory_table.item(row, 1).text() for row in range(4)] == [
+        "最新记忆",
+        "按创建时间兜底的记忆",
+        "较旧记忆",
+        "缺少时间记忆",
+    ]
+    dialog.deleteLater()
+    app.processEvents()
+
+
 def test_settings_dialog_memory_loader_thread_is_not_dialog_child() -> None:
     os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
     qtwidgets = pytest.importorskip("PySide6.QtWidgets")


### PR DESCRIPTION
Summary: Sort memory management entries by latest timestamp, newest first. Prefer updated_at and fall back to created_at when updated_at is missing. Add UI regression coverage for memory ordering. Tests: python -m pytest tests\ui\test_pet_window.py -k settings_dialog_sorts_memory_by_latest_time_on_top or settings_dialog_loads_memory_on_open_in_background or settings_dialog_filters_memory_locally