### PR TITLE
feat: 等待回复动效与输入栏状态提示

### DIFF
--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -1615,7 +1615,7 @@ class PetWindow(QWidget):
         self.input_edit.clear()
         self._log_interaction_stage("input_cleared")
         self._collapse_auto_fit_bubble_height()
-        self.subtitle_controller.cancel_reply_flow("......")
+        self._show_waiting_reply_placeholder()
         self._log_interaction_stage("placeholder_reply_shown")
 
         visual_observation_jobs: list[VisualObservationJob] = []
@@ -1679,6 +1679,20 @@ class PetWindow(QWidget):
             ]
         self._log_interaction_stage("user_message_recorded")
         self._start_chat_worker(request_messages)
+
+    def _show_waiting_reply_placeholder(self) -> None:
+        """显示模型回复等待动效，并阻止自动隐藏在等待期间藏起气泡。"""
+        controller = getattr(self, "bubble_auto_hide", None)
+        if controller is not None:
+            controller.notify_speaking()
+        subtitle_controller = getattr(self, "subtitle_controller", None)
+        if subtitle_controller is None:
+            return
+        start_waiting_indicator = getattr(subtitle_controller, "start_waiting_indicator", None)
+        if callable(start_waiting_indicator):
+            start_waiting_indicator()
+            return
+        subtitle_controller.cancel_reply_flow("...")
 
     def _start_chat_worker(self, request_messages: list[dict[str, Any]]) -> None:
         visual_observation_jobs = getattr(self, "pending_visual_observation_jobs", [])

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -628,7 +628,7 @@ class PetWindow(QWidget):
 
         self.input_edit = QLineEdit(self.input_bar)
         self.input_edit.setObjectName("petInput")
-        self.input_edit.setPlaceholderText(f"和{self.character_profile.display_name}说点什么...")
+        self.input_edit.setPlaceholderText(self._normal_input_placeholder_text())
         self.input_edit.setFixedHeight(38)
         self.input_edit.installEventFilter(self)
         self.input_edit.returnPressed.connect(self._handle_return_pressed)
@@ -637,6 +637,7 @@ class PetWindow(QWidget):
         self.send_button.setObjectName("sendButton")
         self.send_button.setFixedHeight(38)
         self.send_button.clicked.connect(self._handle_send_button_clicked)
+        self.reply_waiting_ui_active = False
 
         self.screenshot_button = QToolButton(self.input_bar)
         self.screenshot_button.setObjectName("screenshotButton")
@@ -987,6 +988,55 @@ class PetWindow(QWidget):
         if controller is not None:
             controller.notify_speaking()
 
+    def _normal_input_placeholder_text(self, profile: CharacterProfile | None = None) -> str:
+        profile = profile or self.character_profile
+        return f"和{profile.display_name}说点什么..."
+
+    def _reply_waiting_placeholder_text(self) -> str:
+        return f"{self.character_profile.display_name}正在思考中…"
+
+    def _set_reply_waiting_ui(self, waiting: bool) -> None:
+        """切换回复等待期间的输入区状态：保留输入能力，只提示当前正在等待。"""
+        if getattr(self, "startup_initializing", False):
+            waiting = False
+        self.reply_waiting_ui_active = waiting
+        if hasattr(self, "input_edit"):
+            self.input_edit.setPlaceholderText(
+                self._reply_waiting_placeholder_text()
+                if waiting
+                else self._normal_input_placeholder_text()
+            )
+            self._set_widget_dynamic_property(self.input_edit, "replyWaiting", waiting)
+        if hasattr(self, "send_button"):
+            self._set_widget_dynamic_property(self.send_button, "replyWaiting", waiting)
+        self._sync_input_bar_waiting_visibility()
+
+    def _sync_input_bar_waiting_visibility(self) -> None:
+        animator = getattr(self, "input_bar_animator", None)
+        sync = getattr(animator, "sync", None)
+        if callable(sync):
+            sync()
+
+    def _set_widget_dynamic_property(self, widget: QWidget | None, name: str, value: object) -> None:
+        if widget is None:
+            return
+        property_getter = getattr(widget, "property", None)
+        if callable(property_getter) and property_getter(name) == value:
+            return
+        set_property = getattr(widget, "setProperty", None)
+        if not callable(set_property):
+            return
+        set_property(name, value)
+        style_getter = getattr(widget, "style", None)
+        if not callable(style_getter):
+            return
+        style = style_getter()
+        style.unpolish(widget)
+        style.polish(widget)
+        update = getattr(widget, "update", None)
+        if callable(update):
+            update()
+
     def _remember_reply_history_segments(self, segments: list[ChatSegment]) -> None:
         clean_segments = [segment for segment in segments if segment.text.strip()]
         if not clean_segments:
@@ -1329,8 +1379,8 @@ class PetWindow(QWidget):
     def _input_bar_pinned(self) -> bool:
         """输入栏在以下任一情况保持常显，避免用户操作中途被收起。
 
-        注意：不把「对话进行中(active_interaction_id)」算进来——输入框的显隐只跟随用户意图
-        （hover/焦点/有文本/待确认动作），不受桌宠讲话或请求影响。
+        注意：不把「对话进行中(active_interaction_id)」整体算进来；但等待模型回复时输入栏有状态提示
+        与呼吸动效，需要保持可见直到回复流程结束。
         """
         # 设置/历史窗口打开时不固定输入栏，配合 hover 禁用一起彻底收起。
         if self._any_dialog_open():
@@ -1338,6 +1388,7 @@ class PetWindow(QWidget):
         return (
             self.input_edit.hasFocus()
             or bool(self.input_edit.text().strip())
+            or bool(getattr(self, "reply_waiting_ui_active", False))
             # 用待确认动作状态而非 panel.isVisible()：输入栏卡片收起时 panel 的可见性会假阴性。
             or self.pending_tool_action is not None
         )
@@ -1461,6 +1512,8 @@ class PetWindow(QWidget):
     @Slot()
     def _handle_return_pressed(self) -> None:
         if getattr(self, "startup_initializing", False):
+            return
+        if self.worker_thread is not None:
             return
         self._begin_interaction("return_pressed")
         self.send_message("return_pressed")
@@ -1682,6 +1735,7 @@ class PetWindow(QWidget):
 
     def _show_waiting_reply_placeholder(self) -> None:
         """显示模型回复等待动效，并阻止自动隐藏在等待期间藏起气泡。"""
+        self._set_reply_waiting_ui(True)
         controller = getattr(self, "bubble_auto_hide", None)
         if controller is not None:
             controller.notify_speaking()
@@ -2612,7 +2666,7 @@ class PetWindow(QWidget):
 
         self.startup_initializing = False
         self._emit_app_started_event()
-        self.input_edit.setPlaceholderText(f"和{self.character_profile.display_name}说点什么...")
+        self.input_edit.setPlaceholderText(self._normal_input_placeholder_text())
         self._collapse_auto_fit_bubble_height()
         self.subtitle_controller.cancel_reply_flow(self.character_profile.initial_message)
         if self.memory_status_message_active:
@@ -2644,7 +2698,7 @@ class PetWindow(QWidget):
     @Slot(str)
     def handle_deferred_startup_failed(self, error: str) -> None:
         self.startup_initializing = False
-        self.input_edit.setPlaceholderText(f"和{self.character_profile.display_name}说点什么...")
+        self.input_edit.setPlaceholderText(self._normal_input_placeholder_text())
         self._collapse_auto_fit_bubble_height()
         self.subtitle_controller.cancel_reply_flow(f"初始化失败：{error}")
         self._set_busy(False)
@@ -2770,7 +2824,7 @@ class PetWindow(QWidget):
     def _set_busy(self, busy: bool) -> None:
         startup_initializing = getattr(self, "startup_initializing", False)
         controls_enabled = not busy and not startup_initializing
-        self.input_edit.setEnabled(controls_enabled)
+        self.input_edit.setEnabled(not startup_initializing)
         self.screenshot_button.setEnabled(controls_enabled)
         self.send_button.setEnabled(controls_enabled)
         tool_confirmation_panel = getattr(self, "tool_confirmation_panel", None)
@@ -2783,6 +2837,9 @@ class PetWindow(QWidget):
             self.send_button.setText("初始化")
         else:
             self.send_button.setText("等待" if busy else "发送")
+            set_reply_waiting_ui = getattr(self, "_set_reply_waiting_ui", None)
+            if callable(set_reply_waiting_ui):
+                set_reply_waiting_ui(busy)
         self._log_interaction_stage("set_busy", {"busy": busy})
         update_reply_history_buttons = getattr(self, "_update_reply_history_buttons", None)
         if update_reply_history_buttons is not None:
@@ -4015,7 +4072,7 @@ class PetWindow(QWidget):
         self.agent_runtime.update_character(self.system_prompt, profile.reply_tones, profile.portrait_choices)
         self.setWindowTitle(profile.display_name)
         self.name_label.setText(profile.display_name)
-        self.input_edit.setPlaceholderText(f"和{profile.display_name}说点什么...")
+        self.input_edit.setPlaceholderText(self._normal_input_placeholder_text(profile))
         # 角色切换可能改变立绘实际尺寸，需按新立绘重算窗口几何；全程抑帧避免中间错位帧，
         # 以立绘底边为锚点保持桌宠站位不动。
         anchor = self._portrait_anchor_global()

--- a/app/ui/subtitle_controller.py
+++ b/app/ui/subtitle_controller.py
@@ -20,6 +20,9 @@ from app.voice import VoicePlaybackController
 SPEECH_TYPING_INTERVAL_MS = 35
 # 分段回复之间的默认停顿时间。
 REPLY_SEGMENT_PAUSE_MS = 100
+# 等待模型回复时的点状动效。
+WAITING_INDICATOR_INTERVAL_MS = 360
+WAITING_INDICATOR_FRAMES = (".", "..", "...", "....", ".....", "......", ".....")
 SUBTITLE_TYPING_INTERVAL_MIN_MS = 5
 SUBTITLE_TYPING_INTERVAL_MAX_MS = 200
 REPLY_SEGMENT_PAUSE_MIN_MS = 0
@@ -75,6 +78,8 @@ class SubtitleController(QObject):
         self.current_segment_speech_done = False
         self.current_segment_tts_done = True
         self.reply_advance_scheduled = False
+        self.waiting_indicator_active = False
+        self.waiting_indicator_index = 0
         self.typing_interval_ms, self.segment_pause_ms = normalize_subtitle_display_speed(
             typing_interval_ms,
             segment_pause_ms,
@@ -83,6 +88,9 @@ class SubtitleController(QObject):
         self.speech_timer = QTimer(self)
         self.speech_timer.setInterval(self.typing_interval_ms)
         self.speech_timer.timeout.connect(self._show_next_speech_char)
+        self.waiting_indicator_timer = QTimer(self)
+        self.waiting_indicator_timer.setInterval(WAITING_INDICATOR_INTERVAL_MS)
+        self.waiting_indicator_timer.timeout.connect(self._show_next_waiting_indicator_frame)
 
     def set_display_speed(self, typing_interval_ms: int, segment_pause_ms: int) -> None:
         """更新字幕逐字间隔和分段停顿，后续显示流程立即使用新配置。"""
@@ -94,7 +102,10 @@ class SubtitleController(QObject):
 
     def show_segments(self, segments: list[ChatSegment]) -> None:
         clean_segments = [segment for segment in segments if segment.text.strip()]
-        if self.is_reply_sequence_active():
+        if not clean_segments:
+            self.stop_waiting_indicator()
+            return
+        if self._reply_segments_active():
             if clean_segments:
                 self.queued_reply_segment_batches.append(clean_segments)
                 self._log_stage(
@@ -116,12 +127,37 @@ class SubtitleController(QObject):
 
         self._start_reply_segments_now(clean_segments)
 
+    def start_waiting_indicator(self) -> None:
+        """显示模型回复等待动效；收到真实回复或错误时由后续流程停止。"""
+        self.reply_sequence_id += 1
+        self.pending_reply_segments = []
+        self.queued_reply_segment_batches = []
+        self.reset_current_segment_progress()
+        self.speech_timer.stop()
+        self.speech_text = ""
+        self.speech_index = 0
+        self._last_label_height = 0
+        self.waiting_indicator_active = True
+        self.waiting_indicator_index = 0
+        self._show_waiting_indicator_frame()
+        self.waiting_indicator_timer.start()
+        self._log_stage("waiting_indicator_started", None)
+
+    def stop_waiting_indicator(self) -> None:
+        """停止等待动效；若动效未启动则安全空操作。"""
+        if not self.waiting_indicator_active and not self.waiting_indicator_timer.isActive():
+            return
+        self.waiting_indicator_active = False
+        self.waiting_indicator_timer.stop()
+        self._log_stage("waiting_indicator_stopped", None)
+
     def cancel_reply_flow(
         self,
         placeholder_text: str | None = None,
         *,
         transition: bool = False,
     ) -> None:
+        self.stop_waiting_indicator()
         self.reply_sequence_id += 1
         self.pending_reply_segments = []
         self.queued_reply_segment_batches = []
@@ -147,6 +183,11 @@ class SubtitleController(QObject):
         )
 
     def is_reply_sequence_active(self) -> bool:
+        if self.waiting_indicator_active:
+            return True
+        return self._reply_segments_active()
+
+    def _reply_segments_active(self) -> bool:
         if self.pending_reply_segments or self.reply_advance_scheduled:
             return True
         return self.current_segment_in_progress()
@@ -162,6 +203,7 @@ class SubtitleController(QObject):
 
     @Slot(str)
     def set_speech(self, text: str, *, pulse: bool = False) -> None:
+        self.stop_waiting_indicator()
         cleaned = " ".join(text.split())
         self.speech_timer.stop()
         self.speech_text = cleaned
@@ -201,6 +243,7 @@ class SubtitleController(QObject):
 
     def show_text_immediately(self, text: str) -> None:
         """立即显示完整字幕，用于历史回看，不触发 TTS 或分段推进。"""
+        self.stop_waiting_indicator()
         cleaned = " ".join(text.split())
         self.speech_timer.stop()
         self.speech_text = cleaned
@@ -393,6 +436,22 @@ class SubtitleController(QObject):
             self.speech_timer.stop()
             if self.current_segment_sequence_id is not None:
                 self._mark_segment_speech_done(self.current_segment_sequence_id)
+
+    def _show_waiting_indicator_frame(self) -> None:
+        if not self.waiting_indicator_active:
+            return
+        self.speech_label.setText(WAITING_INDICATOR_FRAMES[self.waiting_indicator_index])
+
+    @Slot()
+    def _show_next_waiting_indicator_frame(self) -> None:
+        if not self.waiting_indicator_active:
+            self.waiting_indicator_timer.stop()
+            return
+        if self.waiting_indicator_index < len(WAITING_INDICATOR_FRAMES) - 1:
+            self.waiting_indicator_index += 1
+        else:
+            self.waiting_indicator_index = len(WAITING_INDICATOR_FRAMES) - 2
+        self._show_waiting_indicator_frame()
 
 
 def _segment_debug_payload(segment: ChatSegment) -> dict[str, str]:

--- a/app/ui/subtitle_controller.py
+++ b/app/ui/subtitle_controller.py
@@ -106,23 +106,22 @@ class SubtitleController(QObject):
             self.stop_waiting_indicator()
             return
         if self._reply_segments_active():
-            if clean_segments:
-                self.queued_reply_segment_batches.append(clean_segments)
-                self._log_stage(
-                    "reply_segments_queued",
-                    {
-                        "queued_batch_count": len(self.queued_reply_segment_batches),
-                        "segment_count": len(clean_segments),
-                    },
-                )
-                debug_log(
-                    "PetWindow",
-                    "当前回复未播完，后续分段已排队",
-                    {
-                        "queued_batch_count": len(self.queued_reply_segment_batches),
-                        "segments": [_segment_debug_payload(segment) for segment in clean_segments],
-                    },
-                )
+            self.queued_reply_segment_batches.append(clean_segments)
+            self._log_stage(
+                "reply_segments_queued",
+                {
+                    "queued_batch_count": len(self.queued_reply_segment_batches),
+                    "segment_count": len(clean_segments),
+                },
+            )
+            debug_log(
+                "PetWindow",
+                "当前回复未播完，后续分段已排队",
+                {
+                    "queued_batch_count": len(self.queued_reply_segment_batches),
+                    "segments": [_segment_debug_payload(segment) for segment in clean_segments],
+                },
+            )
             return
 
         self._start_reply_segments_now(clean_segments)

--- a/app/ui/theme.py
+++ b/app/ui/theme.py
@@ -323,6 +323,16 @@ def build_pet_window_stylesheet(settings: ThemeSettings) -> str:
     border: 1px solid {rgba(theme.border_color, 92)};
     color: rgba(255, 255, 255, 178);
 }}
+#sendButton[replyWaiting="true"] {{
+    background: {rgba(theme.primary_color, 146)};
+    border: 1px solid {rgba(theme.primary_color, 174)};
+    color: rgba(255, 255, 255, 218);
+}}
+#sendButton[replyWaiting="true"]:disabled {{
+    background: {rgba(theme.primary_color, 146)};
+    border: 1px solid {rgba(theme.primary_color, 174)};
+    color: rgba(255, 255, 255, 218);
+}}
 #confirmActionButton {{
     background: rgba(93, 181, 130, 225);
     border: none;

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -6217,6 +6217,7 @@ class _DummyButton:
 class _DummySubtitleController:
     def __init__(self) -> None:
         self.cancelled_with: list[str | None] = []
+        self.waiting_started = 0
         self.active = False
         self.segments = []
         self.shown_immediately: list[str] = []
@@ -6226,6 +6227,9 @@ class _DummySubtitleController:
 
     def cancel_reply_flow(self, placeholder_text: str | None = None) -> None:
         self.cancelled_with.append(placeholder_text)
+
+    def start_waiting_indicator(self) -> None:
+        self.waiting_started += 1
 
     def show_segments(self, segments):  # type: ignore[no-untyped-def]
         self.segments.append(segments)
@@ -6246,6 +6250,14 @@ class _DummySubtitleController:
         self.display_speeds.append((typing_interval_ms, segment_pause_ms))
 
 
+class _DummyBubbleAutoHide:
+    def __init__(self) -> None:
+        self.speaking_count = 0
+
+    def notify_speaking(self) -> None:
+        self.speaking_count += 1
+
+
 def test_manual_screenshot_empty_input_sends_default_text() -> None:
     window, requests, history = _build_minimal_manual_screenshot_window("")
 
@@ -6256,6 +6268,9 @@ def test_manual_screenshot_empty_input_sends_default_text() -> None:
     assert isinstance(content, list)
     assert content[0]["text"].startswith("请根据我框选的截图继续对话。")
     assert content[1]["image_url"]["url"] == "data:image/jpeg;base64,manual"
+    assert window.subtitle_controller.waiting_started == 1
+    assert window.subtitle_controller.cancelled_with == []
+    assert window.bubble_auto_hide.speaking_count == 1
     assert window.pending_manual_screen_observation is None
     assert history
     assert "data:image/jpeg;base64" not in history[0][1]
@@ -7051,6 +7066,7 @@ def _build_minimal_manual_screenshot_window(text: str):
 
     class MinimalManualScreenshotWindow:
         send_message = PetWindow.send_message
+        _show_waiting_reply_placeholder = PetWindow._show_waiting_reply_placeholder
         _record_user_message = PetWindow._record_user_message
 
     window = MinimalManualScreenshotWindow()
@@ -7069,6 +7085,7 @@ def _build_minimal_manual_screenshot_window(text: str):
     window.messages = []
     window.active_interaction_id = ""
     window.subtitle_controller = _DummySubtitleController()
+    window.bubble_auto_hide = _DummyBubbleAutoHide()
     window._mark_user_activity = lambda: None
     window._begin_interaction = lambda _source: setattr(window, "active_interaction_id", "test")
     window._log_interaction_stage = lambda *_args, **_kwargs: None
@@ -7705,6 +7722,110 @@ def test_subtitle_controller_show_text_immediately_does_not_use_tts() -> None:
         "speech_text_shown_immediately",
         {"text": "第一段。 第二段。"},
     )
+
+
+def test_subtitle_waiting_indicator_animates_and_stops_on_text() -> None:
+    from app.ui.subtitle_controller import SubtitleController
+    from app.voice import VoicePlaybackController
+
+    class DummyLabel:
+        def __init__(self) -> None:
+            self.text = ""
+
+        def clear(self) -> None:
+            self.text = ""
+
+        def setText(self, text: str) -> None:
+            self.text = text
+
+    class DummyTTS:
+        def discard_prepared(self, _handle):  # type: ignore[no-untyped-def]
+            pass
+
+    _qt_app_or_skip()
+    label = DummyLabel()
+    controller = SubtitleController(
+        label,  # type: ignore[arg-type]
+        VoicePlaybackController(DummyTTS(), lambda *_args, **_kwargs: None),
+        "zh",
+        lambda *_args, **_kwargs: None,
+        lambda _segment: None,
+        lambda: None,
+        lambda: True,
+    )
+
+    controller.start_waiting_indicator()
+    assert label.text == "."
+    assert controller.is_reply_sequence_active()
+
+    frames = []
+    for _ in range(8):
+        controller._show_next_waiting_indicator_frame()
+        frames.append(label.text)
+
+    assert frames == ["..", "...", "....", ".....", "......", ".....", "......", "....."]
+
+    controller.show_text_immediately("回复到了")
+
+    assert not controller.waiting_indicator_active
+    assert not controller.waiting_indicator_timer.isActive()
+    assert label.text == "回复到了"
+
+
+def test_subtitle_waiting_indicator_continues_until_tts_starts() -> None:
+    from app.ui.subtitle_controller import SubtitleController
+    from app.voice import VoicePlaybackController
+
+    class DummyLabel:
+        def __init__(self) -> None:
+            self.text = ""
+
+        def clear(self) -> None:
+            self.text = ""
+
+        def setText(self, text: str) -> None:
+            self.text = text
+
+    class DelayedTTS:
+        def __init__(self) -> None:
+            self.on_started = None
+            self.on_finished = None
+
+        def speak(self, _text, _tone, on_finished=None, on_started=None):  # type: ignore[no-untyped-def]
+            self.on_started = on_started
+            self.on_finished = on_finished
+
+        def discard_prepared(self, _handle):  # type: ignore[no-untyped-def]
+            pass
+
+    _qt_app_or_skip()
+    label = DummyLabel()
+    tts = DelayedTTS()
+    controller = SubtitleController(
+        label,  # type: ignore[arg-type]
+        VoicePlaybackController(tts, lambda *_args, **_kwargs: None),
+        "zh",
+        lambda *_args, **_kwargs: None,
+        lambda _segment: None,
+        lambda: None,
+        lambda: True,
+    )
+
+    controller.start_waiting_indicator()
+    controller._show_next_waiting_indicator_frame()
+    controller.show_segments([ChatSegment("第一段回复", "中性", "第一段回复")])
+
+    assert controller.waiting_indicator_active
+    assert label.text == ".."
+    assert controller.current_segment is not None
+    assert tts.on_started is not None
+
+    tts.on_started()
+
+    assert not controller.waiting_indicator_active
+    assert not controller.waiting_indicator_timer.isActive()
+    assert controller.speech_text == "第一段回复"
+    controller.cancel_reply_flow()
 
 
 def test_send_message_injects_runtime_event_context_before_user_message() -> None:

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -6182,9 +6182,15 @@ class _DummyEditableInput:
     def __init__(self, text: str) -> None:
         self._text = text
         self.cleared = False
+        self.enabled = True
+        self.placeholder = ""
+        self.properties: dict[str, object] = {}
 
     def text(self) -> str:
         return self._text
+
+    def hasFocus(self) -> bool:
+        return False
 
     def clear(self) -> None:
         self.cleared = True
@@ -6192,6 +6198,15 @@ class _DummyEditableInput:
 
     def setEnabled(self, enabled: bool) -> None:
         self.enabled = enabled
+
+    def setPlaceholderText(self, text: str) -> None:
+        self.placeholder = text
+
+    def property(self, name: str) -> object:
+        return self.properties.get(name)
+
+    def setProperty(self, name: str, value: object) -> None:
+        self.properties[name] = value
 
 
 class _DummyTimer:
@@ -6203,6 +6218,7 @@ class _DummyButton:
     def __init__(self) -> None:
         self.enabled = True
         self.text = ""
+        self.properties: dict[str, object] = {}
 
     def setVisible(self, _visible: bool) -> None:
         pass
@@ -6212,6 +6228,12 @@ class _DummyButton:
 
     def setText(self, text: str) -> None:
         self.text = text
+
+    def property(self, name: str) -> object:
+        return self.properties.get(name)
+
+    def setProperty(self, name: str, value: object) -> None:
+        self.properties[name] = value
 
 
 class _DummySubtitleController:
@@ -6258,6 +6280,18 @@ class _DummyBubbleAutoHide:
         self.speaking_count += 1
 
 
+class _DummyInputBarAnimator:
+    def __init__(self) -> None:
+        self.sync_count = 0
+        self.feedback_count = 0
+
+    def sync(self) -> None:
+        self.sync_count += 1
+
+    def play_send_feedback(self) -> None:
+        self.feedback_count += 1
+
+
 def test_manual_screenshot_empty_input_sends_default_text() -> None:
     window, requests, history = _build_minimal_manual_screenshot_window("")
 
@@ -6271,6 +6305,10 @@ def test_manual_screenshot_empty_input_sends_default_text() -> None:
     assert window.subtitle_controller.waiting_started == 1
     assert window.subtitle_controller.cancelled_with == []
     assert window.bubble_auto_hide.speaking_count == 1
+    assert window.input_edit.placeholder == "Sakura正在思考中…"
+    assert window.input_edit.properties["replyWaiting"] is True
+    assert window.send_button.properties["replyWaiting"] is True
+    assert window.input_bar_animator.sync_count == 1
     assert window.pending_manual_screen_observation is None
     assert history
     assert "data:image/jpeg;base64" not in history[0][1]
@@ -6338,20 +6376,60 @@ def test_set_busy_disables_manual_screenshot_button() -> None:
 
     class MinimalBusyWindow:
         _set_busy = PetWindow._set_busy
+        _set_reply_waiting_ui = PetWindow._set_reply_waiting_ui
+        _normal_input_placeholder_text = PetWindow._normal_input_placeholder_text
+        _reply_waiting_placeholder_text = PetWindow._reply_waiting_placeholder_text
+        _sync_input_bar_waiting_visibility = PetWindow._sync_input_bar_waiting_visibility
+        _set_widget_dynamic_property = PetWindow._set_widget_dynamic_property
 
     window = MinimalBusyWindow()
+    window.character_profile = type("CharacterProfile", (), {"display_name": "Sakura"})()
+    window.startup_initializing = False
     window.input_edit = _DummyEditableInput("")
     window.screenshot_button = _DummyButton()
     window.send_button = _DummyButton()
     window.confirm_action_button = _DummyButton()
     window.cancel_action_button = _DummyButton()
+    window.input_bar_animator = _DummyInputBarAnimator()
     window._log_interaction_stage = lambda *_args, **_kwargs: None
 
     window._set_busy(True)
+    assert window.input_edit.enabled
     assert not window.screenshot_button.enabled
+    assert not window.send_button.enabled
+    assert window.send_button.text == "等待"
+    assert window.input_edit.placeholder == "Sakura正在思考中…"
+    assert window.input_edit.properties["replyWaiting"] is True
+    assert window.send_button.properties["replyWaiting"] is True
+    assert window.input_bar_animator.sync_count == 1
 
     window._set_busy(False)
     assert window.screenshot_button.enabled
+    assert window.send_button.enabled
+    assert window.send_button.text == "发送"
+    assert window.input_edit.placeholder == "和Sakura说点什么..."
+    assert window.input_edit.properties["replyWaiting"] is False
+    assert window.send_button.properties["replyWaiting"] is False
+    assert window.input_bar_animator.sync_count == 2
+
+
+def test_input_bar_pinned_while_waiting_reply() -> None:
+    from app.ui.pet_window import PetWindow
+
+    class MinimalInputBarWindow:
+        _input_bar_pinned = PetWindow._input_bar_pinned
+        _any_dialog_open = lambda _self: False
+
+    window = MinimalInputBarWindow()
+    window.input_edit = _DummyEditableInput("")
+    window.pending_tool_action = None
+    window.reply_waiting_ui_active = False
+
+    assert not window._input_bar_pinned()
+
+    window.reply_waiting_ui_active = True
+
+    assert window._input_bar_pinned()
 
 
 def test_progress_reply_displays_and_records_assistant_message() -> None:
@@ -7067,6 +7145,11 @@ def _build_minimal_manual_screenshot_window(text: str):
     class MinimalManualScreenshotWindow:
         send_message = PetWindow.send_message
         _show_waiting_reply_placeholder = PetWindow._show_waiting_reply_placeholder
+        _set_reply_waiting_ui = PetWindow._set_reply_waiting_ui
+        _normal_input_placeholder_text = PetWindow._normal_input_placeholder_text
+        _reply_waiting_placeholder_text = PetWindow._reply_waiting_placeholder_text
+        _sync_input_bar_waiting_visibility = PetWindow._sync_input_bar_waiting_visibility
+        _set_widget_dynamic_property = PetWindow._set_widget_dynamic_property
         _record_user_message = PetWindow._record_user_message
 
     window = MinimalManualScreenshotWindow()
@@ -7084,6 +7167,10 @@ def _build_minimal_manual_screenshot_window(text: str):
     window.screen_observation_enabled = True
     window.messages = []
     window.active_interaction_id = ""
+    window.startup_initializing = False
+    window.character_profile = type("CharacterProfile", (), {"display_name": "Sakura"})()
+    window.send_button = _DummyButton()
+    window.input_bar_animator = _DummyInputBarAnimator()
     window.subtitle_controller = _DummySubtitleController()
     window.bubble_auto_hide = _DummyBubbleAutoHide()
     window._mark_user_activity = lambda: None
@@ -7880,6 +7967,14 @@ def test_pet_input_stylesheet_has_solid_visual_effect_state() -> None:
     assert '#inputBar[visualEffectMode="solid"]' in stylesheet
     assert '#petInput[visualEffectMode="solid"]' in stylesheet
     assert '#petInput[visualEffectMode="solid"]:focus' in stylesheet
+
+
+def test_pet_input_stylesheet_has_waiting_send_button_state() -> None:
+    stylesheet = build_pet_window_stylesheet(DEFAULT_THEME_SETTINGS)
+
+    assert '#petInput[replyWaiting="true"]' not in stylesheet
+    assert "waitingBreath" not in stylesheet
+    assert '#sendButton[replyWaiting="true"]:disabled' in stylesheet
 
 
 def test_pet_window_applies_visual_effect_dynamic_property() -> None:


### PR DESCRIPTION
## Summary

- 发送消息后，字幕区显示逐步展开的点状等待动效（`. → .. → ... → ......`），收到真实回复时无缝衔接
- 等待期间输入栏占位文本切换为「X正在思考中…」，发送按钮保留主题色（不退化为灰色 disabled 样式）
- `input_edit` 在等待期间保持可用，允许用户提前输入下一条消息；`_input_bar_pinned` 同步保持输入栏可见
- `_handle_return_pressed` 增加 `worker_thread` 守卫，防止 Enter 键在等待期间重复触发发送

## 改动文件

| 文件 | 说明 |
|---|---|
| `app/ui/subtitle_controller.py` | 新增 `start_waiting_indicator` / `stop_waiting_indicator`；`is_reply_sequence_active` 覆盖等待期；提取 `_reply_segments_active` 私有方法 |
| `app/ui/pet_window.py` | 新增 `_show_waiting_reply_placeholder`、`_set_reply_waiting_ui`、`_set_widget_dynamic_property` 等方法；`_set_busy` 调整 input_edit 启用逻辑 |
| `app/ui/theme.py` | 新增 `#sendButton[replyWaiting="true"]` 等待状态样式 |
| `tests/ui/test_pet_window.py` | 新增动效帧顺序、TTS 延迟停止、输入栏状态等测试；更新已有 `send_message` 相关用例 |

## Test plan

- [x] `pytest tests/ui/test_pet_window.py` — 188 passed，无回归
- [x] `test_subtitle_waiting_indicator_animates_and_stops_on_text` — 验证帧顺序与文本接管
- [x] `test_subtitle_waiting_indicator_continues_until_tts_starts` — 验证 TTS 延迟期间动效持续
- [x] `test_set_busy_disables_manual_screenshot_button` — 验证等待期间 input_edit 可用、send_button 不可用
- [x] `test_input_bar_pinned_while_waiting_reply` — 验证等待期间输入栏保持可见

🤖 Generated with [Claude Code](https://claude.com/claude-code)