### PR TITLE
fix: 气泡/输入栏重新显示时补 raise，避免被立绘遮挡

### DIFF
--- a/app/ui/bubble_auto_hide.py
+++ b/app/ui/bubble_auto_hide.py
@@ -131,6 +131,8 @@ class BubbleAutoHideController(QObject):
         if not window.isVisible():
             window.setWindowOpacity(0.0)
             window.show()
+            # macOS 上 Qt.Tool 子窗口 show() 不会自动浮到父窗口（立绘）之上，需显式 raise
+            window.raise_()
         anim = self._make_fade(window.windowOpacity(), 1.0)
         anim.start()
         self._fade_anim = anim

--- a/app/ui/input_bar_animator.py
+++ b/app/ui/input_bar_animator.py
@@ -149,6 +149,8 @@ class InputBarAnimator(QObject):
         if show:
             self._maybe_before_show()
             self._input_window.show()
+            # macOS 上 Qt.Tool 子窗口 show() 不会自动浮到父窗口（立绘）之上，需显式 raise
+            self._input_window.raise_()
         anim = QPropertyAnimation(self._input_window, b"windowOpacity")
         anim.setDuration(HOVER_ANIM_DURATION_MS)
         anim.setEndValue(1.0 if show else 0.0)
@@ -173,6 +175,7 @@ class InputBarAnimator(QObject):
             self._maybe_before_show()
             self._input_window.setWindowOpacity(1.0)
             self._input_window.show()
+            self._input_window.raise_()
         else:
             self._input_window.setWindowOpacity(0.0)
             self._input_window.hide()

--- a/tests/ui/test_bubble_auto_hide.py
+++ b/tests/ui/test_bubble_auto_hide.py
@@ -97,6 +97,33 @@ def test_pet_click_reveals_when_hidden() -> None:
     window.deleteLater()
 
 
+def test_reveal_after_hidden_shows_and_raises() -> None:
+    from PySide6.QtWidgets import QWidget
+
+    _qt_app_or_skip()
+
+    class RaiseTrackingWindow(QWidget):
+        raise_count = 0
+
+        def raise_(self) -> None:  # noqa: N802
+            self.raise_count += 1
+            super().raise_()
+
+    window = RaiseTrackingWindow()
+    window.show()
+    controller = _make(window, [False])
+    controller.notify_settled()
+    controller._on_hide_timeout()
+    controller._on_fade_out_finished()  # 跳过淡出动画，直接落到真正隐藏态
+    assert not window.isVisible()
+    window.raise_count = 0
+    # macOS 上 Qt.Tool 子窗口 show() 不会自动浮到立绘之上，唤回时必须 raise。
+    controller.notify_speaking()
+    assert window.isVisible()
+    assert window.raise_count == 1
+    window.deleteLater()
+
+
 def test_set_settings_disable_reveals_and_stops() -> None:
     from PySide6.QtWidgets import QWidget
 

--- a/tests/ui/test_input_bar_animator.py
+++ b/tests/ui/test_input_bar_animator.py
@@ -40,6 +40,44 @@ def test_before_show_runs_before_window_show() -> None:
     window.deleteLater()
 
 
+def test_show_paths_raise_window_above_portrait() -> None:
+    from PySide6.QtWidgets import QWidget
+
+    _qt_app_or_skip()
+    bar = QWidget()
+
+    class RaiseTrackingWindow(QWidget):
+        raise_count = 0
+
+        def raise_(self) -> None:  # noqa: N802
+            self.raise_count += 1
+            super().raise_()
+
+    window = RaiseTrackingWindow()
+    animator = InputBarAnimator(
+        bar,
+        window,
+        is_pinned=lambda: True,
+        is_hover_active=lambda: False,
+    )
+    # macOS 上 Qt.Tool 子窗口 show() 不会自动浮到立绘之上，两条显示路径都必须 raise。
+    # 静止态显示路径：start → _apply_resting_state。
+    animator.start()
+    assert window.isVisible()
+    assert window.raise_count == 1
+
+    # 淡入显示路径：拖动挂起后恢复 → _animate(True)。
+    animator.suspend_for_drag()
+    window.hide()  # 模拟淡出动画结束后的真正隐藏
+    window.raise_count = 0
+    animator.resume_after_drag()
+    assert window.isVisible()
+    assert window.raise_count == 1
+
+    bar.deleteLater()
+    window.deleteLater()
+
+
 def test_suspend_for_drag_hides_and_blocks_sync() -> None:
     from PySide6.QtWidgets import QWidget
 


### PR DESCRIPTION
## 问题

macOS 上桌宠说话输出时，对话气泡会被立绘遮挡（用户反馈），鼠标悬停唤出的输入栏偶发同样问题。

## 根因

气泡 `bubble_window` 与输入栏 `input_window` 是独立的 Qt.Tool 无边框窗口，立绘在主窗口 `PetWindow` 中。macOS 上 Qt.Tool 子窗口 `show()` 后不会自动浮到父窗口之上（pet_window.py 的 showEvent/moveEvent 等路径已为此显式补过 raise），但有三条显示路径遗漏：

1. `BubbleAutoHideController._reveal()` — 气泡自动隐藏后，**每段新台词输出**都会经 `notify_speaking()` 走此路径唤回气泡，只 `show()` 未 `raise_()`，气泡直接出现在立绘后面。这是用户报告现象的主路径。
2. `InputBarAnimator._animate()` — hover 淡入显示路径。
3. `InputBarAnimator._apply_resting_state()` — 静止态显示路径。

此前 #58 中的修复（89ba1f2）只覆盖了置顶 flag 同步场景，不含上述路径。

## 修复

三处 `show()` 后各补一行 `raise_()`，无其他逻辑变化。

## 测试

- 新增 `test_reveal_after_hidden_shows_and_raises`（气泡唤回必须 raise）
- 新增 `test_show_paths_raise_window_above_portrait`（输入栏两条显示路径必须 raise）
- 全量通过：tests/unit 311 passed + tests/ui 206 passed（macOS, PySide6 6.11.1）

🤖 Generated with [Claude Code](https://claude.com/claude-code)