### PR TITLE
Feat/stage collision box

### DIFF
--- a/app/config/models.py
+++ b/app/config/models.py
@@ -32,6 +32,10 @@ class DebugLogSettings:
     enabled: bool = False
     body_enabled: bool = False
     file_enabled: bool = False
+    # 开发者选项:舞台调试框(画窗口/布局/实际立绘三框 + DPR 数值,排查布局/HiDPI)。
+    stage_debug_overlay: bool = False
+    # 舞台碰撞遮罩(默认开):setMask 到内容矩形并集,立绘四周空白点击穿透,避免误拖/挡点击。
+    stage_collision_mask: bool = True
 
 
 # ---- TTS 配置 (存根，实际实现在 app/voice/tts_settings.py) ----

--- a/app/config/settings_service.py
+++ b/app/config/settings_service.py
@@ -39,6 +39,10 @@ class DebugLogSettings:
     enabled: bool = False
     body_enabled: bool = False
     file_enabled: bool = False
+    # 开发者选项:舞台调试框(画窗口/布局/实际立绘三框 + DPR 数值,排查布局/HiDPI)。
+    stage_debug_overlay: bool = False
+    # 舞台碰撞遮罩(默认开):setMask 到内容矩形并集,立绘四周空白点击穿透,避免误拖/挡点击。
+    stage_collision_mask: bool = True
 
 
 @dataclass(frozen=True)
@@ -291,6 +295,8 @@ class AppSettingsService:
             enabled=_bool_value(debug.get("enabled"), False),
             body_enabled=_bool_value(debug.get("body_enabled"), False),
             file_enabled=_bool_value(debug.get("file_enabled"), False),
+            stage_debug_overlay=_bool_value(debug.get("stage_debug_overlay"), False),
+            stage_collision_mask=_bool_value(debug.get("stage_collision_mask"), True),
         )
 
     def save_debug_log_settings(self, settings: DebugLogSettings) -> None:
@@ -300,6 +306,8 @@ class AppSettingsService:
                 "enabled": bool(settings.enabled),
                 "body_enabled": bool(settings.body_enabled),
                 "file_enabled": bool(settings.file_enabled),
+                "stage_debug_overlay": bool(settings.stage_debug_overlay),
+                "stage_collision_mask": bool(settings.stage_collision_mask),
             },
         )
 

--- a/app/ui/control_panel_layout.py
+++ b/app/ui/control_panel_layout.py
@@ -46,8 +46,9 @@ CONTROL_PANEL_BOTTOM_MARGIN = 84
 # 舞台（主窗口）尺寸保底与下限，复刻 pet_window 中的同名常量。
 DEFAULT_STAGE_WIDTH = 860
 MIN_STAGE_HEIGHT = 420
-# 窗口宽度 = max(DEFAULT_STAGE_WIDTH, panel_width + STAGE_WIDTH_PANEL_PAD)；
+# 窗口宽度 = max(立绘宽, panel_width) + STAGE_WIDTH_PANEL_PAD(动态包络,无 860 保底);
 # 气泡/输入栏宽度 = min(panel_width, max(MIN_CONTROL_PANEL_WIDTH, window_w - BUBBLE_INNER_PAD))。
+# DEFAULT_STAGE_WIDTH 保留作初始名义尺寸/历史参考,不再参与 window_w 计算。
 STAGE_WIDTH_PANEL_PAD = 96
 BUBBLE_INNER_PAD = 32
 # 立绘底边到窗口底边的基础留白（重构前 _layout_stage 中 `height - portrait_h - 62` 的 62）。
@@ -102,8 +103,9 @@ def compute_pet_layout(
     pw = max(0, int(portrait_width))
     ph = max(0, int(portrait_height))
 
-    # 横向：窗口宽度保底 860 随控制组加宽；气泡/输入栏共用同一宽度并水平居中。
-    window_w = max(DEFAULT_STAGE_WIDTH, panel_width + STAGE_WIDTH_PANEL_PAD)
+    # 横向:窗口宽度取「立绘」与「控制组」中较宽者 + 边距(动态包络),不再固定保底 860,
+    # 避免窄立绘/窄气泡时窗口两侧留大片空白(及随之而来的多余可点击/碰撞区)。
+    window_w = max(pw, panel_width) + STAGE_WIDTH_PANEL_PAD
     bubble_w = min(panel_width, max(MIN_CONTROL_PANEL_WIDTH, window_w - BUBBLE_INNER_PAD))
 
     # 纵向：参考原点为立绘底边(0)，y 向下为正。

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -28,6 +28,7 @@ from PySide6.QtGui import (
     QMouseEvent,
     QPainter,
     QPixmap,
+    QRegion,
 )
 from PySide6.QtWidgets import (
     QApplication,
@@ -619,6 +620,20 @@ class PetWindow(QWidget):
             on_portrait_changed=self._update_tray_icon_pixmap,
             portrait_scale_percent=self.portrait_scale_percent,
             parent=self,
+        )
+
+        # 舞台调试可视化层:开发者选项(设置页)或 env SAKURA_STAGE_DEBUG=1 启用,默认完全惰性。
+        # 画窗口/布局/实际立绘三框 + DPR 等数值,用于诊断布局/碰撞与 mac HiDPI 逻辑/物理错配。
+        self._stage_debug_overlay = None
+        self._apply_stage_debug_overlay(
+            self.debug_log_settings.stage_debug_overlay
+            or bool(os.environ.get("SAKURA_STAGE_DEBUG"))
+        )
+        # 舞台碰撞遮罩:开发者选项,把命中区裁到内容矩形并集(立绘四周空白点击穿透);默认关。
+        self._stage_collision_mask_enabled = False
+        self._apply_stage_collision_mask(
+            self.debug_log_settings.stage_collision_mask
+            or bool(os.environ.get("SAKURA_STAGE_MASK"))
         )
 
         self.bubble = QFrame(self)
@@ -1656,7 +1671,87 @@ class PetWindow(QWidget):
         只摆子控件、不改窗口尺寸，避免 setGeometry → resizeEvent → _layout_stage 递归；
         窗口尺寸的变更统一由 _apply_pet_layout 负责。
         """
-        self._place_pet_children(self._compute_pet_layout())
+        layout = self._compute_pet_layout()
+        self._place_pet_children(layout)
+        self._update_stage_debug_overlay(layout)
+        self._update_stage_mask(layout)
+
+    def _apply_stage_collision_mask(self, enabled: bool, *, refresh: bool = False) -> None:
+        """开关舞台碰撞遮罩。关闭时清除遮罩(整窗可点);开启 + refresh 时立即重算。"""
+        self._stage_collision_mask_enabled = bool(enabled)
+        if not enabled:
+            self.clearMask()
+        elif refresh:
+            self._update_stage_mask(self._compute_pet_layout())
+
+    def _update_stage_mask(self, layout) -> None:  # type: ignore[no-untyped-def]
+        """把窗口命中/绘制区裁到「立绘+气泡+输入栏」矩形并集 ∪ 可见直接子控件,空白处穿透。
+
+        始终并入三个布局矩形(气泡/输入栏即便此刻隐藏也预留,避免其出现时被裁);再并入所有
+        可见直接子控件(回复历史等),确保不裁掉任何可见 UI。任何异常都清除遮罩降级为整窗可点。
+        """
+        if not getattr(self, "_stage_collision_mask_enabled", False):
+            return
+        try:
+            region = QRegion()
+            for x, y, w, h in (layout.portrait_rect, layout.bubble_rect, layout.input_rect):
+                region = region.united(QRegion(x, y, w, h))
+            overlay = getattr(self, "_stage_debug_overlay", None)
+            for child in self.children():
+                if isinstance(child, QWidget) and child is not overlay and child.isVisible():
+                    region = region.united(QRegion(child.geometry()))
+            self.setMask(region)
+        except Exception as exc:  # noqa: BLE001
+            debug_log("UI", "舞台碰撞遮罩更新失败,清除遮罩降级", {"error": str(exc)})
+            self.clearMask()
+
+    def _apply_stage_debug_overlay(self, enabled: bool, *, refresh: bool = False) -> None:
+        """按开关创建/销毁舞台调试层。refresh=True 时立即重排以填充数值(运行期切换用)。"""
+        overlay = getattr(self, "_stage_debug_overlay", None)
+        if enabled and overlay is None:
+            from app.ui.stage_debug_overlay import StageDebugOverlay
+
+            overlay = StageDebugOverlay(self)
+            overlay.setGeometry(self.rect())
+            overlay.show()
+            self._stage_debug_overlay = overlay
+            if refresh:
+                self._layout_stage()
+        elif not enabled and overlay is not None:
+            overlay.hide()
+            overlay.deleteLater()
+            self._stage_debug_overlay = None
+
+    def _update_stage_debug_overlay(self, layout) -> None:  # type: ignore[no-untyped-def]
+        """刷新舞台调试层(仅当启用时存在);并打印一组诊断数值。"""
+        overlay = getattr(self, "_stage_debug_overlay", None)
+        if overlay is None:
+            return
+        overlay.setGeometry(self.rect())
+        overlay.raise_()
+        px, py, pw, ph = layout.portrait_rect
+        pm = self.label.pixmap()
+        pm_info = (
+            f"{pm.width()}x{pm.height()} dpr={pm.devicePixelRatio():.2f}"
+            if pm is not None and not pm.isNull()
+            else "none"
+        )
+        screen = self.screen()
+        screen_dpr = screen.devicePixelRatio() if screen is not None else 0.0
+        lg = self.label.geometry()
+        info = (
+            f"win logical   : {self.width()}x{self.height()}\n"
+            f"devicePixelRatio: win={self.devicePixelRatioF():.2f} screen={screen_dpr:.2f}\n"
+            f"stage_size    : {self.stage_size}\n"
+            f"portrait_rect : ({px},{py},{pw},{ph})  [green]\n"
+            f"label.geometry: ({lg.x()},{lg.y()},{lg.width()},{lg.height()})  [blue]\n"
+            f"label pixmap  : {pm_info}"
+        )
+        overlay.update_debug(
+            portrait_rect=QRect(px, py, pw, ph),
+            label_rect=QRect(lg.x(), lg.y(), lg.width(), lg.height()),
+            info=info,
+        )
 
     def _local_rect_to_global(self, rect: QRect) -> QRect:
         return QRect(self.mapToGlobal(rect.topLeft()), rect.size())
@@ -4308,6 +4403,12 @@ class PetWindow(QWidget):
         mcp_restart_required = dialog.result_mcp_settings != self.mcp_settings
         self.mcp_settings = dialog.result_mcp_settings
         self.debug_log_settings = dialog.result_debug_log_settings
+        self._apply_stage_debug_overlay(
+            self.debug_log_settings.stage_debug_overlay, refresh=True
+        )
+        self._apply_stage_collision_mask(
+            self.debug_log_settings.stage_collision_mask, refresh=True
+        )
         self.startup_settings = result_startup_settings
         sync_screen_awareness_timer = getattr(self, "_sync_screen_awareness_timer", None)
         if callable(sync_screen_awareness_timer):

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 import time
 from datetime import datetime, timedelta

--- a/app/ui/portrait_controller.py
+++ b/app/ui/portrait_controller.py
@@ -144,14 +144,18 @@ class PortraitController(QObject):
         scale = self.portrait_scale_percent / 100
         target_width = round(PORTRAIT_BASE_MAX_WIDTH * scale)
         target_height = round(PORTRAIT_BASE_MAX_HEIGHT * scale)
+        # HiDPI:按物理像素(逻辑尺寸 × dpr)缩放并标记 dpr,否则 retina 上立绘被拉伸成半分辨率(糊)。
+        # 逻辑尺寸(deviceIndependentSize)不变,故不影响舞台布局,只提升清晰度。
+        dpr = label.devicePixelRatioF() or 1.0
         scaled = pixmap.scaled(
-            target_width,
-            target_height,
+            round(target_width * dpr),
+            round(target_height * dpr),
             Qt.AspectRatioMode.KeepAspectRatio,
             Qt.TransformationMode.SmoothTransformation,
         )
+        scaled.setDevicePixelRatio(dpr)
         label.setPixmap(scaled)
-        label.resize(scaled.size())
+        label.resize(scaled.deviceIndependentSize().toSize())
 
     def _crossfade(self, next_pixmap: QPixmap) -> None:
         self._stop_transition(finish_current=True)

--- a/app/ui/settings/pages/sections.py
+++ b/app/ui/settings/pages/sections.py
@@ -771,6 +771,18 @@ class SystemSettingsPage:
         owner.debug_body_enabled_check.setEnabled(owner.debug_log_enabled_check.isChecked())
         owner.debug_file_enabled_check = QCheckBox("输出文件运行日志", tab)
         owner.debug_file_enabled_check.setChecked(debug_settings.file_enabled)
+        owner.stage_debug_overlay_check = QCheckBox("舞台调试框（开发者，画窗口/布局/立绘边界 + DPR）", tab)
+        owner.stage_debug_overlay_check.setChecked(debug_settings.stage_debug_overlay)
+        owner.stage_debug_overlay_check.setToolTip(
+            "在桌宠上叠加可视化调试层:红=窗口/碰撞区,绿=布局算出的立绘框,蓝=实际立绘控件,"
+            "并显示逻辑尺寸与 devicePixelRatio,用于排查舞台尺寸/碰撞与 mac HiDPI 问题。"
+        )
+        owner.stage_collision_mask_check = QCheckBox("舞台碰撞贴合（立绘四周空白可穿透点击，默认开）", tab)
+        owner.stage_collision_mask_check.setChecked(debug_settings.stage_collision_mask)
+        owner.stage_collision_mask_check.setToolTip(
+            "用 setMask 把窗口命中区裁到「立绘+气泡+输入栏」矩形并集,立绘两侧/角落的透明空白"
+            "不再拦截点击(可点到下层窗口),也不会再误拖桌宠。"
+        )
 
         owner.subtitle_typing_interval_spin = _NoWheelSpinBox(tab)
         owner.subtitle_typing_interval_spin.setRange(
@@ -810,6 +822,8 @@ class SystemSettingsPage:
         debug_form.addRow("", owner.debug_log_enabled_check)
         debug_form.addRow("", owner.debug_body_enabled_check)
         debug_form.addRow("", owner.debug_file_enabled_check)
+        debug_form.addRow("", owner.stage_debug_overlay_check)
+        debug_form.addRow("", owner.stage_collision_mask_check)
         subtitle_form = QFormLayout()
         subtitle_form.setContentsMargins(16, 12, 16, 12)
         subtitle_form.setSpacing(12)

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -1366,6 +1366,8 @@ class SettingsDialog(QDialog):
                     and self.debug_body_enabled_check.isChecked()
                 ),
                 file_enabled=self.debug_file_enabled_check.isChecked(),
+                stage_debug_overlay=self.stage_debug_overlay_check.isChecked(),
+                stage_collision_mask=self.stage_collision_mask_check.isChecked(),
             ),
             "startup_settings": StartupSettings(
                 launch_at_login=(

--- a/app/ui/stage_debug_overlay.py
+++ b/app/ui/stage_debug_overlay.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from PySide6.QtCore import QRect, Qt
+from PySide6.QtGui import QColor, QFont, QPainter, QPen
+from PySide6.QtWidgets import QWidget
+
+
+class StageDebugOverlay(QWidget):
+    """舞台调试可视化层(env SAKURA_STAGE_DEBUG=1 启用)。
+
+    画出三个矩形 + 关键数值,用于看清舞台碰撞区、并诊断 mac HiDPI 下逻辑/物理坐标错配:
+      - 红框 = 窗口/舞台 rect(整窗,也就是当前的碰撞/可拖动区);
+      - 绿框 = 布局 compute_pet_layout 算出的 portrait_rect(它"以为"立绘在哪);
+      - 蓝框 = 实际立绘 QLabel 的 geometry()(立绘控件真正在哪)。
+    三框 + 可见立绘若对不齐,即暴露逻辑/物理像素或锚点数学的问题。
+    纯展示层:鼠标穿透、无系统背景,绝不影响交互。
+    """
+
+    def __init__(self, parent: QWidget) -> None:
+        super().__init__(parent)
+        self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents, True)
+        self.setAttribute(Qt.WidgetAttribute.WA_NoSystemBackground, True)
+        self._portrait_rect: QRect | None = None
+        self._label_rect: QRect | None = None
+        self._info: str = ""
+
+    def update_debug(
+        self,
+        *,
+        portrait_rect: QRect | None,
+        label_rect: QRect | None,
+        info: str,
+    ) -> None:
+        self._portrait_rect = portrait_rect
+        self._label_rect = label_rect
+        self._info = info
+        self.update()
+
+    def paintEvent(self, event) -> None:  # type: ignore[no-untyped-def]
+        del event
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing, False)
+        self._stroke(painter, self.rect(), QColor(255, 60, 60), "stage / window (碰撞区)")
+        if self._portrait_rect is not None:
+            self._stroke(painter, self._portrait_rect, QColor(60, 220, 90), "layout portrait_rect")
+        if self._label_rect is not None:
+            self._stroke(painter, self._label_rect, QColor(80, 150, 255), "label.geometry()")
+        if self._info:
+            self._draw_info(painter)
+        painter.end()
+
+    def _stroke(self, painter: QPainter, rect: QRect, color: QColor, label: str) -> None:
+        pen = QPen(color)
+        pen.setWidthF(2.0)
+        painter.setPen(pen)
+        painter.setBrush(Qt.BrushStyle.NoBrush)
+        painter.drawRect(rect.adjusted(1, 1, -2, -2))
+        painter.drawText(rect.adjusted(5, 3, -5, -5), int(Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignLeft), label)
+
+    def _draw_info(self, painter: QPainter) -> None:
+        font = QFont()
+        font.setPointSize(10)
+        font.setStyleHint(QFont.StyleHint.Monospace)
+        painter.setFont(font)
+        # 半透明黑底提升可读性。
+        lines = self._info.count("\n") + 1
+        box = QRect(8, 8, max(260, self.width() - 16), 18 * lines + 10)
+        painter.fillRect(box, QColor(0, 0, 0, 150))
+        painter.setPen(QColor(255, 235, 60))
+        painter.drawText(box.adjusted(6, 4, -6, -4), int(Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignLeft), self._info)

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -8285,6 +8285,12 @@ def _minimal_settings_window(pet_window_cls, settings_service, api_client, memor
         _apply_launch_at_login_settings = pet_window_cls._apply_launch_at_login_settings
         _apply_bubble_settings = pet_window_cls._apply_bubble_settings
 
+        def _apply_stage_debug_overlay(self, enabled: bool, *, refresh: bool = False) -> None:
+            self.stage_debug_overlay_applied = (enabled, refresh)
+
+        def _apply_stage_collision_mask(self, enabled: bool, *, refresh: bool = False) -> None:
+            self.stage_collision_mask_applied = (enabled, refresh)
+
         def _create_tts_provider_from_settings(self, _settings):  # type: ignore[no-untyped-def]
             return object()
 

--- a/tests/unit/test_pet_layout.py
+++ b/tests/unit/test_pet_layout.py
@@ -9,10 +9,10 @@ from __future__ import annotations
 import pytest
 
 from app.ui.control_panel_layout import (
-    DEFAULT_STAGE_WIDTH,
     INPUT_BAR_HEIGHT,
     MIN_STAGE_HEIGHT,
     PORTRAIT_BOTTOM_PAD,
+    STAGE_WIDTH_PANEL_PAD,
     PetLayout,
     compute_pet_layout,
 )
@@ -27,21 +27,25 @@ def _rect_bottom(rect: tuple[int, int, int, int]) -> int:
     return rect[1] + rect[3]
 
 
-def test_default_layout_reproduces_legacy_geometry() -> None:
-    """默认参数（立绘 560x570、控制组 640、气泡 128、偏移 0）应复刻重构前几何。"""
+def test_default_layout_geometry() -> None:
+    """默认参数（立绘 560x570、控制组 640、气泡 128、偏移 0）的单窗口几何。
+
+    宽度为「立绘/控制组较宽者 + 边距」的动态包络（640+96=736），不再固定 860;
+    纵向几何（立绘底边锚点、各元素相对位置）仍复刻重构前。
+    """
     layout = compute_pet_layout(portrait_width=560, portrait_height=570)
 
-    assert layout.window_size == (860, 640)
+    assert layout.window_size == (736, 640)
     # 立绘水平居中、顶部留白 8、底边距窗口底 62。
-    assert layout.portrait_rect == (150, 8, 560, 570)
+    assert layout.portrait_rect == (88, 8, 560, 570)
     assert _portrait_bottom(layout) == 578
     assert layout.window_size[1] - _portrait_bottom(layout) == PORTRAIT_BOTTOM_PAD
-    assert layout.portrait_anchor == (430, 578)
+    assert layout.portrait_anchor == (368, 578)
     # 气泡：宽 640 居中，底边在立绘底边上方 84。
-    assert layout.bubble_rect == (110, 366, 640, 128)
+    assert layout.bubble_rect == (48, 366, 640, 128)
     assert _rect_bottom(layout.bubble_rect) == 578 - 84
     # 输入栏：与气泡同宽同 x，落在窗口内。
-    assert layout.input_rect == (110, 504, 640, 52)
+    assert layout.input_rect == (48, 504, 640, 52)
     assert _rect_bottom(layout.input_rect) <= layout.window_size[1]
 
 
@@ -89,11 +93,12 @@ def test_min_stage_height_clamp_keeps_portrait_bottom_pad() -> None:
     assert layout.window_size[1] - _portrait_bottom(layout) == PORTRAIT_BOTTOM_PAD
 
 
-def test_window_width_grows_with_control_panel() -> None:
+def test_window_width_is_content_envelope() -> None:
+    # 窗口宽 = max(立绘, 控制组) + 边距:窄面板时由立绘决定,宽面板时由面板决定,无 860 保底。
     narrow = compute_pet_layout(portrait_width=560, portrait_height=570, control_panel_width=420)
     wide = compute_pet_layout(portrait_width=560, portrait_height=570, control_panel_width=860)
-    assert narrow.window_size[0] == DEFAULT_STAGE_WIDTH  # 420+96=516 < 860 保底
-    assert wide.window_size[0] == 860 + 96
+    assert narrow.window_size[0] == 560 + STAGE_WIDTH_PANEL_PAD  # 立绘 560 > 面板 420
+    assert wide.window_size[0] == 860 + STAGE_WIDTH_PANEL_PAD     # 面板 860 > 立绘 560
 
 
 def test_portrait_anchor_matches_portrait_bottom_center() -> None:


### PR DESCRIPTION
# fix: 立绘 HiDPI 模糊 · 舞台/碰撞体积过大 · 接话 TTS 稳定性

修复三类桌宠体验问题(macOS Retina + 通用)。

## 1. macOS Retina 立绘模糊
`PortraitController._apply_pixmap_to_label` 原按逻辑尺寸缩放(dpr=1.0),在 2x
retina 屏上被拉伸成半分辨率(糊)。改为按物理像素(逻辑尺寸 × devicePixelRatio)
缩放并标记 dpr,逻辑尺寸(deviceIndependentSize)不变 → 不影响舞台布局,只提升清晰度。

## 2. 舞台与碰撞体积过大
- **宽度动态包络**:窗口宽此前固定保底 860,远大于实际内容(气泡 640、立绘更窄),
  两侧留大片空白。改为 `window_w = max(立绘, 控制组) + 边距`,随内容收窄(如 736),
  去掉 860 保底。
- **舞台碰撞贴合(默认开)**:`setMask` 把窗口命中/绘制区裁到「立绘+气泡+输入栏」矩形
  并集 ∪ 可见子控件,立绘四周透明空白点击穿透到下层、不再误拖桌宠;异常清除遮罩降级。
  窗口尺寸变更(`_apply_pet_layout`)与子控件重排(`_layout_stage`)两条路径都刷新
  遮罩(抑帧内单帧呈现),避免气泡自适应变高时被裁。设置页保留关闭开关。
- 附:舞台调试框开发者选项(env `SAKURA_STAGE_DEBUG` / 设置页),叠加窗口/布局/立绘
  三框 + DPR 数值,用于排查布局与 HiDPI。

## 3. 接话(backchannel)TTS 稳定性
- **文本清洗**:`_normalize_tts_request_text` 去前导标点、迭代脱「」/括号/引号、无可
  发音字符返回空串 → 调用点跳过合成,根治 "……"/纯标点文本触发 GPT-SoVITS 400。
- **队列门控**:接话音频预生成限额 16→2,且仅在 TTS 队列空闲
  (`_tts_provider_has_queued_work`)时预生成,避免抢占正文合成/播放。
- 变体级 portrait 校验(manifest 加载时按角色表情词表校验)。

## 测试
全量单测 612 passed(含新增 TTS 清洗、manifest 变体 portrait、pet_window 用例)。

## 部署
立绘 dpr 与宽度包络无新依赖;碰撞遮罩默认开、设置页可关。