### PR TITLE
feat: add memory model import

### DIFF
--- a/app/agent/memory.py
+++ b/app/agent/memory.py
@@ -2,13 +2,17 @@ from __future__ import annotations
 
 import logging
 import os
+import re
+import shutil
 import sqlite3
+import stat
 import sys
 import threading
 import time
+import zipfile
 from contextlib import nullcontext
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any, Callable, Iterable
 
 from app.storage.chat_history import ChatHistoryEntry
@@ -26,7 +30,9 @@ DEFAULT_EMBEDDING_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
 DEFAULT_EMBEDDING_DIMS = 384
 DEFAULT_MEMORY_LIMIT = 20
 DEFAULT_HUGGINGFACE_ENDPOINT = "https://huggingface.co"
+DEFAULT_EMBEDDING_MODEL_CACHE_NAME = "models--" + DEFAULT_EMBEDDING_MODEL.replace("/", "--")
 _MEM0_CREATE_LOCK = threading.Lock()
+_WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:")
 os.environ.setdefault("MEM0_TELEMETRY", "False")
 DEFAULT_MEMORY_LANGUAGE_INSTRUCTIONS = (
     "Sakura 的长期记忆必须使用简体中文记录。"
@@ -62,6 +68,20 @@ class MemoryCurationCounts:
     returned: int = 0
     unclassified: int = 0
     event_counts: dict[str, int] = field(default_factory=dict)
+
+
+class MemoryModelImportError(RuntimeError):
+    """记忆嵌入模型归档包格式错误或导入失败。"""
+
+
+@dataclass(frozen=True)
+class EmbeddingModelImportResult:
+    """记忆嵌入模型导入结果。"""
+
+    model_name: str
+    cache_folder: Path
+    model_dir: Path
+    snapshot_count: int
 
 
 @dataclass
@@ -131,7 +151,10 @@ class MemoryStore:
         self.reset_runtime()
 
     def reset_runtime(self) -> None:
+        old_memory: Any | None = None
         with self._lock:
+            if self._memory is not None and self._memory is not self.memory_client:
+                old_memory = self._memory
             self._memory = self.memory_client
             self._loading = False
             self._loading_started_at = 0.0
@@ -145,6 +168,7 @@ class MemoryStore:
             else:
                 self._status = "idle"
                 self._status_message = ""
+        _close_memory_client(old_memory)
 
     def is_ready(self) -> bool:
         """返回长期记忆运行时是否已经可直接使用。"""
@@ -161,6 +185,15 @@ class MemoryStore:
         """返回当前嵌入模型下载端点，便于 UI 提示用户。"""
 
         return (os.environ.get("HF_ENDPOINT") or DEFAULT_HUGGINGFACE_ENDPOINT).strip()
+
+    def import_embedding_model_archive(self, path: Path) -> EmbeddingModelImportResult:
+        """导入离线嵌入模型 ZIP，并重置长期记忆运行时以复用新缓存。"""
+
+        result = import_embedding_model_archive(path, self.base_dir)
+        if not self.is_ready():
+            self.reset_runtime()
+            self.preload(wait=False)
+        return result
 
     def preload(self, *, wait: bool = False) -> None:
         """提前启动 mem0 加载，避免首次打开设置或聊天时才初始化。"""
@@ -773,6 +806,158 @@ def _project_embedding_cache_folder(base_dir: Path | None = None) -> Path:
     return root / "runtime" / "hf-cache" / "hub"
 
 
+def import_embedding_model_archive(path: Path, base_dir: Path | None = None) -> EmbeddingModelImportResult:
+    """导入 all-MiniLM-L6-v2 的 HuggingFace hub 缓存 ZIP。"""
+
+    archive_path = Path(path)
+    if not archive_path.exists():
+        raise FileNotFoundError(f"记忆模型包不存在：{archive_path}")
+    destination_root = _project_embedding_cache_folder(base_dir)
+    destination_model_dir = destination_root / DEFAULT_EMBEDDING_MODEL_CACHE_NAME
+    destination_root.mkdir(parents=True, exist_ok=True)
+
+    temp_root = destination_root / f".memory_model_import_{int(time.time() * 1000)}_{threading.get_ident()}"
+    staging_model_dir = temp_root / DEFAULT_EMBEDDING_MODEL_CACHE_NAME
+    backup_model_dir = destination_root / f".{DEFAULT_EMBEDDING_MODEL_CACHE_NAME}.backup"
+    try:
+        with zipfile.ZipFile(archive_path, "r") as zf:
+            model_prefix = _validate_embedding_model_zip_members(zf)
+            temp_root.mkdir(parents=True, exist_ok=False)
+            _extract_embedding_model_zip(zf, model_prefix, staging_model_dir)
+            snapshot_dir = staging_model_dir / "snapshots"
+            if not _hub_snapshot_has_model_weights(snapshot_dir):
+                raise MemoryModelImportError(
+                    "记忆模型包不完整：snapshots/ 下未找到 model.safetensors 或 pytorch_model.bin。"
+                )
+
+        if backup_model_dir.exists():
+            shutil.rmtree(backup_model_dir, ignore_errors=True)
+        if destination_model_dir.exists():
+            destination_model_dir.rename(backup_model_dir)
+        moved = False
+        try:
+            shutil.move(str(staging_model_dir), str(destination_model_dir))
+            moved = True
+            if backup_model_dir.exists():
+                shutil.rmtree(backup_model_dir, ignore_errors=True)
+        except Exception:
+            if moved and destination_model_dir.exists():
+                shutil.rmtree(destination_model_dir, ignore_errors=True)
+            if backup_model_dir.exists() and not destination_model_dir.exists():
+                backup_model_dir.rename(destination_model_dir)
+            raise
+    except zipfile.BadZipFile as exc:
+        raise MemoryModelImportError("不是有效的记忆模型 ZIP 包。") from exc
+    finally:
+        shutil.rmtree(temp_root, ignore_errors=True)
+
+    snapshot_count = sum(
+        1
+        for child in (destination_model_dir / "snapshots").iterdir()
+        if child.is_dir()
+    )
+    return EmbeddingModelImportResult(
+        model_name=DEFAULT_EMBEDDING_MODEL,
+        cache_folder=destination_root,
+        model_dir=destination_model_dir,
+        snapshot_count=snapshot_count,
+    )
+
+
+def _validate_embedding_model_zip_members(zf: zipfile.ZipFile) -> PurePosixPath:
+    """校验 ZIP 只包含目标模型目录，并返回模型目录在 ZIP 内的前缀。"""
+
+    paths: list[PurePosixPath] = []
+    file_paths: list[PurePosixPath] = []
+    for info in zf.infolist():
+        rel = _safe_zip_member_path(info)
+        paths.append(rel)
+        if not info.is_dir():
+            file_paths.append(rel)
+    if not file_paths:
+        raise MemoryModelImportError("记忆模型包为空。")
+
+    prefixes = [
+        PurePosixPath(DEFAULT_EMBEDDING_MODEL_CACHE_NAME),
+        PurePosixPath("hub", DEFAULT_EMBEDDING_MODEL_CACHE_NAME),
+        PurePosixPath("hf-cache", "hub", DEFAULT_EMBEDDING_MODEL_CACHE_NAME),
+    ]
+    for prefix in prefixes:
+        if not any(_zip_path_is_under(path, prefix) for path in file_paths):
+            continue
+        allowed_parents = set(prefix.parents)
+        for path in paths:
+            if path == PurePosixPath("."):
+                continue
+            if path in allowed_parents:
+                continue
+            if not _zip_path_is_under(path, prefix):
+                raise MemoryModelImportError(
+                    "记忆模型包只能包含 "
+                    f"{DEFAULT_EMBEDDING_MODEL_CACHE_NAME} 模型缓存目录。"
+                )
+        return prefix
+    if any(path.parts[0] == "snapshots" for path in file_paths):
+        allowed_root_parts = {"blobs", "refs", "snapshots", ".no_exist"}
+        for path in paths:
+            if path.parts[0] not in allowed_root_parts:
+                raise MemoryModelImportError(
+                    "记忆模型包根目录只能包含 blobs/、refs/、snapshots/ 或 .no_exist/。"
+                )
+        return PurePosixPath(".")
+    raise MemoryModelImportError(
+        f"记忆模型包缺少 {DEFAULT_EMBEDDING_MODEL_CACHE_NAME} 目录。"
+    )
+
+
+def _safe_zip_member_path(info: zipfile.ZipInfo) -> PurePosixPath:
+    member = str(info.filename or "").replace("\\", "/").rstrip("/")
+    if not member:
+        raise MemoryModelImportError("记忆模型包包含空 ZIP 成员名。")
+    if _is_zip_symlink(info):
+        raise MemoryModelImportError(f"记忆模型包不允许包含符号链接：{member}")
+    if "\x00" in member or member.startswith("/") or _WINDOWS_DRIVE_RE.match(member):
+        raise MemoryModelImportError(f"ZIP 成员必须是安全的相对路径：{member!r}")
+    parts = member.split("/")
+    if any(part in ("", ".", "..") for part in parts):
+        raise MemoryModelImportError(f"ZIP 成员包含不安全路径片段：{member!r}")
+    return PurePosixPath(*parts)
+
+
+def _zip_path_is_under(path: PurePosixPath, prefix: PurePosixPath) -> bool:
+    if prefix == PurePosixPath("."):
+        return True
+    return path == prefix or path.is_relative_to(prefix)
+
+
+def _extract_embedding_model_zip(
+    zf: zipfile.ZipFile,
+    model_prefix: PurePosixPath,
+    destination_model_dir: Path,
+) -> None:
+    """只把目标模型目录抽取到 staging 目录，避免 zipfile.extractall 的路径风险。"""
+
+    destination_model_dir.mkdir(parents=True, exist_ok=True)
+    for info in zf.infolist():
+        rel = _safe_zip_member_path(info)
+        if not _zip_path_is_under(rel, model_prefix) or rel == model_prefix:
+            continue
+        prefix_length = 0 if model_prefix == PurePosixPath(".") else len(model_prefix.parts)
+        target_rel = PurePosixPath(*rel.parts[prefix_length:])
+        target = destination_model_dir.joinpath(*target_rel.parts)
+        if info.is_dir():
+            target.mkdir(parents=True, exist_ok=True)
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with zf.open(info, "r") as source, target.open("wb") as output:
+            shutil.copyfileobj(source, output)
+
+
+def _is_zip_symlink(info: zipfile.ZipInfo) -> bool:
+    mode = (info.external_attr >> 16) & 0o170000
+    return mode == stat.S_IFLNK
+
+
 def _format_memory_load_error(exc: Exception, *, embedding_download: bool) -> str:
     raw_message = str(exc).strip() or exc.__class__.__name__
     if not embedding_download:
@@ -786,6 +971,27 @@ def _format_memory_load_error(exc: Exception, *, embedding_download: bool) -> st
 
 def _is_closed_client_error(exc: Exception) -> bool:
     return "client has been closed" in str(exc).lower()
+
+
+def _close_memory_client(memory: Any | None) -> None:
+    """释放 mem0 及本地 Qdrant 资源，避免重建时残留文件锁。"""
+
+    if memory is None:
+        return
+    close = getattr(memory, "close", None)
+    if callable(close):
+        try:
+            close()
+        except Exception:  # noqa: BLE001
+            logger.debug("关闭 mem0 运行时失败", exc_info=True)
+    vector_store = getattr(memory, "vector_store", None)
+    client = getattr(vector_store, "client", None)
+    client_close = getattr(client, "close", None)
+    if callable(client_close):
+        try:
+            client_close()
+        except Exception:  # noqa: BLE001
+            logger.debug("关闭 Qdrant 客户端失败", exc_info=True)
 
 
 def _hub_snapshot_has_model_weights(snapshot_dir: Path) -> bool:

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -42,7 +42,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from app.agent.memory import MemoryStore
+from app.agent.memory import EmbeddingModelImportResult, MemoryStore
 from app.agent.mcp import MCPRuntimeSettings, WINDOWS_MCP_EXPERIMENTAL_TEXT
 from app.core.debug_log import debug_log
 from app.config.character_archive import (
@@ -355,6 +355,28 @@ class MemoryListWorker(QObject):
             self.finished.emit()
 
 
+class MemoryModelImportWorker(QObject):
+    succeeded = Signal(object)
+    failed = Signal(str)
+    finished = Signal()
+
+    def __init__(self, memory_store: MemoryStore, archive_path: Path) -> None:
+        super().__init__()
+        self.memory_store = memory_store
+        self.archive_path = archive_path
+
+    @Slot()
+    def run(self) -> None:
+        try:
+            result = self.memory_store.import_embedding_model_archive(self.archive_path)
+        except Exception as exc:  # UI 边界统一转成可读错误。
+            self.failed.emit(str(exc))
+        else:
+            self.succeeded.emit(result)
+        finally:
+            self.finished.emit()
+
+
 class ThemeAiWorker(QObject):
     succeeded = Signal(object)
     failed = Signal(str)
@@ -545,6 +567,8 @@ class SettingsDialog(QDialog):
         self._save_button_text: str | None = None
         self._memory_list_thread: QThread | None = None
         self._memory_list_worker: MemoryListWorker | None = None
+        self._memory_model_import_thread: QThread | None = None
+        self._memory_model_import_worker: MemoryModelImportWorker | None = None
         self._theme_ai_thread: QThread | None = None
         self._theme_ai_worker: ThemeAiWorker | None = None
         self._theme_ai_enabled = self.theme_settings.ai_enabled
@@ -1565,6 +1589,11 @@ class SettingsDialog(QDialog):
 
         self.memory_refresh_button = QPushButton("刷新", tab)
         self.memory_refresh_button.clicked.connect(self._load_memory_entries)
+        self.memory_import_model_button = QPushButton("导入记忆模型", tab)
+        self.memory_import_model_button.setToolTip(
+            "导入 models--sentence-transformers--all-MiniLM-L6-v2.zip，供无法自动下载时使用。"
+        )
+        self.memory_import_model_button.clicked.connect(self._import_memory_model_archive)
         self.memory_status_label = QLabel(MEMORY_READING_TEXT, tab)
 
         self.memory_table = QTableWidget(0, 4, tab)
@@ -1615,6 +1644,7 @@ class SettingsDialog(QDialog):
 
         filter_layout = QHBoxLayout()
         filter_layout.addWidget(self.memory_search_edit, 1)
+        filter_layout.addWidget(self.memory_import_model_button)
         filter_layout.addWidget(self.memory_refresh_button)
 
         status_layout = QHBoxLayout()
@@ -1680,6 +1710,74 @@ class SettingsDialog(QDialog):
         self._memory_list_worker = worker
         thread.start()
 
+    def _import_memory_model_archive(self) -> None:
+        if self.memory_store is None:
+            return
+        if self._memory_model_import_thread is not None:
+            QMessageBox.information(self, "导入中", "记忆模型正在导入，请等待完成。")
+            return
+        path_text, _ = QFileDialog.getOpenFileName(
+            self,
+            "导入记忆模型 ZIP",
+            str(self.base_dir),
+            "记忆模型 ZIP (*.zip)",
+        )
+        if not path_text:
+            return
+        self._start_memory_model_import(Path(path_text))
+
+    def _start_memory_model_import(self, archive_path: Path) -> None:
+        if self.memory_store is None:
+            return
+        self._set_memory_model_import_busy(True)
+        self.memory_status_label.setText("正在导入记忆模型...")
+
+        thread = QThread()
+        worker = MemoryModelImportWorker(self.memory_store, archive_path)
+        worker.moveToThread(thread)
+        thread.started.connect(worker.run)
+        worker.succeeded.connect(self._handle_memory_model_import_success)
+        worker.failed.connect(self._handle_memory_model_import_failed)
+        worker.finished.connect(thread.quit)
+        worker.finished.connect(worker.deleteLater)
+        thread.finished.connect(thread.deleteLater)
+        thread.finished.connect(self._reset_memory_model_import_worker)
+
+        self._memory_model_import_thread = thread
+        self._memory_model_import_worker = worker
+        thread.start()
+
+    @Slot(object)
+    def _handle_memory_model_import_success(self, result: EmbeddingModelImportResult) -> None:
+        self.memory_status_label.setText("记忆模型已导入，正在重新读取长期记忆...")
+        QMessageBox.information(
+            self,
+            "导入成功",
+            (
+                f"记忆模型已导入：{result.model_name}\n"
+                f"缓存目录：{result.cache_folder}\n"
+                f"快照数量：{result.snapshot_count}"
+            ),
+        )
+        self._load_memory_entries()
+
+    @Slot(str)
+    def _handle_memory_model_import_failed(self, message: str) -> None:
+        self.memory_status_label.setText(f"导入失败：{message}")
+        QMessageBox.warning(self, "导入失败", message)
+
+    @Slot()
+    def _reset_memory_model_import_worker(self) -> None:
+        self._memory_model_import_thread = None
+        self._memory_model_import_worker = None
+        self._set_memory_model_import_busy(False)
+
+    def _set_memory_model_import_busy(self, busy: bool) -> None:
+        if hasattr(self, "memory_import_model_button"):
+            self.memory_import_model_button.setEnabled(not busy)
+        if hasattr(self, "memory_refresh_button"):
+            self.memory_refresh_button.setEnabled(not busy and self._memory_list_thread is None)
+
     def _memory_loading_text(self) -> str:
         if self.memory_store is None:
             return MEMORY_READING_TEXT
@@ -1714,7 +1812,7 @@ class SettingsDialog(QDialog):
 
     @Slot()
     def _reset_memory_list_worker(self) -> None:
-        self.memory_refresh_button.setEnabled(True)
+        self.memory_refresh_button.setEnabled(self._memory_model_import_thread is None)
         self._memory_list_thread = None
         self._memory_list_worker = None
         if self._memory_reload_pending:

--- a/tests/integration/test_agent_core.py
+++ b/tests/integration/test_agent_core.py
@@ -4,17 +4,19 @@ from datetime import datetime, timedelta
 from concurrent.futures import ThreadPoolExecutor
 import json
 from pathlib import Path
+import stat
 import sys
 import threading
 import time
 from types import SimpleNamespace
 import uuid
+import zipfile
 
 import pytest
 
 from app.agent.actions import AgentEvent, PendingToolAction
 from app.agent.builtin_tools import create_builtin_tool_registry
-from app.agent.memory import MemoryStore
+from app.agent.memory import MemoryModelImportError, MemoryStore
 from app.agent.mcp.bridge import MCPToolSpec
 from app.agent.mcp.config import load_mcp_config
 from app.agent.mcp.provider import MCPToolProvider, register_mcp_tools_from_config
@@ -611,6 +613,134 @@ def test_memory_store_ignores_incomplete_local_embedding_cache(monkeypatch) -> N
     assert config["embedder"]["config"]["model_kwargs"] == {
         "cache_folder": str(root / "runtime" / "hf-cache" / "hub"),
     }
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        "",
+        "models--sentence-transformers--all-MiniLM-L6-v2",
+        "hub/models--sentence-transformers--all-MiniLM-L6-v2",
+        "hf-cache/hub/models--sentence-transformers--all-MiniLM-L6-v2",
+    ],
+)
+def test_memory_store_imports_embedding_model_archive_structures(prefix: str) -> None:
+    root = _runtime_root_path("memory_model_import")
+    archive_path = root / "models--sentence-transformers--all-MiniLM-L6-v2.zip"
+    _write_memory_model_zip(archive_path, prefix=prefix)
+    store = MemoryStore(base_dir=root, memory_client=FakeMem0())
+
+    result = store.import_embedding_model_archive(archive_path)
+
+    expected_model_dir = (
+        root
+        / "runtime"
+        / "hf-cache"
+        / "hub"
+        / "models--sentence-transformers--all-MiniLM-L6-v2"
+    )
+    assert result.model_dir == expected_model_dir
+    assert result.snapshot_count == 1
+    assert (expected_model_dir / "snapshots" / "revision" / "model.safetensors").is_file()
+    assert store.needs_embedding_model_download() is False
+
+
+def test_memory_store_import_does_not_reload_ready_runtime() -> None:
+    root = _runtime_root_path("memory_model_import_ready")
+    archive_path = root / "models--sentence-transformers--all-MiniLM-L6-v2.zip"
+    _write_memory_model_zip(archive_path, prefix="")
+    runtime = ClosableMemoryRuntime()
+    store = MemoryStore(base_dir=root, memory_client=runtime)
+
+    store.import_embedding_model_archive(archive_path)
+
+    assert store.is_ready() is True
+    assert runtime.memory_closed is False
+    assert runtime.client.closed is False
+
+
+def test_memory_store_reset_runtime_closes_qdrant_client() -> None:
+    runtime = ClosableMemoryRuntime()
+    store = MemoryStore(base_dir=_runtime_root_path("memory_reset_closes_runtime"))
+    store._memory = runtime  # type: ignore[attr-defined]
+
+    store.reset_runtime()
+
+    assert runtime.memory_closed is True
+    assert runtime.client.closed is True
+
+
+def test_memory_store_rejects_incomplete_embedding_model_archive(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    root = _runtime_root_path("memory_model_import_incomplete")
+    monkeypatch.setenv("HF_HOME", str(root / "empty_hf_home"))
+    monkeypatch.delenv("SENTENCE_TRANSFORMERS_HOME", raising=False)
+    monkeypatch.delenv("HUGGINGFACE_HUB_CACHE", raising=False)
+    monkeypatch.delenv("TRANSFORMERS_CACHE", raising=False)
+    archive_path = root / "bad.zip"
+    _write_memory_model_zip(
+        archive_path,
+        prefix="models--sentence-transformers--all-MiniLM-L6-v2",
+        include_weight=False,
+    )
+    store = MemoryStore(base_dir=root, memory_client=FakeMem0())
+
+    with pytest.raises(MemoryModelImportError):
+        store.import_embedding_model_archive(archive_path)
+
+    assert store.needs_embedding_model_download() is True
+
+
+def test_memory_store_import_failure_keeps_existing_embedding_cache() -> None:
+    root = _runtime_root_path("memory_model_import_keeps_existing")
+    existing_snapshot = (
+        root
+        / "runtime"
+        / "hf-cache"
+        / "hub"
+        / "models--sentence-transformers--all-MiniLM-L6-v2"
+        / "snapshots"
+        / "existing"
+    )
+    existing_snapshot.mkdir(parents=True)
+    (existing_snapshot / "model.safetensors").write_text("existing", encoding="utf-8")
+    archive_path = root / "bad.zip"
+    _write_memory_model_zip(
+        archive_path,
+        prefix="models--sentence-transformers--all-MiniLM-L6-v2",
+        include_weight=False,
+    )
+    store = MemoryStore(base_dir=root, memory_client=FakeMem0())
+
+    with pytest.raises(MemoryModelImportError):
+        store.import_embedding_model_archive(archive_path)
+
+    assert (existing_snapshot / "model.safetensors").read_text(encoding="utf-8") == "existing"
+    assert store.needs_embedding_model_download() is False
+
+
+@pytest.mark.parametrize(
+    "member_name",
+    [
+        "../models--sentence-transformers--all-MiniLM-L6-v2/snapshots/revision/model.safetensors",
+        "models--other--model/snapshots/revision/model.safetensors",
+        "models--sentence-transformers--all-MiniLM-L6-v2/snapshots/revision/model.safetensors",
+    ],
+)
+def test_memory_store_rejects_unsafe_or_wrong_embedding_model_archive(member_name: str) -> None:
+    root = _runtime_root_path("memory_model_import_rejects")
+    archive_path = root / "bad.zip"
+    archive_path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(archive_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        if member_name.startswith("models--sentence-transformers"):
+            info = zipfile.ZipInfo(member_name)
+            info.external_attr = (stat.S_IFLNK | 0o777) << 16
+            zf.writestr(info, "target")
+        else:
+            zf.writestr(member_name, "bad")
+    store = MemoryStore(base_dir=root, memory_client=FakeMem0())
+
+    with pytest.raises(MemoryModelImportError):
+        store.import_embedding_model_archive(archive_path)
 
 
 def test_memory_store_create_update_search_and_delete() -> None:
@@ -3194,6 +3324,23 @@ def _runtime_root_path(name: str) -> Path:
     return Path(__file__).resolve().parents[2] / "__pycache__" / "test_runtime" / name / uuid.uuid4().hex
 
 
+def _write_memory_model_zip(
+    archive_path: Path,
+    *,
+    prefix: str,
+    include_weight: bool = True,
+) -> None:
+    archive_path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(archive_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        revision = f"{prefix}/snapshots/revision" if prefix else "snapshots/revision"
+        zf.writestr(f"{revision}/config.json", "{}")
+        if not prefix:
+            zf.writestr("refs/main", "revision")
+            zf.writestr("blobs/fake", "fake")
+        if include_weight:
+            zf.writestr(f"{revision}/model.safetensors", "fake")
+
+
 class FakeMem0:
     def __init__(self) -> None:
         self.records: list[dict[str, object]] = []
@@ -3248,6 +3395,29 @@ class FakeMem0:
             for record in self.records
             if user_id is None or record.get("user_id") == user_id
         ]
+
+
+class ClosableClient:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class ClosableVectorStore:
+    def __init__(self, client: ClosableClient) -> None:
+        self.client = client
+
+
+class ClosableMemoryRuntime:
+    def __init__(self) -> None:
+        self.client = ClosableClient()
+        self.vector_store = ClosableVectorStore(self.client)
+        self.memory_closed = False
+
+    def close(self) -> None:
+        self.memory_closed = True
 
 
 def _write_mcp_config(root: Path, server_body: str) -> Path:

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -3650,6 +3650,75 @@ def test_settings_dialog_shows_memory_dependency_download_hint() -> None:
     app.processEvents()
 
 
+def test_settings_dialog_imports_memory_model_archive(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    if not hasattr(qtwidgets, "QApplication"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+
+    from app.ui import settings_dialog as settings_dialog_module
+    from app.ui.settings_dialog import SettingsDialog
+
+    class ImportResult:
+        model_name = "sentence-transformers/all-MiniLM-L6-v2"
+        cache_folder = Path("runtime/hf-cache/hub")
+        snapshot_count = 1
+
+    class MemoryStoreStub:
+        def __init__(self) -> None:
+            self.list_calls = 0
+            self.imported_paths: list[Path] = []
+
+        def needs_embedding_model_download(self) -> bool:
+            return True
+
+        def list_memories(self, *, limit: int = 20):  # type: ignore[no-untyped-def]
+            self.list_calls += 1
+            return []
+
+        def import_embedding_model_archive(self, archive_path: Path) -> ImportResult:
+            self.imported_paths.append(archive_path)
+            return ImportResult()
+
+    QApplication = qtwidgets.QApplication
+    app = QApplication.instance() or QApplication([])
+    root = _ui_runtime_root("memory_model_import_dialog")
+    archive_path = root / "models--sentence-transformers--all-MiniLM-L6-v2.zip"
+    archive_path.write_bytes(b"zip")
+    memory_store = MemoryStoreStub()
+    monkeypatch.setattr(
+        settings_dialog_module.QFileDialog,
+        "getOpenFileName",
+        lambda *_args, **_kwargs: (str(archive_path), "记忆模型 ZIP (*.zip)"),
+    )
+    monkeypatch.setattr(settings_dialog_module.QMessageBox, "information", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(settings_dialog_module.QMessageBox, "warning", lambda *_args, **_kwargs: None)
+    dialog = SettingsDialog(
+        api_settings=ApiSettings(
+            base_url="https://api.example.com/v1",
+            api_key="test-key",
+            model="test-model",
+        ),
+        tts_settings=_minimal_tts_settings(),
+        base_dir=root,
+        proactive_care_settings=ProactiveCareSettings(screen_context_enabled=True),
+        mcp_settings=MCPRuntimeSettings(windows_enabled=False),
+        memory_store=memory_store,  # type: ignore[arg-type]
+    )
+
+    assert hasattr(dialog, "memory_import_model_button")
+    assert _process_events_until(app, lambda: dialog._memory_list_thread is None)
+
+    dialog.memory_import_model_button.click()
+
+    assert _process_events_until(app, lambda: dialog._memory_model_import_thread is None)
+    assert memory_store.imported_paths == [archive_path]
+    assert _process_events_until(app, lambda: dialog._memory_list_thread is None)
+    assert memory_store.list_calls >= 2
+    dialog.deleteLater()
+    app.processEvents()
+
+
 def test_settings_dialog_filters_memory_locally() -> None:
     os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
     qtwidgets = pytest.importorskip("PySide6.QtWidgets")


### PR DESCRIPTION
## 变更内容
- 在设置页“记忆”Tab 增加记忆模型 ZIP 导入入口，作为无法自动下载 `sentence-transformers/all-MiniLM-L6-v2` 时的备选方案。
- 支持多种 HuggingFace 缓存 ZIP 结构，包括模型目录顶层、`hub/`、`hf-cache/hub/`，以及直接以 `snapshots/ refs/ blobs/` 为根目录的压缩包。
- 增加 ZIP 路径安全校验、符号链接拒绝、模型权重完整性校验和失败回滚。
- 修复导入模型后重建 mem0 时旧 Qdrant client 未释放导致 `data/memory/qdrant` 锁冲突的问题。

## 验证
- `python -m pytest tests\integration\test_agent_core.py -q`
- `python -m pytest tests\ui\test_pet_window.py -q`
- `python -m py_compile app\agent\memory.py app\ui\settings_dialog.py`