### PR TITLE
feat: 新增 GUI 运行时日志窗口

### DIFF
--- a/app/core/debug_log.py
+++ b/app/core/debug_log.py
@@ -7,6 +7,8 @@ from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Any
 
+from app.core.gui_log import record_debug_log_for_gui
+
 
 
 DEBUG_KEY = "SAKURA_DEBUG"
@@ -62,12 +64,18 @@ def debug_file_enabled() -> bool:
 
 def debug_log(category: str, message: str, data: Any | None = None) -> None:
     """按统一格式输出调试日志；文件日志始终使用严格脱敏数据。"""
+    timestamp = datetime.now().astimezone().isoformat(timespec="seconds")
+    try:
+        record_debug_log_for_gui(category, message, data, timestamp=timestamp)
+    except Exception:
+        # GUI 日志只是诊断辅助，任何异常都不应影响主流程。
+        pass
+
     terminal_enabled = debug_enabled()
     file_enabled = debug_file_enabled()
     if not terminal_enabled and not file_enabled:
         return
 
-    timestamp = datetime.now().astimezone().isoformat(timespec="seconds")
     if terminal_enabled:
         line = f"[Debug][{category}][{timestamp}] {message}"
         if data is not None:

--- a/app/core/gui_log.py
+++ b/app/core/gui_log.py
@@ -60,9 +60,9 @@ _PROGRAM_INFO_MESSAGES = {
 }
 _PROGRAM_MESSAGE_LABELS = {
     ("API", "准备发送聊天补全请求"): "发送请求",
-    ("API", "准备发送原生工具聊天补全请求"): "发送请求",
-    ("API", "模型原始文本返回"): "收到回复",
-    ("API", "原生工具模型返回"): "收到回复",
+    ("API", "准备发送原生工具聊天补全请求"): "发送请求（带工具）",
+    ("API", "模型原始文本返回"): "收到回复：文本",
+    ("API", "原生工具模型返回"): "收到回复：工具调用",
 }
 _PROGRAM_TTS_MESSAGE_LABELS = {
     "发送 GPT-SoVITS 请求": "送入 TTS：GPT-SoVITS",
@@ -93,6 +93,10 @@ _SEMANTIC_PROGRESS_MERGE_KEY = "semantic-token-progress"
 # 记录各 provider 最近一次 EOS 的 token 数，用于丢弃 tqdm 收尾时重复的最终帧，
 # 避免"预测完成（EOS）"行被一条停在中途百分比的旧进度覆盖
 _LAST_EOS_TOKEN_COUNTS: dict[str, int] = {}
+# 各 provider 最近一次语义 token 推理速度，供 EOS 完成行展示
+_LAST_SPEED_BY_PROVIDER: dict[str, str] = {}
+_SERVER_PROCESS_RE = re.compile(r"\[(\d+)\]")
+_UVICORN_URL_RE = re.compile(r"https?://[^\s)]+")
 _MAX_DETAIL_TEXT_CHARS = 180
 _MAX_DETAIL_ITEMS = 8
 _MAX_DETAIL_KEYS = 16
@@ -207,6 +211,7 @@ def get_gui_log_buffer() -> GuiLogBuffer:
 def clear_gui_logs() -> None:
     _GLOBAL_GUI_LOG_BUFFER.clear()
     _LAST_EOS_TOKEN_COUNTS.clear()
+    _LAST_SPEED_BY_PROVIDER.clear()
 
 
 def record_debug_log_for_gui(
@@ -234,7 +239,7 @@ def record_debug_log_for_gui(
         scope=scope,
         level=level,
         category=category_text,
-        message=_compact_debug_message(category_text, message_text),
+        message=_compact_debug_message(category_text, message_text, data),
         detail=detail,
         text_preview=_tts_text_preview(category_text, data),
     )
@@ -319,15 +324,50 @@ def _should_record(scope: str, category: str, message: str, level: str) -> bool:
     return message in _PROGRAM_INFO_MESSAGES or (category, message) in _PROGRAM_MESSAGE_LABELS
 
 
-def _compact_debug_message(category: str, message: str) -> str:
+def _compact_debug_message(category: str, message: str, data: Any | None = None) -> str:
     if category.lower() == "tts":
         label = _PROGRAM_TTS_MESSAGE_LABELS.get(message)
         if label:
             return label
     label = _PROGRAM_MESSAGE_LABELS.get((category, message))
     if label:
+        if message == "原生工具模型返回":
+            tool_calls = data.get("tool_calls") if isinstance(data, dict) else None
+            if isinstance(tool_calls, list):
+                if tool_calls:
+                    tool_names = _extract_tool_names(data)
+                    return f"收到回复：工具调用：{tool_names}" if tool_names else "收到回复：工具调用"
+                else:
+                    # tool_calls 为空列表说明模型实际只返回了文本内容
+                    return "收到回复：文本"
         return label
     return _compact_message(message)
+
+
+def _extract_tool_names(data: Any | None) -> str:
+    """从 tool_calls 数据中提取工具函数名，用于日志展示。
+
+    支持内部自定义格式（call["name"]）和 OpenAI 标准格式（call["function"]["name"]）。
+    """
+    if not isinstance(data, dict):
+        return ""
+    tool_calls = data.get("tool_calls")
+    if not isinstance(tool_calls, list) or not tool_calls:
+        return ""
+    names: list[str] = []
+    for call in tool_calls:
+        if not isinstance(call, dict):
+            continue
+        # 内部格式：{"name": "tool_name", "type": "tool_call", ...}
+        # OpenAI 格式：{"function": {"name": "tool_name"}, ...}
+        name = call.get("name") or (call.get("function") or {}).get("name")
+        if name:
+            names.append(str(name))
+    if not names:
+        return ""
+    if len(names) > 3:
+        return "、".join(names[:3]) + f" 等 {len(names)} 个"
+    return "、".join(names)
 
 
 def _compact_message(message: str) -> str:
@@ -365,22 +405,23 @@ def _compact_tts_service_message(line: str, provider: str) -> tuple[str, str]:
             start = int(eos_match.group("start"))
             end = int(eos_match.group("end"))
             _LAST_EOS_TOKEN_COUNTS[provider] = end
+            speed = _LAST_SPEED_BY_PROVIDER.pop(provider, "")
+            speed_part = f"，{speed} it/s" if speed else ""
             return (
-                f"语义 token 预测完成：EOS（{start} → {end}）",
+                f"语义 token 预测完成：EOS（{start} → {end}{speed_part}）",
                 _SEMANTIC_PROGRESS_MERGE_KEY,
             )
         return "语义 token 预测完成（EOS）", _SEMANTIC_PROGRESS_MERGE_KEY
-    if "Set seed to" in line:
-        return "设置随机种子", ""
-    if "分桶处理模式已开启" in line:
-        return "分桶处理已开启", ""
+    if "Set seed to" in line or "分桶处理模式已开启" in line:
+        return "", ""  # 内部初始化操作，不展示
 
     progress_message = _semantic_progress_message(line, provider)
     if progress_message is not None:
         return progress_message, _SEMANTIC_PROGRESS_MERGE_KEY
 
     if line.startswith("INFO:"):
-        return _compact_message(line.removeprefix("INFO:").strip()), ""
+        content = line.removeprefix("INFO:").strip()
+        return _compact_message(_translate_info_line(content)), ""
     if line.startswith(("ERROR:", "WARNING:")):
         return _compact_message(line), ""
     if any(marker in line.lower() for marker in ("error", "warning", "started", "server", "http")):
@@ -408,7 +449,9 @@ def _semantic_progress_message(line: str, provider: str) -> str | None:
     if current is not None and total is not None:
         extras.append(f"{current}/{total}")
     if speed_match is not None:
-        extras.append(f"{speed_match.group('speed')} it/s")
+        speed_str = speed_match.group("speed")
+        _LAST_SPEED_BY_PROVIDER[provider] = speed_str  # 缓存速度，供 EOS 完成行展示
+        extras.append(f"{speed_str} it/s")
     extras_text = f"（{'，'.join(extras)}）" if extras else ""
 
     if percent_match is not None:
@@ -427,6 +470,32 @@ def _summarize_service_text_line(line: str) -> str:
     if not text:
         return "收到合成文本"
     return f"收到合成文本（{len(text)} 字）"
+
+
+def _translate_info_line(line: str) -> str:
+    """将 uvicorn/服务常见英文 INFO 行翻译为中文，无匹配时原样返回。"""
+    lower = line.lower()
+    if "started server process" in lower:
+        m = _SERVER_PROCESS_RE.search(line)
+        pid = m.group(1) if m else ""
+        return f"已启动服务进程 [{pid}]" if pid else "已启动服务进程"
+    if "waiting for application startup" in lower:
+        return "等待应用启动…"
+    if "application startup complete" in lower:
+        return "应用启动完成"
+    if "uvicorn running on" in lower:
+        m = _UVICORN_URL_RE.search(line)
+        url = m.group(0) if m else ""
+        return f"服务已就绪：{url}" if url else "服务已就绪"
+    if "waiting for application shutdown" in lower:
+        return "等待应用关闭…"
+    if "application shutdown complete" in lower:
+        return "应用关闭完成"
+    if "finished server process" in lower:
+        return "服务进程已结束"
+    if "shutting down" in lower:
+        return "服务正在关闭"
+    return line
 
 
 def _tts_text_preview(category: str, data: Any | None) -> str:

--- a/app/core/gui_log.py
+++ b/app/core/gui_log.py
@@ -1,0 +1,509 @@
+from __future__ import annotations
+
+import json
+import re
+import threading
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+GUI_LOG_SCOPE_PROGRAM = "program"
+GUI_LOG_SCOPE_TTS = "tts"
+GUI_LOG_LEVEL_INFO = "info"
+GUI_LOG_LEVEL_WARNING = "warning"
+GUI_LOG_LEVEL_ERROR = "error"
+DEFAULT_GUI_LOG_SCOPE_LIMIT = 200
+
+_SENSITIVE_KEY_MARKERS = ("api_key", "authorization", "token", "secret", "password")
+_PRIVATE_TEXT_KEY_MARKERS = (
+    "body",
+    "content",
+    "input",
+    "messages",
+    "output",
+    "payload",
+    "prompt",
+    "query",
+    "reply",
+    "response",
+    "system_prompt",
+    "text",
+    "translation",
+)
+_ERROR_MARKERS = (
+    "error",
+    "exception",
+    "fail",
+    "failed",
+    "timeout",
+    "不可用",
+    "失败",
+    "异常",
+    "错误",
+    "超时",
+    "无效",
+)
+_WARNING_MARKERS = (
+    "fallback",
+    "warning",
+    "回退",
+    "警告",
+)
+_PROGRAM_INFO_MESSAGES = {
+    "应用初始化完成",
+    "初始主窗口服务已创建",
+    "TTS Provider 已创建",
+    "后台启动服务已创建",
+    "后台启动服务已注入窗口",
+}
+_PROGRAM_MESSAGE_LABELS = {
+    ("API", "准备发送聊天补全请求"): "发送请求",
+    ("API", "准备发送原生工具聊天补全请求"): "发送请求",
+    ("API", "模型原始文本返回"): "收到回复",
+    ("API", "原生工具模型返回"): "收到回复",
+}
+_PROGRAM_TTS_MESSAGE_LABELS = {
+    "发送 GPT-SoVITS 请求": "送入 TTS：GPT-SoVITS",
+    "发送 Genie TTS 请求": "送入 TTS：Genie",
+    "GPT-SoVITS 请求成功": "合成完成：GPT-SoVITS",
+    "Genie 临时音频已写入": "合成完成：Genie",
+    "音频请求失败": "TTS 合成失败",
+    "开始播放音频": "开始播放",
+    "音频播放完成": "播放完成",
+    "已启动本地 GPT-SoVITS 服务": "准备：已拉起 GPT-SoVITS 服务",
+    "本地 GPT-SoVITS 服务启动并探测成功": "准备：GPT-SoVITS 服务已就绪",
+    "已启动本地 Genie TTS 服务": "准备：已拉起 Genie TTS 服务",
+    "本地 Genie TTS 服务启动并探测成功": "准备：Genie TTS 服务已就绪",
+    "服务探测成功": "准备：TTS 服务探测成功",
+    "Genie 服务探测成功": "准备：Genie TTS 服务探测成功",
+    "角色权重切换完成": "准备：TTS 角色权重切换完成",
+}
+_ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
+_HTTP_LINE_RE = re.compile(
+    r'"(?P<method>[A-Z]+)\s+(?P<path>[^\s"]+)[^"]*"\s+(?P<status>\d{3})(?:\s+(?P<status_text>[A-Za-z]+))?'
+)
+_PROGRESS_RE = re.compile(r"(?P<percent>\d{1,3})%\|")
+_PROGRESS_COUNT_RE = re.compile(r"(?P<current>\d+)\s*/\s*(?P<total>\d+)")
+_PROGRESS_SPEED_RE = re.compile(r"(?P<speed>\d+(?:\.\d+)?)\s*it/s")
+_T2S_EOS_RE = re.compile(r"Decoding EOS \[\s*(?P<start>\d+)\s*->\s*(?P<end>\d+)\s*\]")
+# 语义 token 预测进度的原地合并键：相邻进度记录互相替换，只保留最新一条
+_SEMANTIC_PROGRESS_MERGE_KEY = "semantic-token-progress"
+# 记录各 provider 最近一次 EOS 的 token 数，用于丢弃 tqdm 收尾时重复的最终帧，
+# 避免"预测完成（EOS）"行被一条停在中途百分比的旧进度覆盖
+_LAST_EOS_TOKEN_COUNTS: dict[str, int] = {}
+_MAX_DETAIL_TEXT_CHARS = 180
+_MAX_DETAIL_ITEMS = 8
+_MAX_DETAIL_KEYS = 16
+_TEXT_PREVIEW_MAX_CHARS = 60
+
+
+@dataclass(frozen=True)
+class GuiLogRecord:
+    """展示到 GUI 的精简运行日志记录。"""
+
+    record_id: int
+    timestamp: str
+    scope: str
+    level: str
+    category: str
+    message: str
+    detail: str = ""
+    # 合成/播放相关记录附带的文本内容预览，仅用于界面展示
+    text_preview: str = ""
+    # 非空时，同 scope 相邻的同 merge_key 记录会原地替换（用于推理进度刷新）
+    merge_key: str = ""
+
+
+class GuiLogBuffer:
+    """线程安全的内存环形日志缓冲；只保留本次会话。"""
+
+    def __init__(self, *, max_records_per_scope: int = DEFAULT_GUI_LOG_SCOPE_LIMIT) -> None:
+        self.max_records_per_scope = max(1, int(max_records_per_scope))
+        self._records: dict[str, list[GuiLogRecord]] = {
+            GUI_LOG_SCOPE_PROGRAM: [],
+            GUI_LOG_SCOPE_TTS: [],
+        }
+        self._next_id = 1
+        self._lock = threading.Lock()
+
+    def append(
+        self,
+        *,
+        timestamp: str,
+        scope: str,
+        level: str,
+        category: str,
+        message: str,
+        detail: str = "",
+        text_preview: str = "",
+        merge_key: str = "",
+    ) -> GuiLogRecord:
+        normalized_scope = scope if scope in self._records else GUI_LOG_SCOPE_PROGRAM
+        with self._lock:
+            record = GuiLogRecord(
+                record_id=self._next_id,
+                timestamp=timestamp,
+                scope=normalized_scope,
+                level=level,
+                category=category,
+                message=message,
+                detail=detail,
+                text_preview=text_preview,
+                merge_key=merge_key,
+            )
+            self._next_id += 1
+            scope_records = self._records[normalized_scope]
+            # 进度类记录原地替换上一条，避免高频刷新挤掉环形缓冲里的其他日志
+            if (
+                merge_key
+                and scope_records
+                and scope_records[-1].merge_key == merge_key
+            ):
+                scope_records[-1] = record
+            else:
+                scope_records.append(record)
+            if len(scope_records) > self.max_records_per_scope:
+                del scope_records[: len(scope_records) - self.max_records_per_scope]
+            return record
+
+    def snapshot(
+        self,
+        *,
+        scope: str | None = None,
+        after_id: int = 0,
+    ) -> list[GuiLogRecord]:
+        with self._lock:
+            if scope is not None:
+                records = list(self._records.get(scope, []))
+            else:
+                records = [
+                    record
+                    for scope_records in self._records.values()
+                    for record in scope_records
+                ]
+            return sorted(
+                (record for record in records if record.record_id > after_id),
+                key=lambda record: record.record_id,
+            )
+
+    def clear(self, *, scope: str | None = None) -> None:
+        with self._lock:
+            if scope is None:
+                for scope_records in self._records.values():
+                    scope_records.clear()
+                return
+            self._records.get(scope, []).clear()
+
+
+_GLOBAL_GUI_LOG_BUFFER = GuiLogBuffer()
+
+
+def get_gui_log_buffer() -> GuiLogBuffer:
+    return _GLOBAL_GUI_LOG_BUFFER
+
+
+def clear_gui_logs() -> None:
+    _GLOBAL_GUI_LOG_BUFFER.clear()
+    _LAST_EOS_TOKEN_COUNTS.clear()
+
+
+def record_debug_log_for_gui(
+    category: str,
+    message: str,
+    data: Any | None = None,
+    *,
+    timestamp: str | None = None,
+) -> GuiLogRecord | None:
+    """把内部 debug_log 转为适合界面查看的精简日志。"""
+
+    category_text = str(category).strip() or "Runtime"
+    message_text = str(message).strip()
+    if not message_text:
+        return None
+
+    scope = _scope_for(category_text, message_text)
+    level = _level_for(message_text, data)
+    if not _should_record(scope, category_text, message_text, level):
+        return None
+
+    detail = _format_detail(data)
+    return _GLOBAL_GUI_LOG_BUFFER.append(
+        timestamp=timestamp or _now_iso(),
+        scope=scope,
+        level=level,
+        category=category_text,
+        message=_compact_debug_message(category_text, message_text),
+        detail=detail,
+        text_preview=_tts_text_preview(category_text, data),
+    )
+
+
+def record_tts_service_output(
+    provider: str,
+    line: str,
+    *,
+    timestamp: str | None = None,
+) -> GuiLogRecord | None:
+    """记录本地 TTS 服务原生输出的精简摘要。"""
+
+    raw_line = _normalize_service_line(line)
+    if not raw_line:
+        return None
+    provider_text = str(provider).strip() or "TTS"
+    message, merge_key = _compact_tts_service_message(raw_line, provider_text)
+    if not message:
+        return None
+    return _GLOBAL_GUI_LOG_BUFFER.append(
+        timestamp=timestamp or _now_iso(),
+        scope=GUI_LOG_SCOPE_TTS,
+        level=_level_for(raw_line, None),
+        category=f"{provider_text} 服务",
+        message=message,
+        detail="",
+        merge_key=merge_key,
+    )
+
+
+def _now_iso() -> str:
+    return datetime.now().astimezone().isoformat(timespec="seconds")
+
+
+def _scope_for(category: str, message: str) -> str:
+    _ = message
+    return GUI_LOG_SCOPE_PROGRAM
+
+
+def _level_for(message: str, data: Any | None) -> str:
+    message_haystack = message.lower()
+    if any(marker.lower() in message_haystack for marker in _ERROR_MARKERS):
+        return GUI_LOG_LEVEL_ERROR
+    if _data_has_error_value(data):
+        return GUI_LOG_LEVEL_ERROR
+    if any(marker.lower() in message_haystack for marker in _WARNING_MARKERS):
+        return GUI_LOG_LEVEL_WARNING
+    return GUI_LOG_LEVEL_INFO
+
+
+def _safe_data_for_level(data: Any | None) -> Any:
+    if isinstance(data, dict):
+        return {
+            str(key): value
+            for key, value in data.items()
+            if not _is_sensitive_key(str(key).lower())
+        }
+    return data
+
+
+def _data_has_error_value(data: Any | None) -> bool:
+    if not isinstance(data, dict):
+        return False
+    for key, value in data.items():
+        normalized_key = str(key).lower()
+        if normalized_key not in {"error", "exception", "error_body"}:
+            continue
+        if value in (None, "", False, 0):
+            continue
+        return True
+    return False
+
+
+def _should_record(scope: str, category: str, message: str, level: str) -> bool:
+    if level == GUI_LOG_LEVEL_ERROR:
+        return True
+    if category.lower() == "tts":
+        return message in _PROGRAM_TTS_MESSAGE_LABELS
+    if level == GUI_LOG_LEVEL_WARNING:
+        return True
+    return message in _PROGRAM_INFO_MESSAGES or (category, message) in _PROGRAM_MESSAGE_LABELS
+
+
+def _compact_debug_message(category: str, message: str) -> str:
+    if category.lower() == "tts":
+        label = _PROGRAM_TTS_MESSAGE_LABELS.get(message)
+        if label:
+            return label
+    label = _PROGRAM_MESSAGE_LABELS.get((category, message))
+    if label:
+        return label
+    return _compact_message(message)
+
+
+def _compact_message(message: str) -> str:
+    return _truncate(message.replace("\r", " ").replace("\n", " "), 140)
+
+
+def _normalize_service_line(line: str) -> str:
+    text = _ANSI_RE.sub("", str(line))
+    if "\r" in text:
+        # 一段里混有多次 \r 刷新时（按行读取的退路），只保留最新一帧
+        segments = [segment for segment in text.split("\r") if segment.strip()]
+        text = segments[-1] if segments else ""
+    text = re.sub(r"\s+", " ", text.strip())
+    return text
+
+
+def _compact_tts_service_message(line: str, provider: str) -> tuple[str, str]:
+    """压缩服务输出行，返回 (消息, 合并键)；消息为空表示丢弃该行。"""
+    http_match = _HTTP_LINE_RE.search(line)
+    if http_match is not None:
+        method = http_match.group("method")
+        path = http_match.group("path")
+        status = http_match.group("status")
+        status_text = http_match.group("status_text") or ""
+        return f"HTTP {method} {path} -> {status} {status_text}".strip(), ""
+
+    if "合成音频" in line:
+        return "开始合成音频", ""
+    if "实际输入的目标文本" in line or "目标文本" in line:
+        return _summarize_service_text_line(line), ""
+    if "Decoding EOS" in line:
+        # T2S 语义 token 预测命中 EOS；记录 token 数以便丢弃 tqdm 收尾重复帧
+        eos_match = _T2S_EOS_RE.search(line)
+        if eos_match is not None:
+            start = int(eos_match.group("start"))
+            end = int(eos_match.group("end"))
+            _LAST_EOS_TOKEN_COUNTS[provider] = end
+            return (
+                f"语义 token 预测完成：EOS（{start} → {end}）",
+                _SEMANTIC_PROGRESS_MERGE_KEY,
+            )
+        return "语义 token 预测完成（EOS）", _SEMANTIC_PROGRESS_MERGE_KEY
+    if "Set seed to" in line:
+        return "设置随机种子", ""
+    if "分桶处理模式已开启" in line:
+        return "分桶处理已开启", ""
+
+    progress_message = _semantic_progress_message(line, provider)
+    if progress_message is not None:
+        return progress_message, _SEMANTIC_PROGRESS_MERGE_KEY
+
+    if line.startswith("INFO:"):
+        return _compact_message(line.removeprefix("INFO:").strip()), ""
+    if line.startswith(("ERROR:", "WARNING:")):
+        return _compact_message(line), ""
+    if any(marker in line.lower() for marker in ("error", "warning", "started", "server", "http")):
+        return _compact_message(line), ""
+    return "", ""
+
+
+def _semantic_progress_message(line: str, provider: str) -> str | None:
+    """解析 tqdm 进度行为语义 token 预测进度；返回 None 表示不是进度行，
+    返回空串表示是进度行但应丢弃（EOS 后的收尾重复帧）。"""
+    percent_match = _PROGRESS_RE.search(line)
+    count_match = _PROGRESS_COUNT_RE.search(line)
+    if percent_match is None and (count_match is None or "it/s" not in line):
+        return None
+
+    current = int(count_match.group("current")) if count_match else None
+    total = int(count_match.group("total")) if count_match else None
+    if current is not None and _LAST_EOS_TOKEN_COUNTS.get(provider) == current:
+        # EOS 已经展示完成行，丢弃 tqdm 关闭时停在中途百分比的最终帧
+        _LAST_EOS_TOKEN_COUNTS.pop(provider, None)
+        return ""
+
+    speed_match = _PROGRESS_SPEED_RE.search(line)
+    extras: list[str] = []
+    if current is not None and total is not None:
+        extras.append(f"{current}/{total}")
+    if speed_match is not None:
+        extras.append(f"{speed_match.group('speed')} it/s")
+    extras_text = f"（{'，'.join(extras)}）" if extras else ""
+
+    if percent_match is not None:
+        percent = min(100, int(percent_match.group("percent")))
+        return f"语义 token 预测 {percent}%{extras_text}"
+    return f"语义 token 预测{extras_text}"
+
+
+def _summarize_service_text_line(line: str) -> str:
+    text = line
+    for separator in (":", "："):
+        if separator in text:
+            text = text.split(separator, 1)[1]
+            break
+    text = text.strip(" []'\"")
+    if not text:
+        return "收到合成文本"
+    return f"收到合成文本（{len(text)} 字）"
+
+
+def _tts_text_preview(category: str, data: Any | None) -> str:
+    """TTS 合成/播放记录提取文本内容预览，供界面灰字直接展示。
+
+    仅 GUI 内存日志使用；文件日志与 detail 字段仍按既有规则脱敏。
+    """
+    if category.lower() != "tts" or not isinstance(data, dict):
+        return ""
+    text = data.get("text")
+    if not isinstance(text, str):
+        return ""
+    text = " ".join(text.split())
+    if len(text) > _TEXT_PREVIEW_MAX_CHARS:
+        return f"{text[:_TEXT_PREVIEW_MAX_CHARS]}…"
+    return text
+
+
+def _format_detail(data: Any | None) -> str:
+    if data is None:
+        return ""
+    safe = _sanitize_detail(data, private_context=False)
+    return json.dumps(safe, ensure_ascii=False, default=str)
+
+
+def _sanitize_detail(value: Any, *, private_context: bool) -> Any:
+    if isinstance(value, dict):
+        sanitized: dict[str, Any] = {}
+        items = list(value.items())
+        for key, item_value in items[:_MAX_DETAIL_KEYS]:
+            key_text = str(key)
+            normalized_key = key_text.lower()
+            if _is_sensitive_key(normalized_key):
+                sanitized[key_text] = "<redacted>"
+                continue
+            next_private_context = private_context or _is_private_text_key(normalized_key)
+            sanitized[key_text] = _sanitize_detail(
+                item_value,
+                private_context=next_private_context,
+            )
+        if len(items) > _MAX_DETAIL_KEYS:
+            sanitized["omitted_keys"] = len(items) - _MAX_DETAIL_KEYS
+        return sanitized
+    if isinstance(value, list):
+        if private_context:
+            return {"type": "list", "items": len(value)}
+        items = [
+            _sanitize_detail(item, private_context=private_context)
+            for item in value[:_MAX_DETAIL_ITEMS]
+        ]
+        if len(value) > _MAX_DETAIL_ITEMS:
+            items.append({"omitted_items": len(value) - _MAX_DETAIL_ITEMS})
+        return items
+    if isinstance(value, tuple):
+        return _sanitize_detail(list(value), private_context=private_context)
+    if isinstance(value, bytes):
+        return {"type": "bytes", "bytes": len(value)}
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, str):
+        if value.startswith("data:image/"):
+            return {"type": "image_data_url", "chars": len(value)}
+        if private_context:
+            return {"type": "text", "chars": len(value)}
+        return _truncate(value, _MAX_DETAIL_TEXT_CHARS)
+    return value
+
+
+def _is_sensitive_key(normalized_key: str) -> bool:
+    return any(marker in normalized_key for marker in _SENSITIVE_KEY_MARKERS)
+
+
+def _is_private_text_key(normalized_key: str) -> bool:
+    return any(marker in normalized_key for marker in _PRIVATE_TEXT_KEY_MARKERS)
+
+
+def _truncate(text: str, max_chars: int) -> str:
+    if len(text) <= max_chars:
+        return text
+    return f"{text[:max_chars]}...<truncated {len(text) - max_chars} chars>"

--- a/app/ui/log_window.py
+++ b/app/ui/log_window.py
@@ -546,8 +546,11 @@ def _detail_summary(detail: str) -> str:
     return " · ".join(pairs)
 
 
-def _record_collapse_key(record: GuiLogRecord) -> tuple[str, str, str, str, str]:
+def _record_collapse_key(record: GuiLogRecord) -> tuple:
     # 含 text_preview：文本不同的"开始播放"等记录不应折叠成一条
+    # 合成文本记录内容各异，用 record_id 保证每条独立展示，避免同字数文本被误折叠为 ×N
+    if record.message.startswith("收到合成文本"):
+        return (record.scope, record.level, record.category, record.message, record.text_preview, record.record_id)
     return (record.scope, record.level, record.category, record.message, record.text_preview)
 
 

--- a/app/ui/log_window.py
+++ b/app/ui/log_window.py
@@ -1,0 +1,577 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+from PySide6.QtCore import QRectF, QSize, Qt, QTimer
+from PySide6.QtGui import QColor, QFont, QFontMetricsF, QPainter
+from PySide6.QtWidgets import (
+    QApplication,
+    QCheckBox,
+    QDialog,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QPushButton,
+    QStyle,
+    QStyledItemDelegate,
+    QStyleOptionViewItem,
+    QTabWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
+from app.core.gui_log import (
+    GUI_LOG_LEVEL_ERROR,
+    GUI_LOG_LEVEL_INFO,
+    GUI_LOG_LEVEL_WARNING,
+    GUI_LOG_SCOPE_PROGRAM,
+    GUI_LOG_SCOPE_TTS,
+    GuiLogBuffer,
+    GuiLogRecord,
+    get_gui_log_buffer,
+)
+from app.ui.theme import (
+    DEFAULT_THEME_SETTINGS,
+    ThemeSettings,
+    build_runtime_log_window_stylesheet,
+)
+
+
+_POLL_INTERVAL_MS = 700
+_LEVEL_LABELS = {
+    GUI_LOG_LEVEL_INFO: "信息",
+    GUI_LOG_LEVEL_WARNING: "提醒",
+    GUI_LOG_LEVEL_ERROR: "错误",
+}
+_COPY_TEXT_ROLE = int(Qt.ItemDataRole.UserRole)
+_COLLAPSE_KEY_ROLE = _COPY_TEXT_ROLE + 1
+_REPEAT_COUNT_ROLE = _COPY_TEXT_ROLE + 2
+_BASE_COPY_TEXT_ROLE = _COPY_TEXT_ROLE + 3
+_BASE_TOOLTIP_ROLE = _COPY_TEXT_ROLE + 4
+_SEGMENTS_ROLE = _COPY_TEXT_ROLE + 5
+_LEVEL_ROLE = _COPY_TEXT_ROLE + 6
+_MERGE_KEY_ROLE = _COPY_TEXT_ROLE + 7
+
+# 行内分段类型：时间 / 分类标签 / 级别 / 消息 / 详情摘要 / 重复次数
+_SEG_TIME = "time"
+_SEG_CATEGORY = "category"
+_SEG_LEVEL = "level"
+_SEG_MESSAGE = "message"
+_SEG_DETAIL = "detail"
+_SEG_REPEAT = "repeat"
+
+_LEVEL_TEXT_COLORS = {
+    GUI_LOG_LEVEL_ERROR: "#b13e5a",
+    GUI_LOG_LEVEL_WARNING: "#9c6a1b",
+}
+# warning/error 行的淡色背景，让异常行一眼可辨
+_LEVEL_ROW_BG_ALPHA = {
+    GUI_LOG_LEVEL_ERROR: 24,
+    GUI_LOG_LEVEL_WARNING: 22,
+}
+
+# 详情摘要优先展示的字段；其余标量字段按出现顺序补足
+_DETAIL_PRIORITY_KEYS = (
+    "model",
+    "provider",
+    "voice",
+    "character",
+    "status",
+    "status_code",
+    "elapsed_ms",
+    "duration_ms",
+    "chars",
+    "count",
+    "error",
+)
+_MAX_DETAIL_SUMMARY_ITEMS = 3
+_MAX_DETAIL_SUMMARY_VALUE_CHARS = 36
+
+
+def _with_alpha(color_text: str, alpha: int) -> QColor:
+    color = QColor(color_text)
+    color.setAlpha(max(0, min(255, alpha)))
+    return color
+
+
+class RuntimeLogItemDelegate(QStyledItemDelegate):
+    """按分段绘制日志行：时间淡色、分类做成标签、消息按级别着色、详情摘要弱化。"""
+
+    _ROW_VPAD = 5
+    _ROW_HPAD = 10
+    _SEGMENT_SPACING = 8
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._theme = DEFAULT_THEME_SETTINGS
+
+    def set_theme_settings(self, settings: ThemeSettings) -> None:
+        self._theme = (settings or DEFAULT_THEME_SETTINGS).normalized()
+
+    def sizeHint(self, option: QStyleOptionViewItem, index) -> QSize:  # type: ignore[no-untyped-def]
+        base = super().sizeHint(option, index)
+        height = int(QFontMetricsF(option.font).height()) + self._ROW_VPAD * 2 + 4
+        return QSize(base.width(), max(base.height(), height))
+
+    def paint(self, painter: QPainter, option: QStyleOptionViewItem, index) -> None:  # type: ignore[no-untyped-def]
+        segments = index.data(_SEGMENTS_ROLE)
+        if not segments:
+            super().paint(painter, option, index)
+            return
+        level = str(index.data(_LEVEL_ROLE) or GUI_LOG_LEVEL_INFO)
+
+        painter.save()
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        row_rect = QRectF(option.rect).adjusted(0, 2, 0, -2)
+        background = self._row_background(level, option.state)
+        if background is not None:
+            painter.setPen(Qt.PenStyle.NoPen)
+            painter.setBrush(background)
+            painter.drawRoundedRect(row_rect, 8, 8)
+
+        x = row_rect.left() + self._ROW_HPAD
+        right_limit = row_rect.right() - self._ROW_HPAD
+        for kind, text in segments:
+            if not text or x >= right_limit:
+                break
+            font = self._segment_font(option.font, kind)
+            metrics = QFontMetricsF(font)
+            available = right_limit - x
+            if kind == _SEG_CATEGORY:
+                x = self._draw_category_chip(painter, row_rect, x, available, font, metrics, text)
+                continue
+            elided = metrics.elidedText(text, Qt.TextElideMode.ElideRight, int(available))
+            painter.setFont(font)
+            painter.setPen(self._segment_color(kind, level))
+            text_rect = QRectF(x, row_rect.top(), available, row_rect.height())
+            painter.drawText(
+                text_rect,
+                Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter,
+                elided,
+            )
+            x += metrics.horizontalAdvance(elided) + self._SEGMENT_SPACING
+        painter.restore()
+
+    def _row_background(self, level: str, state) -> QColor | None:  # type: ignore[no-untyped-def]
+        if state & QStyle.StateFlag.State_Selected:
+            return _with_alpha(self._theme.primary_color, 58)
+        level_color = _LEVEL_TEXT_COLORS.get(level)
+        if level_color is not None:
+            return _with_alpha(level_color, _LEVEL_ROW_BG_ALPHA.get(level, 22))
+        return None
+
+    def _draw_category_chip(
+        self,
+        painter: QPainter,
+        row_rect: QRectF,
+        x: float,
+        available: float,
+        font: QFont,
+        metrics: QFontMetricsF,
+        text: str,
+    ) -> float:
+        chip_hpad = 6.0
+        elided = metrics.elidedText(text, Qt.TextElideMode.ElideRight, int(max(0.0, available - chip_hpad * 2)))
+        text_width = metrics.horizontalAdvance(elided)
+        chip_height = metrics.height() + 2
+        chip_rect = QRectF(
+            x,
+            row_rect.center().y() - chip_height / 2,
+            text_width + chip_hpad * 2,
+            chip_height,
+        )
+        painter.setPen(Qt.PenStyle.NoPen)
+        painter.setBrush(_with_alpha(self._theme.primary_color, 34))
+        painter.drawRoundedRect(chip_rect, 5, 5)
+        painter.setFont(font)
+        painter.setPen(QColor(self._theme.secondary_text_color))
+        painter.drawText(chip_rect, Qt.AlignmentFlag.AlignCenter, elided)
+        return chip_rect.right() + self._SEGMENT_SPACING
+
+    def _segment_font(self, base_font: QFont, kind: str) -> QFont:
+        font = QFont(base_font)
+        if kind == _SEG_CATEGORY:
+            # QSS 用 font-size 像素指定字体时 pointSizeF() 为 -1，需按实际单位缩小
+            if font.pixelSize() > 0:
+                font.setPixelSize(max(8, font.pixelSize() - 1))
+            elif font.pointSizeF() > 0:
+                font.setPointSizeF(max(6.0, font.pointSizeF() - 1))
+            font.setBold(True)
+        elif kind == _SEG_LEVEL:
+            font.setBold(True)
+        elif kind == _SEG_REPEAT:
+            font.setBold(True)
+        return font
+
+    def _segment_color(self, kind: str, level: str) -> QColor:
+        if kind in (_SEG_TIME, _SEG_DETAIL):
+            return QColor(self._theme.muted_text_color)
+        if kind == _SEG_REPEAT:
+            return QColor(self._theme.secondary_text_color)
+        level_color = _LEVEL_TEXT_COLORS.get(level)
+        if level_color is not None:
+            return QColor(level_color)
+        return QColor(self._theme.text_color)
+
+
+class RuntimeLogWindow(QDialog):
+    """非模态运行日志窗口，按软件/TTS 两页显示精简日志。"""
+
+    def __init__(
+        self,
+        log_buffer: GuiLogBuffer | None = None,
+        theme_settings: ThemeSettings | None = None,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.log_buffer = log_buffer or get_gui_log_buffer()
+        self.theme_settings = (theme_settings or DEFAULT_THEME_SETTINGS).normalized()
+        self._last_record_id = 0
+        self._lists_by_scope: dict[str, QListWidget] = {}
+        self._last_selected_list: QListWidget | None = None
+        self._item_delegate = RuntimeLogItemDelegate(self)
+
+        self.setWindowTitle("运行日志")
+        self.setWindowModality(Qt.WindowModality.NonModal)
+        self.resize(900, 560)
+
+        self.title_label = QLabel("运行日志", self)
+        self.title_label.setObjectName("runtimeLogTitle")
+        self.summary_label = QLabel("软件与 TTS 服务的本次会话精简日志", self)
+        self.summary_label.setObjectName("runtimeLogSummary")
+
+        header_layout = QHBoxLayout()
+        header_layout.addWidget(self.title_label)
+        header_layout.addStretch(1)
+        header_layout.addWidget(self.summary_label)
+
+        self.program_list, program_page = self._build_log_page(
+            GUI_LOG_SCOPE_PROGRAM,
+            "软件",
+        )
+        self.tts_list, tts_page = self._build_log_page(
+            GUI_LOG_SCOPE_TTS,
+            "TTS 服务",
+        )
+
+        self.tabs = QTabWidget(self)
+        self.tabs.setObjectName("runtimeLogTabs")
+        self.tabs.addTab(program_page, "软件")
+        self.tabs.addTab(tts_page, "TTS")
+
+        self.auto_scroll_check = QCheckBox("自动滚动", self)
+        self.auto_scroll_check.setChecked(True)
+
+        refresh_button = QPushButton("刷新", self)
+        refresh_button.clicked.connect(lambda: self.refresh(reset=True))
+
+        copy_button = QPushButton("复制选中", self)
+        copy_button.clicked.connect(self._copy_selected)
+
+        clear_button = QPushButton("清空", self)
+        clear_button.setObjectName("dangerButton")
+        clear_button.clicked.connect(self._clear_logs)
+
+        close_button = QPushButton("关闭", self)
+        close_button.clicked.connect(self.close)
+
+        button_layout = QHBoxLayout()
+        button_layout.addWidget(self.auto_scroll_check)
+        button_layout.addStretch(1)
+        button_layout.addWidget(refresh_button)
+        button_layout.addWidget(copy_button)
+        button_layout.addWidget(clear_button)
+        button_layout.addWidget(close_button)
+
+        layout = QVBoxLayout()
+        layout.setContentsMargins(18, 18, 18, 16)
+        layout.setSpacing(12)
+        layout.addLayout(header_layout)
+        layout.addWidget(self.tabs, 1)
+        layout.addLayout(button_layout)
+        self.setLayout(layout)
+
+        self._poll_timer = QTimer(self)
+        self._poll_timer.setInterval(_POLL_INTERVAL_MS)
+        self._poll_timer.timeout.connect(self.refresh)
+
+        self.set_theme_settings(self.theme_settings)
+        self.refresh(reset=True)
+
+    def showEvent(self, event) -> None:  # type: ignore[no-untyped-def]
+        super().showEvent(event)
+        self.refresh(reset=True)
+        self._poll_timer.start()
+
+    def hideEvent(self, event) -> None:  # type: ignore[no-untyped-def]
+        super().hideEvent(event)
+        self._poll_timer.stop()
+
+    def set_theme_settings(self, settings: ThemeSettings) -> None:
+        self.theme_settings = (settings or DEFAULT_THEME_SETTINGS).normalized()
+        self.setStyleSheet(build_runtime_log_window_stylesheet(self.theme_settings))
+        self._item_delegate.set_theme_settings(self.theme_settings)
+        for log_list in self._lists_by_scope.values():
+            log_list.viewport().update()
+
+    def refresh(self, *, reset: bool = False) -> None:
+        if reset:
+            self._last_record_id = 0
+            for log_list in self._lists_by_scope.values():
+                log_list.clear()
+
+        records = self.log_buffer.snapshot(after_id=self._last_record_id)
+        if not records:
+            self._refresh_summary()
+            return
+
+        for record in records:
+            self._append_record(record)
+            self._last_record_id = max(self._last_record_id, record.record_id)
+        self._refresh_summary()
+
+    def _build_log_page(self, scope: str, _title: str) -> tuple[QListWidget, QFrame]:
+        page = QFrame(self)
+        page.setObjectName("runtimeLogPage")
+
+        log_list = QListWidget(page)
+        log_list.setObjectName("runtimeLogList")
+        log_list.setSelectionMode(QListWidget.SelectionMode.SingleSelection)
+        log_list.setItemDelegate(self._item_delegate)
+        log_list.itemDoubleClicked.connect(lambda _item: self._copy_selected())
+        log_list.itemSelectionChanged.connect(
+            lambda scope=scope: self._handle_selection_changed(scope)
+        )
+
+        page_layout = QVBoxLayout(page)
+        page_layout.setContentsMargins(12, 12, 12, 12)
+        page_layout.setSpacing(0)
+        page_layout.addWidget(log_list, 1)
+
+        self._lists_by_scope[scope] = log_list
+        return log_list, page
+
+    def _append_record(self, record: GuiLogRecord) -> None:
+        log_list = self._lists_by_scope.get(record.scope)
+        if log_list is None:
+            return
+
+        collapse_key = _record_collapse_key(record)
+        last_item = log_list.item(log_list.count() - 1) if log_list.count() else None
+
+        # 进度类记录：原地替换上一条同 merge_key 的行，而不是追加新行
+        if (
+            record.merge_key
+            and last_item is not None
+            and last_item.data(_MERGE_KEY_ROLE) == record.merge_key
+        ):
+            self._apply_record_to_item(last_item, record)
+            if self.auto_scroll_check.isChecked():
+                log_list.scrollToBottom()
+            return
+
+        if last_item is not None and last_item.data(_COLLAPSE_KEY_ROLE) == collapse_key:
+            repeat_count = int(last_item.data(_REPEAT_COUNT_ROLE) or 1) + 1
+            base_segments = list(last_item.data(_SEGMENTS_ROLE) or [])
+            base_segments = [seg for seg in base_segments if seg[0] != _SEG_REPEAT]
+            segments = _segments_with_repeat(base_segments, repeat_count)
+            base_copy_text = str(
+                last_item.data(_BASE_COPY_TEXT_ROLE)
+                or last_item.data(_COPY_TEXT_ROLE)
+                or last_item.text()
+            )
+            base_tooltip = str(last_item.data(_BASE_TOOLTIP_ROLE) or last_item.toolTip())
+            last_item.setData(_REPEAT_COUNT_ROLE, repeat_count)
+            last_item.setData(_SEGMENTS_ROLE, segments)
+            last_item.setText(_segments_text(segments))
+            last_item.setToolTip(_repeat_tooltip_text(base_tooltip, repeat_count))
+            last_item.setData(_COPY_TEXT_ROLE, _repeat_copy_text(base_copy_text, repeat_count))
+            if self.auto_scroll_check.isChecked():
+                log_list.scrollToBottom()
+            return
+
+        item = QListWidgetItem()
+        self._apply_record_to_item(item, record)
+        log_list.addItem(item)
+        if self.auto_scroll_check.isChecked():
+            log_list.scrollToBottom()
+
+    def _apply_record_to_item(self, item: QListWidgetItem, record: GuiLogRecord) -> None:
+        """把日志记录的全部展示状态写入列表项（新建与原地替换共用）。"""
+        segments = _record_segments(record)
+        tooltip_text = _record_tooltip(record)
+        copy_text = _record_copy_text(record)
+        item.setText(_segments_text(segments))
+        item.setToolTip(tooltip_text)
+        item.setData(_COPY_TEXT_ROLE, copy_text)
+        item.setData(_COLLAPSE_KEY_ROLE, _record_collapse_key(record))
+        item.setData(_REPEAT_COUNT_ROLE, 1)
+        item.setData(_SEGMENTS_ROLE, segments)
+        item.setData(_LEVEL_ROLE, record.level)
+        item.setData(_MERGE_KEY_ROLE, record.merge_key)
+        item.setData(_BASE_COPY_TEXT_ROLE, copy_text)
+        item.setData(_BASE_TOOLTIP_ROLE, tooltip_text)
+
+    def _refresh_summary(self) -> None:
+        parts: list[str] = []
+        for scope, title in (
+            (GUI_LOG_SCOPE_PROGRAM, "软件"),
+            (GUI_LOG_SCOPE_TTS, "TTS 服务"),
+        ):
+            log_list = self._lists_by_scope[scope]
+            count = log_list.count()
+            parts.append(f"{title}：{count} 条")
+        self.summary_label.setText("  |  ".join(parts))
+
+    def _handle_selection_changed(self, scope: str) -> None:
+        selected_list = self._lists_by_scope.get(scope)
+        if selected_list is None or not selected_list.selectedItems():
+            return
+        self._last_selected_list = selected_list
+        for other_scope, other_list in self._lists_by_scope.items():
+            if other_scope == scope:
+                continue
+            other_list.blockSignals(True)
+            other_list.clearSelection()
+            other_list.blockSignals(False)
+
+    def _copy_selected(self) -> None:
+        active_list = self._last_selected_list or self.program_list
+        item = active_list.currentItem()
+        if item is None:
+            return
+        clipboard = QApplication.clipboard()
+        clipboard.setText(str(item.data(_COPY_TEXT_ROLE) or item.text()))
+
+    def _clear_logs(self) -> None:
+        self.log_buffer.clear()
+        self.refresh(reset=True)
+
+
+def _format_time(timestamp: str) -> str:
+    try:
+        return datetime.fromisoformat(timestamp).strftime("%H:%M:%S")
+    except ValueError:
+        return timestamp[-8:] if len(timestamp) >= 8 else timestamp
+
+
+def _record_tooltip(record: GuiLogRecord) -> str:
+    lines = [
+        f"时间：{record.timestamp}",
+        f"分类：{record.category}",
+        f"级别：{_LEVEL_LABELS.get(record.level, record.level)}",
+        f"消息：{record.message}",
+    ]
+    if record.text_preview:
+        lines.append(f"文本：{record.text_preview}")
+    if record.detail:
+        lines.append(f"详情：{record.detail}")
+    return "\n".join(lines)
+
+
+def _record_segments(record: GuiLogRecord) -> list[tuple[str, str]]:
+    """把日志记录拆为带类型的行内分段，供 delegate 分层着色绘制。"""
+    segments: list[tuple[str, str]] = [
+        (_SEG_TIME, _format_time(record.timestamp)),
+        (_SEG_CATEGORY, record.category),
+    ]
+    if record.level != GUI_LOG_LEVEL_INFO:
+        segments.append((_SEG_LEVEL, _LEVEL_LABELS.get(record.level, "信息")))
+    segments.append((_SEG_MESSAGE, record.message))
+    # 合成/播放类记录优先把文本内容作为灰字摘要，其余记录回退到关键字段摘要
+    if record.text_preview:
+        segments.append((_SEG_DETAIL, f"「{record.text_preview}」"))
+    else:
+        summary = _detail_summary(record.detail)
+        if summary:
+            segments.append((_SEG_DETAIL, summary))
+    return segments
+
+
+def _segments_text(segments: list[tuple[str, str]]) -> str:
+    """分段拼出纯文本行，用于无障碍/兜底显示与测试断言。"""
+    parts: list[str] = []
+    for kind, text in segments:
+        if not text:
+            continue
+        if kind == _SEG_CATEGORY:
+            parts.append(f"[{text}]")
+        else:
+            parts.append(text)
+    return "  ".join(parts)
+
+
+def _segments_with_repeat(
+    base_segments: list[tuple[str, str]],
+    repeat_count: int,
+) -> list[tuple[str, str]]:
+    if repeat_count <= 1:
+        return list(base_segments)
+    return [*base_segments, (_SEG_REPEAT, f"×{repeat_count}")]
+
+
+def _detail_summary(detail: str) -> str:
+    """从 detail JSON 提取少量关键标量字段作为行尾摘要。"""
+    if not detail:
+        return ""
+    try:
+        data = json.loads(detail)
+    except ValueError:
+        return ""
+    if not isinstance(data, dict):
+        return ""
+
+    pairs: list[str] = []
+    used_keys: set[str] = set()
+    ordered_keys = [key for key in _DETAIL_PRIORITY_KEYS if key in data]
+    ordered_keys.extend(key for key in data if key not in _DETAIL_PRIORITY_KEYS)
+    for key in ordered_keys:
+        if len(pairs) >= _MAX_DETAIL_SUMMARY_ITEMS:
+            break
+        if key in used_keys or key == "omitted_keys":
+            continue
+        value = data[key]
+        if not isinstance(value, (str, int, float, bool)):
+            continue
+        if value == "" or value == "<redacted>":
+            continue
+        used_keys.add(key)
+        value_text = str(value)
+        if len(value_text) > _MAX_DETAIL_SUMMARY_VALUE_CHARS:
+            value_text = f"{value_text[:_MAX_DETAIL_SUMMARY_VALUE_CHARS]}…"
+        pairs.append(f"{key}={value_text}")
+    return " · ".join(pairs)
+
+
+def _record_collapse_key(record: GuiLogRecord) -> tuple[str, str, str, str, str]:
+    # 含 text_preview：文本不同的"开始播放"等记录不应折叠成一条
+    return (record.scope, record.level, record.category, record.message, record.text_preview)
+
+
+def _repeat_tooltip_text(base_tooltip: str, repeat_count: int) -> str:
+    if repeat_count <= 1:
+        return base_tooltip
+    return f"{base_tooltip}\n连续重复：{repeat_count} 次"
+
+
+def _repeat_copy_text(base_copy_text: str, repeat_count: int) -> str:
+    if repeat_count <= 1:
+        return base_copy_text
+    return f"{base_copy_text} 连续重复：{repeat_count} 次"
+
+
+def _record_copy_text(record: GuiLogRecord) -> str:
+    parts = [
+        f"[{record.timestamp}]",
+        f"[{record.category}]",
+        f"[{_LEVEL_LABELS.get(record.level, record.level)}]",
+        record.message,
+    ]
+    if record.text_preview:
+        parts.append(f"「{record.text_preview}」")
+    if record.detail:
+        parts.append(record.detail)
+    return " ".join(parts)

--- a/app/ui/log_window.py
+++ b/app/ui/log_window.py
@@ -458,6 +458,25 @@ def _format_time(timestamp: str) -> str:
         return timestamp[-8:] if len(timestamp) >= 8 else timestamp
 
 
+def _format_detail_for_display(detail: str) -> str:
+    """格式化 detail JSON 用于展示，将 bytes 字段转换为 KB。"""
+    if not detail:
+        return detail
+    try:
+        data = json.loads(detail)
+    except ValueError:
+        return detail
+    if not isinstance(data, dict):
+        return detail
+    formatted: dict = {}
+    for key, value in data.items():
+        if key == "bytes" and isinstance(value, (int, float)):
+            formatted[key] = f"{value / 1024:.1f} KB"
+        else:
+            formatted[key] = value
+    return json.dumps(formatted, ensure_ascii=False)
+
+
 def _record_tooltip(record: GuiLogRecord) -> str:
     lines = [
         f"时间：{record.timestamp}",
@@ -468,7 +487,7 @@ def _record_tooltip(record: GuiLogRecord) -> str:
     if record.text_preview:
         lines.append(f"文本：{record.text_preview}")
     if record.detail:
-        lines.append(f"详情：{record.detail}")
+        lines.append(f"详情：{_format_detail_for_display(record.detail)}")
     return "\n".join(lines)
 
 
@@ -539,9 +558,12 @@ def _detail_summary(detail: str) -> str:
         if value == "" or value == "<redacted>":
             continue
         used_keys.add(key)
-        value_text = str(value)
-        if len(value_text) > _MAX_DETAIL_SUMMARY_VALUE_CHARS:
-            value_text = f"{value_text[:_MAX_DETAIL_SUMMARY_VALUE_CHARS]}…"
+        if key == "bytes" and isinstance(value, (int, float)):
+            value_text = f"{value / 1024:.1f} KB"
+        else:
+            value_text = str(value)
+            if len(value_text) > _MAX_DETAIL_SUMMARY_VALUE_CHARS:
+                value_text = f"{value_text[:_MAX_DETAIL_SUMMARY_VALUE_CHARS]}…"
         pairs.append(f"{key}={value_text}")
     return " · ".join(pairs)
 

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -88,6 +88,7 @@ from app.platforms.launch_at_login import (
     set_launch_at_login_enabled,
 )
 from app.ui.history_window import HistoryWindow
+from app.ui.log_window import RuntimeLogWindow
 from app.agent.proactive_care import (
     PROACTIVE_SCREEN_CONTEXT_HISTORY_MARKER,
     PROACTIVE_TIMER_DUE_GRACE_SECONDS,
@@ -377,6 +378,7 @@ class PetWindow(QWidget):
         self.tool_registry.set_free_access_enabled(self.free_access_enabled)
         self.always_on_top_enabled = self._load_always_on_top_enabled()
         self.history_window: HistoryWindow | None = None
+        self.runtime_log_window: RuntimeLogWindow | None = None
         self.settings_dialog: SettingsDialog | None = None
         self.messages: list[dict[str, Any]] = []
         self.worker_thread: QThread | None = None
@@ -1116,10 +1118,11 @@ class PetWindow(QWidget):
         self._raise_open_dialogs()
 
     def _raise_open_dialogs(self) -> None:
-        # 设置/历史窗口打开时应始终在桌宠卡片之上，避免说话时被卡片盖住。
+        # 独立窗口打开时应始终在桌宠卡片之上，避免说话时被卡片盖住。
         for dialog in (
             getattr(self, "settings_dialog", None),
             getattr(self, "history_window", None),
+            getattr(self, "runtime_log_window", None),
         ):
             if dialog is not None and dialog.isVisible():
                 dialog.raise_()
@@ -1294,6 +1297,7 @@ class PetWindow(QWidget):
             on_toggle_free_access=self._toggle_free_access,
             on_toggle_always_on_top=self._toggle_always_on_top,
             on_show_history=self.show_history,
+            on_show_runtime_log=self.show_runtime_log,
             on_show_settings=self.show_settings,
         )
 
@@ -2911,6 +2915,19 @@ class PetWindow(QWidget):
         self.history_window.raise_()
         self.history_window.activateWindow()
 
+    @Slot()
+    def show_runtime_log(self) -> None:
+        if self.runtime_log_window is None:
+            self.runtime_log_window = RuntimeLogWindow(
+                theme_settings=self.theme_settings,
+                parent=self,
+            )
+        self.runtime_log_window.set_theme_settings(self.theme_settings)
+        self.runtime_log_window.refresh(reset=True)
+        self.runtime_log_window.show()
+        self.runtime_log_window.raise_()
+        self.runtime_log_window.activateWindow()
+
     def _save_history_to_memory_and_clear(self) -> None:
         if self.memory_curation_thread is not None:
             if self.memory_curation_mode in {"auto", "backfill"}:
@@ -3762,6 +3779,8 @@ class PetWindow(QWidget):
         self._apply_card_window_theme()
         if self.history_window is not None:
             self.history_window.set_theme_settings(self.theme_settings)
+        if self.runtime_log_window is not None:
+            self.runtime_log_window.set_theme_settings(self.theme_settings)
         if hasattr(self, "tray_icon"):
             self.tray_icon.setIcon(_build_status_tray_icon(self.theme_settings.primary_color))
 

--- a/app/ui/theme.py
+++ b/app/ui/theme.py
@@ -884,6 +884,112 @@ QPushButton#secondaryButton:default {{
 """
 
 
+def build_runtime_log_window_stylesheet(settings: ThemeSettings) -> str:
+    theme = settings.normalized()
+    return f"""
+QDialog {{
+    background: {theme.page_background_color};
+    color: {theme.text_color};
+    font-family: "Microsoft YaHei", "Yu Gothic UI", sans-serif;
+    font-size: 14px;
+}}
+QLabel#runtimeLogTitle {{
+    color: {theme.secondary_text_color};
+    font-size: 22px;
+    font-weight: 700;
+}}
+QLabel#runtimeLogSummary {{
+    color: {theme.muted_text_color};
+    background: {rgba(theme.panel_background_color, 205)};
+    border: 1px solid {rgba(theme.border_color, 122)};
+    border-radius: 11px;
+    padding: 5px 10px;
+    font-size: 13px;
+}}
+QTabWidget#runtimeLogTabs::pane {{
+    background: transparent;
+    border: none;
+}}
+QTabBar::tab {{
+    background: {rgba(theme.input_background_color, 214)};
+    border: 1px solid {rgba(theme.border_color, 132)};
+    border-bottom: none;
+    border-top-left-radius: 8px;
+    border-top-right-radius: 8px;
+    color: {theme.muted_text_color};
+    padding: 8px 20px;
+    margin-right: 4px;
+    font-size: 14px;
+    font-weight: 700;
+}}
+QTabBar::tab:selected {{
+    background: {rgba(theme.panel_background_color, 245)};
+    color: {theme.secondary_text_color};
+    border: 1px solid {rgba(theme.primary_color, 145)};
+    border-bottom: none;
+}}
+QTabBar::tab:hover {{
+    color: {theme.secondary_text_color};
+    background: {rgba(theme.panel_background_color, 230)};
+}}
+QFrame#runtimeLogPage {{
+    background: {rgba(mix(theme.page_background_color, "#ffffff", 0.12), 238)};
+    border: 1px solid {rgba(theme.border_color, 138)};
+    border-radius: 12px;
+}}
+QListWidget#runtimeLogList {{
+    background: transparent;
+    border: none;
+    outline: 0;
+    color: {theme.text_color};
+    font-size: 13px;
+}}
+QPushButton {{
+    background: {rgba(theme.input_background_color, 230)};
+    border: 1px solid {rgba(theme.border_color, 148)};
+    border-radius: 8px;
+    color: {theme.secondary_text_color};
+    min-width: 72px;
+    padding: 7px 11px;
+    font-size: 14px;
+    font-weight: 600;
+}}
+QPushButton:hover {{
+    background: {rgba(theme.panel_background_color, 245)};
+    border: 1px solid {rgba(theme.primary_color, 158)};
+}}
+QPushButton#dangerButton {{
+    background: #fff1f5;
+    border: 1px solid rgba(199, 88, 122, 0.52);
+    color: #b13e5a;
+}}
+QPushButton#dangerButton:hover {{
+    background: #ffe1ea;
+}}
+QCheckBox {{
+    color: {theme.secondary_text_color};
+    font-size: 13px;
+    spacing: 8px;
+}}
+QCheckBox::indicator {{
+    width: 16px;
+    height: 16px;
+    border-radius: 4px;
+    border: 1px solid {rgba(theme.primary_color, 173)};
+    background: {theme.input_background_color};
+}}
+QCheckBox::indicator:hover {{
+    border: 1px solid {rgba(theme.primary_color, 210)};
+    background: {rgba(theme.panel_background_color, 210)};
+}}
+QCheckBox::indicator:checked {{
+    image: url("{_MENU_CHECK_URL}");
+    background: {theme.primary_color};
+    border: 1px solid {theme.accent_color};
+}}
+"""
+
+
 def rgba(hex_color: str, alpha: int) -> str:
     red, green, blue = _rgb(hex_color)
     return f"rgba({red}, {green}, {blue}, {max(0, min(255, alpha))})"
@@ -948,3 +1054,4 @@ def _bool_value(value: object, default: bool) -> bool:
 DEFAULT_PET_WINDOW_STYLESHEET = build_pet_window_stylesheet(DEFAULT_THEME_SETTINGS)
 DEFAULT_SETTINGS_DIALOG_STYLESHEET = build_settings_dialog_stylesheet(DEFAULT_THEME_SETTINGS)
 DEFAULT_HISTORY_WINDOW_STYLESHEET = build_history_window_stylesheet(DEFAULT_THEME_SETTINGS)
+DEFAULT_RUNTIME_LOG_WINDOW_STYLESHEET = build_runtime_log_window_stylesheet(DEFAULT_THEME_SETTINGS)

--- a/app/ui/theme.py
+++ b/app/ui/theme.py
@@ -987,6 +987,16 @@ QCheckBox::indicator:checked {{
     background: {theme.primary_color};
     border: 1px solid {theme.accent_color};
 }}
+QToolTip {{
+    background: {theme.panel_background_color};
+    color: {theme.text_color};
+    border: 1px solid {rgba(theme.border_color, 190)};
+    border-radius: 8px;
+    padding: 6px 10px;
+    font-family: "Microsoft YaHei", "Yu Gothic UI", sans-serif;
+    font-size: 13px;
+    font-weight: normal;
+}}
 """
 
 

--- a/app/ui/tray_menu.py
+++ b/app/ui/tray_menu.py
@@ -19,6 +19,7 @@ def build_pet_tray_menu(
     on_toggle_free_access: Callable[[bool], None],
     on_toggle_always_on_top: Callable[[bool], None],
     on_show_history: Callable[[], None],
+    on_show_runtime_log: Callable[[], None],
     on_show_settings: Callable[[], None],
     window_visible: bool = True,
     interactions_enabled: bool = True,
@@ -68,6 +69,11 @@ def build_pet_tray_menu(
     history_action.setEnabled(interactions_enabled)
     history_action.triggered.connect(on_show_history)
     menu.addAction(history_action)
+
+    runtime_log_action = QAction("运行日志", parent)
+    runtime_log_action.setEnabled(interactions_enabled)
+    runtime_log_action.triggered.connect(on_show_runtime_log)
+    menu.addAction(runtime_log_action)
 
     settings_action = QAction("设置", parent)
     settings_action.setEnabled(interactions_enabled)

--- a/app/voice/tts.py
+++ b/app/voice/tts.py
@@ -32,6 +32,7 @@ TTS_PLAYBACK_BACKEND_MEDIA_PLAYER = "media_player"
 _DEFAULT_PLAYBACK_BACKEND = TTS_PLAYBACK_BACKEND_AUDIO_SINK
 
 from app.config.character_loader import CharacterProfile
+from app.core.gui_log import record_tts_service_output
 from app.llm.chat_reply import DEFAULT_TONE
 from app.core.debug_log import debug_log
 from app.voice.runtime_compat import find_usable_runtime_python, format_runtime_python_issue
@@ -382,7 +383,7 @@ class GPTSoVITSTTSSettings:
 
 class GPTSoVITSTTSProvider(QObject):
     error_occurred = Signal(str)
-    _audio_ready = Signal(str, object, object)
+    _audio_ready = Signal(str, object, object, str)
     _prepared_audio_ready = Signal(object, str)
     _prepared_audio_failed = Signal(object, str)
     _failed = Signal(str)
@@ -403,10 +404,13 @@ class GPTSoVITSTTSProvider(QObject):
         # 与启动清理 purge_tts_cache(base_dir) 同源，避免写入目录与清理目录错位。
         # base_dir 为空时退回 _resolve_tts_cache_dir 的 __file__ 推算，保持向后兼容。
         self._tts_cache_dir = _resolve_tts_cache_dir(base_dir)
+        # 队列元素：(音频路径, 开始回调, 完成回调, 预生成句柄, 合成文本)
         self._pending_audio: list[
-            tuple[Path, TTSCallback | None, TTSCallback | None, TTSPreparedAudio | None]
+            tuple[Path, TTSCallback | None, TTSCallback | None, TTSPreparedAudio | None, str]
         ] = []
         self._current_audio: Path | None = None
+        # 当前正在播放的音频对应的合成文本，仅用于日志展示
+        self._current_text: str = ""
         self._current_started: TTSCallback | None = None
         self._current_finished: TTSCallback | None = None
         self._current_started_emitted = False
@@ -522,13 +526,13 @@ class GPTSoVITSTTSProvider(QObject):
             ]
 
         pending_audio: list[
-            tuple[Path, TTSCallback | None, TTSCallback | None, TTSPreparedAudio | None]
+            tuple[Path, TTSCallback | None, TTSCallback | None, TTSPreparedAudio | None, str]
         ] = []
-        for audio_path, on_started, on_finished, prepared_audio in self._pending_audio:
+        for audio_path, on_started, on_finished, prepared_audio, text in self._pending_audio:
             if prepared_audio is handle:
                 self._schedule_audio_cleanup(audio_path)
                 continue
-            pending_audio.append((audio_path, on_started, on_finished, prepared_audio))
+            pending_audio.append((audio_path, on_started, on_finished, prepared_audio, text))
         self._pending_audio = pending_audio
 
         if handle.audio_path is not None:
@@ -733,7 +737,12 @@ class GPTSoVITSTTSProvider(QObject):
                 audio_path = audio_file.name
             debug_log("TTS", "临时音频已写入", {"audio_path": audio_path, "bytes": len(audio_data)})
             if tts_request.prepared_audio is None:
-                self._audio_ready.emit(audio_path, tts_request.on_started, tts_request.on_finished)
+                self._audio_ready.emit(
+                    audio_path,
+                    tts_request.on_started,
+                    tts_request.on_finished,
+                    tts_request.text,
+                )
             else:
                 self._prepared_audio_ready.emit(tts_request.prepared_audio, audio_path)
         finally:
@@ -905,18 +914,27 @@ class GPTSoVITSTTSProvider(QObject):
             kwargs: dict[str, object] = {
                 "cwd": str(work_dir),
                 "env": _local_tts_subprocess_env(),
+                "stdout": subprocess.PIPE,
                 "stderr": subprocess.STDOUT,
+                "text": True,
+                "encoding": "utf-8",
+                "errors": "replace",
+                "bufsize": 1,
             }
             if hasattr(subprocess, "CREATE_NO_WINDOW"):
                 kwargs["creationflags"] = getattr(subprocess, "CREATE_NO_WINDOW")
             with log_path.open("a", encoding="utf-8") as log_file:
                 log_file.write(f"\n[{time.strftime('%Y-%m-%d %H:%M:%S')}] 启动 GPT-SoVITS：{work_dir}\n")
                 log_file.flush()
-                kwargs["stdout"] = log_file
-                self._server_process = subprocess.Popen(
-                    _build_gpt_sovits_start_command(python_exe, api_script, self.settings),
-                    **kwargs,
-                )
+            self._server_process = subprocess.Popen(
+                _build_gpt_sovits_start_command(python_exe, api_script, self.settings),
+                **kwargs,
+            )
+            _start_local_tts_output_reader(
+                self._server_process,
+                log_path,
+                "GPT-SoVITS",
+            )
         except OSError as exc:
             debug_log("TTS", "本地 GPT-SoVITS 服务启动失败", {"work_dir": str(work_dir), "error": str(exc)})
             fail_callback(f"GPT-SoVITS 服务启动失败：{exc}")
@@ -1060,12 +1078,14 @@ class GPTSoVITSTTSProvider(QObject):
         audio_path: str,
         on_started: TTSCallback | None,
         on_finished: TTSCallback | None,
+        text: str = "",
     ) -> None:
-        self._pending_audio.append((Path(audio_path), on_started, on_finished, None))
+        self._pending_audio.append((Path(audio_path), on_started, on_finished, None, text))
         debug_log(
             "TTS",
             "音频加入播放队列",
             {
+                "text": text,
                 "audio_path": audio_path,
                 "pending_audio": len(self._pending_audio),
                 "current_audio": str(self._current_audio) if self._current_audio else None,
@@ -1198,7 +1218,7 @@ class GPTSoVITSTTSProvider(QObject):
             return
         handle.enqueued = True
         self._pending_audio.append(
-            (handle.audio_path, handle.on_started, handle.on_finished, handle)
+            (handle.audio_path, handle.on_started, handle.on_finished, handle, handle.text)
         )
         debug_log(
             "TTS",
@@ -1226,8 +1246,10 @@ class GPTSoVITSTTSProvider(QObject):
             on_started,
             on_finished,
             _prepared_audio,
+            text,
         ) = self._pending_audio.pop(0)
         self._current_audio = audio_path
+        self._current_text = text
         self._current_started = on_started
         self._current_finished = on_finished
         self._current_started_emitted = False
@@ -1237,6 +1259,7 @@ class GPTSoVITSTTSProvider(QObject):
             "TTS",
             "开始播放音频",
             {
+                "text": text,
                 "backend": self._playback_backend,
                 "audio_path": str(audio_path),
                 "file_size": audio_path.stat().st_size if audio_path.exists() else 0,
@@ -1416,6 +1439,7 @@ class GPTSoVITSTTSProvider(QObject):
                 "TTS",
                 "音频播放完成",
                 {
+                    "text": self._current_text,
                     "reason": reason,
                     "audio_path": str(audio_path),
                     "pending_audio": len(self._pending_audio),
@@ -1445,6 +1469,7 @@ class GPTSoVITSTTSProvider(QObject):
 
     def _reset_current_audio_state(self) -> None:
         self._current_audio = None
+        self._current_text = ""
         self._current_started = None
         self._current_finished = None
         self._current_started_emitted = False
@@ -1640,7 +1665,12 @@ class GenieTTSProvider(GPTSoVITSTTSProvider):
 
             debug_log("TTS", "Genie 临时音频已写入", {"audio_path": audio_path, "bytes": len(audio_data)})
             if tts_request.prepared_audio is None:
-                self._audio_ready.emit(str(audio_path), tts_request.on_started, tts_request.on_finished)
+                self._audio_ready.emit(
+                    str(audio_path),
+                    tts_request.on_started,
+                    tts_request.on_finished,
+                    tts_request.text,
+                )
             else:
                 self._prepared_audio_ready.emit(tts_request.prepared_audio, str(audio_path))
         finally:
@@ -1768,14 +1798,28 @@ class GenieTTSProvider(GPTSoVITSTTSProvider):
         try:
             kwargs: dict[str, object] = {
                 "cwd": str(work_dir),
-                "stdout": subprocess.DEVNULL,
-                "stderr": subprocess.DEVNULL,
+                "stdout": subprocess.PIPE,
+                "stderr": subprocess.STDOUT,
+                "text": True,
+                "encoding": "utf-8",
+                "errors": "replace",
+                "bufsize": 1,
             }
             if hasattr(subprocess, "CREATE_NO_WINDOW"):
                 kwargs["creationflags"] = getattr(subprocess, "CREATE_NO_WINDOW")
+            log_path = _local_tts_service_log_path(self.settings.provider)
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            with log_path.open("a", encoding="utf-8") as log_file:
+                log_file.write(f"\n[{time.strftime('%Y-%m-%d %H:%M:%S')}] 启动 Genie TTS：{work_dir}\n")
+                log_file.flush()
             self._server_process = subprocess.Popen(
                 _build_genie_start_command(python_exe, host, port),
                 **kwargs,
+            )
+            _start_local_tts_output_reader(
+                self._server_process,
+                log_path,
+                "Genie TTS",
             )
         except OSError as exc:
             fail_callback(f"Genie TTS 服务启动失败：{exc}")
@@ -2289,6 +2333,67 @@ def _local_tts_service_log_path(provider: str) -> Path:
 
     safe_provider = re.sub(r"[^A-Za-z0-9_.-]+", "-", provider.strip().lower()) or "tts"
     return Path.cwd() / "data" / "logs" / f"{safe_provider}-service.log"
+
+
+def _start_local_tts_output_reader(
+    process: subprocess.Popen[str],
+    log_path: Path,
+    provider: str,
+) -> None:
+    stream = getattr(process, "stdout", None)
+    if stream is None:
+        return
+    thread = threading.Thread(
+        target=_read_local_tts_output,
+        args=(stream, log_path, provider),
+        daemon=True,
+    )
+    thread.start()
+
+
+def _iter_tts_service_segments(stream):  # type: ignore[no-untyped-def]
+    """逐段产出服务输出。
+
+    tqdm 进度条用 \r 原地刷新且长时间不输出 \n，按行读取要等进度条整条结束
+    才能一次性收到，无法实时展示推理进度，因此优先按字符读取并以 \r/\n 切段；
+    不支持 read() 的流（如测试桩）退回按行迭代。
+    """
+    if hasattr(stream, "read"):
+        buffer = ""
+        while True:
+            chunk = stream.read(1)
+            if not chunk:
+                break
+            if chunk in ("\r", "\n"):
+                if buffer:
+                    yield buffer
+                buffer = ""
+                continue
+            buffer += chunk
+        if buffer:
+            yield buffer
+        return
+    for raw_line in stream:
+        yield str(raw_line)
+
+
+def _read_local_tts_output(stream, log_path: Path, provider: str) -> None:  # type: ignore[no-untyped-def]
+    try:
+        with log_path.open("a", encoding="utf-8") as log_file:
+            for segment in _iter_tts_service_segments(stream):
+                line = segment.rstrip("\r\n")
+                if not line.strip():
+                    continue
+                log_file.write(f"{line}\n")
+                log_file.flush()
+                record_tts_service_output(provider, line)
+    except Exception as exc:  # noqa: BLE001
+        debug_log("TTS", "本地 TTS 服务输出读取失败", {"provider": provider, "error": str(exc)})
+    finally:
+        try:
+            stream.close()
+        except Exception:
+            pass
 
 
 def _resolve_path(path_text: str, base_dir: Path) -> Path:

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -81,6 +81,7 @@ def test_pet_window_menu_keeps_only_allowed_checkable_switches() -> None:
     host._toggle_free_access = lambda _checked: None
     host._toggle_always_on_top = lambda _checked: None
     host.show_history = lambda: None
+    host.show_runtime_log = lambda: None
     host.show_settings = lambda: None
     host.show()
     app.processEvents()
@@ -94,6 +95,7 @@ def test_pet_window_menu_keeps_only_allowed_checkable_switches() -> None:
     assert "启用模型视觉" not in texts
     assert "允许自主看屏幕" not in texts
     assert "自由访问权限" not in texts
+    assert "运行日志" in texts
     assert "显示中文字幕" in checkable_texts
     assert "完整访问权限" in checkable_texts
     assert "保持置顶" in checkable_texts
@@ -131,6 +133,7 @@ def test_pet_window_menu_shows_restore_action_when_hidden() -> None:
     host._toggle_free_access = lambda _checked: None
     host._toggle_always_on_top = lambda _checked: None
     host.show_history = lambda: None
+    host.show_runtime_log = lambda: None
     host.show_settings = lambda: None
 
     menu = PetWindow._build_menu(host)  # type: ignore[arg-type]
@@ -140,6 +143,256 @@ def test_pet_window_menu_shows_restore_action_when_hidden() -> None:
 
     menu.deleteLater()
     host.deleteLater()
+    app.processEvents()
+
+
+def test_show_runtime_log_uses_non_modal_show(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    if not hasattr(qtwidgets, "QWidget"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+
+    import app.ui.pet_window as pet_window_module
+
+    events: list[str] = []
+
+    class RuntimeLogWindowStub:
+        def __init__(self, **kwargs):  # type: ignore[no-untyped-def]
+            self.kwargs = kwargs
+            self.visible = False
+
+        def set_theme_settings(self, settings):  # type: ignore[no-untyped-def]
+            events.append("theme")
+            self.theme_settings = settings
+
+        def refresh(self, *, reset: bool = False) -> None:
+            events.append(f"refresh:{reset}")
+
+        def show(self) -> None:
+            events.append("show")
+            self.visible = True
+
+        def raise_(self) -> None:
+            events.append("raise")
+
+        def activateWindow(self) -> None:
+            events.append("activate")
+
+        def exec(self):  # type: ignore[no-untyped-def]
+            raise AssertionError("运行日志窗口不应使用 exec() 打开")
+
+    class Host(qtwidgets.QWidget):
+        show_runtime_log = pet_window_module.PetWindow.show_runtime_log
+        _any_dialog_open = pet_window_module.PetWindow._any_dialog_open
+
+    monkeypatch.setattr(pet_window_module, "RuntimeLogWindow", RuntimeLogWindowStub)
+
+    app = qtwidgets.QApplication.instance() or qtwidgets.QApplication([])
+    host = Host()
+    host.theme_settings = DEFAULT_THEME_SETTINGS
+    host.runtime_log_window = None
+    host.settings_dialog = None
+    host.history_window = None
+
+    host.show_runtime_log()
+
+    assert events == ["theme", "refresh:True", "show", "raise", "activate"]
+    assert host.runtime_log_window.kwargs["parent"] is host
+    assert host._any_dialog_open() is False
+
+    host.deleteLater()
+    app.processEvents()
+
+
+def test_runtime_log_window_is_non_modal() -> None:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    qtcore = pytest.importorskip("PySide6.QtCore")
+    if not hasattr(qtwidgets, "QApplication"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+
+    from app.ui.log_window import RuntimeLogWindow
+
+    app = qtwidgets.QApplication.instance() or qtwidgets.QApplication([])
+    window = RuntimeLogWindow(theme_settings=DEFAULT_THEME_SETTINGS)
+
+    assert window.windowModality() == qtcore.Qt.WindowModality.NonModal
+    assert window.tabs.count() == 2
+    assert window.tabs.tabText(0) == "软件"
+    assert window.tabs.tabText(1) == "TTS"
+    assert "runtimeLogPage" in window.styleSheet()
+    assert "QCheckBox::indicator:checked" in window.styleSheet()
+    assert DEFAULT_THEME_SETTINGS.page_background_color in window.styleSheet()
+
+    window.close()
+    window.deleteLater()
+    app.processEvents()
+
+
+def test_runtime_log_window_collapses_consecutive_duplicate_rows() -> None:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    qtcore = pytest.importorskip("PySide6.QtCore")
+    if not hasattr(qtwidgets, "QApplication"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+
+    from app.core.gui_log import GUI_LOG_LEVEL_INFO, GUI_LOG_SCOPE_PROGRAM, GuiLogBuffer
+    from app.ui.log_window import RuntimeLogWindow
+
+    buffer = GuiLogBuffer()
+    for _index in range(2):
+        buffer.append(
+            timestamp="2026-06-11T18:43:44+08:00",
+            scope=GUI_LOG_SCOPE_PROGRAM,
+            level=GUI_LOG_LEVEL_INFO,
+            category="TTS",
+            message="准备：GPT-SoVITS 服务已就绪",
+        )
+    buffer.append(
+        timestamp="2026-06-11T18:43:45+08:00",
+        scope=GUI_LOG_SCOPE_PROGRAM,
+        level=GUI_LOG_LEVEL_INFO,
+        category="TTS",
+        message="准备：TTS 角色权重切换完成",
+    )
+
+    app = qtwidgets.QApplication.instance() or qtwidgets.QApplication([])
+    window = RuntimeLogWindow(log_buffer=buffer, theme_settings=DEFAULT_THEME_SETTINGS)
+
+    assert window.program_list.count() == 2
+    first_item = window.program_list.item(0)
+    assert first_item.text() == "18:43:44  [TTS]  准备：GPT-SoVITS 服务已就绪  ×2"
+    assert "信息" not in first_item.text()
+    assert "连续重复：2 次" in str(first_item.data(qtcore.Qt.ItemDataRole.UserRole))
+
+    window.close()
+    window.deleteLater()
+    app.processEvents()
+
+
+def test_runtime_log_window_row_shows_category_level_and_detail_summary() -> None:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    if not hasattr(qtwidgets, "QApplication"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+
+    from app.core.gui_log import (
+        GUI_LOG_LEVEL_ERROR,
+        GUI_LOG_LEVEL_INFO,
+        GUI_LOG_SCOPE_PROGRAM,
+        GuiLogBuffer,
+    )
+    from app.ui.log_window import RuntimeLogWindow
+
+    buffer = GuiLogBuffer()
+    buffer.append(
+        timestamp="2026-06-11T18:51:27+08:00",
+        scope=GUI_LOG_SCOPE_PROGRAM,
+        level=GUI_LOG_LEVEL_INFO,
+        category="API",
+        message="发送请求",
+        detail='{"model": "gpt-4o-mini", "stream": true, "messages": {"type": "list", "items": 4}}',
+    )
+    buffer.append(
+        timestamp="2026-06-11T18:51:31+08:00",
+        scope=GUI_LOG_SCOPE_PROGRAM,
+        level=GUI_LOG_LEVEL_ERROR,
+        category="API",
+        message="请求失败",
+        detail='{"error": "connection timeout", "api_key": "<redacted>"}',
+    )
+
+    app = qtwidgets.QApplication.instance() or qtwidgets.QApplication([])
+    window = RuntimeLogWindow(log_buffer=buffer, theme_settings=DEFAULT_THEME_SETTINGS)
+
+    info_item = window.program_list.item(0)
+    # 行内带分类标签，detail 中的标量字段提取为行尾摘要，嵌套结构与脱敏值不出现
+    assert info_item.text() == "18:51:27  [API]  发送请求  model=gpt-4o-mini · stream=True"
+    error_item = window.program_list.item(1)
+    assert error_item.text() == "18:51:31  [API]  错误  请求失败  error=connection timeout"
+    assert "<redacted>" not in error_item.text()
+
+    # 两个列表都应使用自定义 delegate 做分层着色
+    assert window.program_list.itemDelegate() is window._item_delegate
+    assert window.tts_list.itemDelegate() is window._item_delegate
+
+    window.close()
+    window.deleteLater()
+    app.processEvents()
+
+
+def test_runtime_log_window_shows_tts_text_preview_as_detail() -> None:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    if not hasattr(qtwidgets, "QApplication"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+
+    from app.core.gui_log import GUI_LOG_LEVEL_INFO, GUI_LOG_SCOPE_PROGRAM, GuiLogBuffer
+    from app.ui.log_window import RuntimeLogWindow
+
+    buffer = GuiLogBuffer()
+    buffer.append(
+        timestamp="2026-06-11T18:51:35+08:00",
+        scope=GUI_LOG_SCOPE_PROGRAM,
+        level=GUI_LOG_LEVEL_INFO,
+        category="TTS",
+        message="开始播放",
+        detail='{"audio_path": "x.wav"}',
+        text_preview="今天天气真好喵",
+    )
+
+    app = qtwidgets.QApplication.instance() or qtwidgets.QApplication([])
+    window = RuntimeLogWindow(log_buffer=buffer, theme_settings=DEFAULT_THEME_SETTINGS)
+
+    item = window.program_list.item(0)
+    # 合成/播放记录的灰字摘要优先显示文本内容而不是 detail 字段
+    assert item.text() == "18:51:35  [TTS]  开始播放  「今天天气真好喵」"
+    assert "文本：今天天气真好喵" in item.toolTip()
+
+    window.close()
+    window.deleteLater()
+    app.processEvents()
+
+
+def test_runtime_log_window_updates_progress_rows_in_place() -> None:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    if not hasattr(qtwidgets, "QApplication"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+
+    from app.core.gui_log import GUI_LOG_LEVEL_INFO, GUI_LOG_SCOPE_TTS, GuiLogBuffer
+    from app.ui.log_window import RuntimeLogWindow
+
+    buffer = GuiLogBuffer()
+    buffer.append(
+        timestamp="2026-06-11T18:51:31+08:00",
+        scope=GUI_LOG_SCOPE_TTS,
+        level=GUI_LOG_LEVEL_INFO,
+        category="GPT-SoVITS 服务",
+        message="语义 token 预测 4%（60/1500，104.91 it/s）",
+        merge_key="semantic-token-progress",
+    )
+
+    app = qtwidgets.QApplication.instance() or qtwidgets.QApplication([])
+    window = RuntimeLogWindow(log_buffer=buffer, theme_settings=DEFAULT_THEME_SETTINGS)
+    assert window.tts_list.count() == 1
+
+    # 已展示的进度行在新进度到达后应原地刷新，而不是追加新行
+    buffer.append(
+        timestamp="2026-06-11T18:51:34+08:00",
+        scope=GUI_LOG_SCOPE_TTS,
+        level=GUI_LOG_LEVEL_INFO,
+        category="GPT-SoVITS 服务",
+        message="语义 token 预测 24%（363/1500，105.23 it/s）",
+        merge_key="semantic-token-progress",
+    )
+    window.refresh()
+
+    assert window.tts_list.count() == 1
+    assert "24%" in window.tts_list.item(0).text()
+
+    window.close()
+    window.deleteLater()
     app.processEvents()
 
 

--- a/tests/unit/test_gui_log.py
+++ b/tests/unit/test_gui_log.py
@@ -73,9 +73,50 @@ def test_gui_log_compacts_software_request_and_reply_events() -> None:
     records = get_gui_log_buffer().snapshot(scope=GUI_LOG_SCOPE_PROGRAM)
 
     assert [(record.level, record.message) for record in records] == [
-        ("info", "发送请求"),
-        ("info", "收到回复"),
+        ("info", "发送请求（带工具）"),
+        ("info", "收到回复：工具调用"),  # 无 tool_calls 字段时不追加工具名
         ("info", "后台启动服务已创建"),
+    ]
+
+
+def test_gui_log_tool_call_reply_includes_tool_names() -> None:
+    # 内部自定义格式：call["name"] 直接存工具名
+    record_debug_log_for_gui(
+        "API",
+        "原生工具模型返回",
+        {
+            "content": {"type": "text", "chars": 0},
+            "tool_calls": [
+                {"type": "tool_call", "id": "call_abc", "name": "observe_screen", "argument_keys": []},
+                {"type": "tool_call", "id": "call_def", "name": "get_current_time", "argument_keys": []},
+            ],
+        },
+    )
+
+    records = get_gui_log_buffer().snapshot(scope=GUI_LOG_SCOPE_PROGRAM)
+    assert records[0].message == "收到回复：工具调用：observe_screen、get_current_time"
+
+
+def test_gui_log_native_tool_reply_with_empty_tool_calls_shows_as_text() -> None:
+    # tool_calls 为空列表时模型实际只返回了文本，不应标为"工具调用"
+    record_debug_log_for_gui(
+        "API",
+        "原生工具模型返回",
+        {"content": {"type": "text", "chars": 598}, "tool_calls": []},
+    )
+
+    records = get_gui_log_buffer().snapshot(scope=GUI_LOG_SCOPE_PROGRAM)
+    assert records[0].message == "收到回复：文本"
+
+
+def test_gui_log_plain_request_label_has_no_tool_marker() -> None:
+    record_debug_log_for_gui("API", "准备发送聊天补全请求", {"model": "gemini"})
+    record_debug_log_for_gui("API", "模型原始文本返回", {"content": "hello"})
+
+    records = get_gui_log_buffer().snapshot(scope=GUI_LOG_SCOPE_PROGRAM)
+    assert [(r.level, r.message) for r in records] == [
+        ("info", "发送请求"),
+        ("info", "收到回复：文本"),
     ]
 
 
@@ -151,8 +192,9 @@ def test_tts_service_eos_replaces_progress_and_drops_trailing_frame() -> None:
 
     records = get_gui_log_buffer().snapshot(scope=GUI_LOG_SCOPE_TTS)
 
+    # EOS 完成行应携带最近一次进度行记录的推理速度
     assert [record.message for record in records] == [
-        "语义 token 预测完成：EOS（128 → 363）",
+        "语义 token 预测完成：EOS（128 → 363，105.23 it/s）",
     ]
 
 

--- a/tests/unit/test_gui_log.py
+++ b/tests/unit/test_gui_log.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import pytest
+
+from app.core.debug_log import debug_log
+from app.core.gui_log import (
+    GUI_LOG_SCOPE_PROGRAM,
+    GUI_LOG_SCOPE_TTS,
+    GuiLogBuffer,
+    clear_gui_logs,
+    get_gui_log_buffer,
+    record_debug_log_for_gui,
+    record_tts_service_output,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_logs_after_test():  # type: ignore[no-untyped-def]
+    clear_gui_logs()
+    yield
+    clear_gui_logs()
+
+
+def test_gui_log_records_even_when_terminal_and_file_logs_disabled(monkeypatch, capsys) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr("app.core.debug_log._load_debug_values", lambda: {})
+
+    debug_log("TTS", "发送 GPT-SoVITS 请求", {"api_key": "sk-secret", "text": "不应完整显示的语音文本"})
+
+    assert capsys.readouterr().out == ""
+    records = get_gui_log_buffer().snapshot(scope=GUI_LOG_SCOPE_PROGRAM)
+    assert len(records) == 1
+    assert records[0].message == "送入 TTS：GPT-SoVITS"
+
+
+def test_gui_log_routes_program_and_native_tts_records_to_separate_scopes() -> None:
+    record_debug_log_for_gui("Startup", "应用初始化完成")
+    record_tts_service_output("GPT-SoVITS", 'INFO: 127.0.0.1:49840 - "POST /tts HTTP/1.1" 200 OK')
+
+    program_records = get_gui_log_buffer().snapshot(scope=GUI_LOG_SCOPE_PROGRAM)
+    tts_records = get_gui_log_buffer().snapshot(scope=GUI_LOG_SCOPE_TTS)
+
+    assert [record.message for record in program_records] == ["应用初始化完成"]
+    assert [record.message for record in tts_records] == ["HTTP POST /tts -> 200 OK"]
+
+
+def test_gui_log_sanitizes_sensitive_and_private_text_detail() -> None:
+    record_debug_log_for_gui(
+        "TTS",
+        "发送 GPT-SoVITS 请求",
+        {
+            "api_key": "sk-secret",
+            "text": "不应完整显示的语音文本",
+            "payload": {
+                "prompt_text": "参考文本也不能完整显示",
+                "top_k": 15,
+            },
+        },
+    )
+
+    detail = get_gui_log_buffer().snapshot(scope=GUI_LOG_SCOPE_PROGRAM)[0].detail
+    assert "<redacted>" in detail
+    assert "不应完整显示的语音文本" not in detail
+    assert "参考文本也不能完整显示" not in detail
+    assert '"chars"' in detail
+
+
+def test_gui_log_compacts_software_request_and_reply_events() -> None:
+    record_debug_log_for_gui("API", "准备发送原生工具聊天补全请求", {"error_count": 0})
+    record_debug_log_for_gui("API", "HTTP 请求体已构建", {"error_count": 0})
+    record_debug_log_for_gui("API", "原生工具模型返回", {"content": "不应完整显示"})
+    record_debug_log_for_gui("Startup", "后台启动服务已创建", {"error_count": 0})
+
+    records = get_gui_log_buffer().snapshot(scope=GUI_LOG_SCOPE_PROGRAM)
+
+    assert [(record.level, record.message) for record in records] == [
+        ("info", "发送请求"),
+        ("info", "收到回复"),
+        ("info", "后台启动服务已创建"),
+    ]
+
+
+def test_gui_log_keeps_key_tts_software_events() -> None:
+    record_debug_log_for_gui("TTS", "提交播放请求")
+    record_debug_log_for_gui("TTS", "提交预生成请求")
+    record_debug_log_for_gui("TTS", "请求播放预生成音频")
+    record_debug_log_for_gui("TTS", "开始播放音频")
+    record_debug_log_for_gui("TTS", "发送 GPT-SoVITS 请求")
+    record_debug_log_for_gui("TTS", "GPT-SoVITS 请求成功")
+    record_debug_log_for_gui("TTS", "预生成音频已就绪")
+    record_debug_log_for_gui("TTS", "音频播放完成")
+    record_debug_log_for_gui("TTS", "临时音频已写入")
+    record_debug_log_for_gui("ChatWorker", "处理完成")
+
+    records = get_gui_log_buffer().snapshot(scope=GUI_LOG_SCOPE_PROGRAM)
+
+    assert [record.message for record in records] == [
+        "开始播放",
+        "送入 TTS：GPT-SoVITS",
+        "合成完成：GPT-SoVITS",
+        "播放完成",
+    ]
+
+
+def test_gui_log_keeps_internal_preparation_events_for_troubleshooting() -> None:
+    record_debug_log_for_gui("TTS", "本地 GPT-SoVITS 服务启动并探测成功")
+    record_debug_log_for_gui("TTS", "角色权重切换完成")
+
+    records = get_gui_log_buffer().snapshot(scope=GUI_LOG_SCOPE_PROGRAM)
+
+    assert [record.message for record in records] == [
+        "准备：GPT-SoVITS 服务已就绪",
+        "准备：TTS 角色权重切换完成",
+    ]
+
+
+def test_tts_service_output_is_compacted_without_full_text() -> None:
+    record_tts_service_output("GPT-SoVITS", "########## 合成音频 ##########")
+    record_tts_service_output("GPT-SoVITS", "实际输入的目标文本(切句后): ['そんなの当たり前だっ。']")
+    record_tts_service_output("GPT-SoVITS", "100%|██████████| 1/1 [00:00<00:00, 111.08it/s]")
+
+    records = get_gui_log_buffer().snapshot(scope=GUI_LOG_SCOPE_TTS)
+
+    assert [record.message for record in records] == [
+        "开始合成音频",
+        "收到合成文本（11 字）",
+        "语义 token 预测 100%（1/1，111.08 it/s）",
+    ]
+    assert all("そんなの" not in record.message for record in records)
+
+
+def test_tts_service_semantic_progress_merges_in_place() -> None:
+    record_tts_service_output("GPT-SoVITS", "########## 合成音频 ##########")
+    record_tts_service_output("GPT-SoVITS", "  4%|▍         | 60/1500 [00:00<00:13, 104.91it/s]")
+    record_tts_service_output("GPT-SoVITS", " 24%|██▍       | 363/1500 [00:03<00:10, 105.23it/s]")
+
+    records = get_gui_log_buffer().snapshot(scope=GUI_LOG_SCOPE_TTS)
+
+    # 相邻进度记录原地合并，只保留最新一条
+    assert [record.message for record in records] == [
+        "开始合成音频",
+        "语义 token 预测 24%（363/1500，105.23 it/s）",
+    ]
+    assert records[-1].merge_key != ""
+
+
+def test_tts_service_eos_replaces_progress_and_drops_trailing_frame() -> None:
+    record_tts_service_output("GPT-SoVITS", " 24%|██▍       | 363/1500 [00:03<00:10, 105.23it/s]")
+    record_tts_service_output("GPT-SoVITS", "T2S Decoding EOS [128 -> 363]")
+    # tqdm 收尾时停在中途百分比的最终帧不应覆盖 EOS 完成行
+    record_tts_service_output("GPT-SoVITS", " 24%|██▍       | 363/1500 [00:03<00:10, 105.23it/s]")
+
+    records = get_gui_log_buffer().snapshot(scope=GUI_LOG_SCOPE_TTS)
+
+    assert [record.message for record in records] == [
+        "语义 token 预测完成：EOS（128 → 363）",
+    ]
+
+
+def test_gui_log_keeps_tts_text_preview_for_display() -> None:
+    record_debug_log_for_gui(
+        "TTS",
+        "发送 GPT-SoVITS 请求",
+        {"text": "今天天气真好喵", "api_key": "sk-secret"},
+    )
+    record_debug_log_for_gui("API", "模型原始文本返回", {"text": "API 文本不应出预览"})
+
+    records = get_gui_log_buffer().snapshot(scope=GUI_LOG_SCOPE_PROGRAM)
+
+    assert records[0].message == "送入 TTS：GPT-SoVITS"
+    assert records[0].text_preview == "今天天气真好喵"
+    # detail 字段仍按既有规则脱敏，仅 text_preview 提供展示用文本
+    assert "今天天气真好喵" not in records[0].detail
+    assert "<redacted>" in records[0].detail
+    # 非 TTS 分类不提取预览
+    assert records[1].text_preview == ""
+
+
+def test_gui_log_buffer_keeps_scope_limited_ring() -> None:
+    buffer = GuiLogBuffer(max_records_per_scope=3)
+
+    for index in range(5):
+        buffer.append(
+            timestamp="2026-06-11T10:00:00+08:00",
+            scope=GUI_LOG_SCOPE_PROGRAM,
+            level="info",
+            category="Test",
+            message=f"item-{index}",
+        )
+
+    records = buffer.snapshot(scope=GUI_LOG_SCOPE_PROGRAM)
+    assert [record.message for record in records] == ["item-2", "item-3", "item-4"]

--- a/tests/unit/test_tts.py
+++ b/tests/unit/test_tts.py
@@ -82,11 +82,13 @@ from app.voice.tts import (
     _format_gpt_sovits_http_error,
     _load_tone_references,
     _local_tts_subprocess_env,
+    _read_local_tts_output,
     _resolve_request_text_lang,
     _resolve_tts_cache_dir,
     _write_genie_audio,
     purge_tts_cache,
 )
+from app.core.gui_log import GUI_LOG_SCOPE_TTS, clear_gui_logs, get_gui_log_buffer
 from app.voice import VoicePlaybackController
 from app.voice.text_language_guard import should_skip_tts_text
 
@@ -829,6 +831,43 @@ def test_local_tts_subprocess_env_uses_utf8_stdio_without_forcing_interpreter(
     assert env["PYTHONIOENCODING"] == "utf-8"
 
 
+def test_local_tts_output_reader_writes_file_and_gui_log() -> None:
+    clear_gui_logs()
+
+    class Stream:
+        def __init__(self) -> None:
+            self.closed = False
+            self._lines = iter(
+                [
+                    "########## 合成音频 ##########\n",
+                    'INFO: 127.0.0.1:49840 - "POST /tts HTTP/1.1" 200 OK\n',
+                ]
+            )
+
+        def __iter__(self):  # type: ignore[no-untyped-def]
+            return self
+
+        def __next__(self) -> str:
+            return next(self._lines)
+
+        def close(self) -> None:
+            self.closed = True
+
+    stream = Stream()
+    log_path = _runtime_root("local_tts_output_reader") / "service.log"
+
+    _read_local_tts_output(stream, log_path, "GPT-SoVITS")
+
+    assert stream.closed
+    assert "合成音频" in log_path.read_text(encoding="utf-8")
+    records = get_gui_log_buffer().snapshot(scope=GUI_LOG_SCOPE_TTS)
+    assert [record.message for record in records] == [
+        "开始合成音频",
+        "HTTP POST /tts -> 200 OK",
+    ]
+    clear_gui_logs()
+
+
 def test_gptsovits_charmap_http_error_gets_actionable_message() -> None:
     message = _format_gpt_sovits_http_error(
         400,
@@ -900,7 +939,7 @@ def test_gptsovits_provider_warms_up_qt_player_before_first_play(monkeypatch) ->
 
     assert calls == ["timer", "audio", "player"]
 
-    provider._pending_audio.append((Path("dummy.wav"), None, None, None))
+    provider._pending_audio.append((Path("dummy.wav"), None, None, None, ""))
     provider._play_next()
 
     assert calls == ["timer", "audio", "player", "source", "play"]
@@ -961,6 +1000,7 @@ def test_tts_provider_treats_started_stopped_state_as_audio_finished(monkeypatch
             lambda: events.append("first_started"),
             lambda: events.append("first_finished"),
             None,
+            "",
         )
     )
     provider._pending_audio.append(
@@ -969,6 +1009,7 @@ def test_tts_provider_treats_started_stopped_state_as_audio_finished(monkeypatch
             lambda: events.append("second_started"),
             lambda: events.append("second_finished"),
             None,
+            "",
         )
     )
 
@@ -1048,6 +1089,7 @@ def test_tts_provider_finish_fallback_advances_queue_without_player_end_signal(m
             lambda: events.append("first_started"),
             lambda: events.append("first_finished"),
             None,
+            "",
         )
     )
     provider._pending_audio.append(
@@ -1056,6 +1098,7 @@ def test_tts_provider_finish_fallback_advances_queue_without_player_end_signal(m
             lambda: events.append("second_started"),
             lambda: events.append("second_finished"),
             None,
+            "",
         )
     )
 


### PR DESCRIPTION
## Summary

- 新增非模态「运行日志」窗口，按软件 / TTS 两个 Tab 分类展示本次会话的精简运行日志
- 日志行使用自定义 delegate 分段着色绘制（时间、分类标签、级别、消息、详情摘要）
- 支持重复行折叠（显示 ×N）、进度类记录原地替换、自动滚动、复制选中、清空
- tooltip 悬停提示应用当前主题配色，音频大小单位展示为 KB

## Test plan

- [x] 打开运行日志窗口，软件 / TTS Tab 均能正常展示日志条目
- [x] 悬停条目弹出的 tooltip 颜色跟随当前主题（非系统默认黄色）
- [x] 含 bytes 字段的 TTS 合成完成记录，行尾摘要和 tooltip 详情均显示 KB 单位
- [x] 重复日志折叠为 ×N，双击条目可复制，「清空」按钮生效
- [x] 自动滚动勾选时新日志追加后列表滚动到底部

🤖 Generated with [Claude Code](https://claude.com/claude-code)