### PR TITLE
[codex] 避免后台窗口触发输入栏

### DIFF
--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -1706,10 +1706,65 @@ class PetWindow(QWidget):
         # 设置/历史窗口打开时禁用输入栏浮现，避免盖住对话框。
         if self._any_dialog_open():
             return False
+        if not self._input_bar_foreground_allowed():
+            return False
         # 单窗口重构后气泡/输入栏已并入主窗口，主窗口几何即桌宠整体区域；
-        # 光标落在其中即视为悬停桌宠（暂停自动隐藏倒计时）。
+        # 但只有桌宠实际位于光标下方时才视为悬停，避免窗口被其他软件遮挡时误触发输入栏浮现。
         pos = QCursor.pos()
-        return self.isVisible() and self.frameGeometry().contains(pos)
+        return (
+            self.isVisible()
+            and self.frameGeometry().contains(pos)
+            and self._cursor_over_exposed_pet_window(pos)
+        )
+
+    def _cursor_over_exposed_pet_window(self, pos: QPoint) -> bool:
+        """确认当前全局坐标实际命中的 Qt 窗口属于桌宠。
+
+        单纯用 frameGeometry 会在桌宠被其他窗口遮挡时误判 hover；widgetAt/topLevelAt
+        会经过平台命中测试，被外部窗口盖住时不会返回当前桌宠窗口。
+        """
+        widget = QApplication.widgetAt(pos)
+        if widget is not None:
+            return widget is self or widget.window() is self or self.isAncestorOf(widget)
+
+        top_level_at = getattr(QApplication, "topLevelAt", None)
+        window_handle = self.windowHandle()
+        if not callable(top_level_at) or window_handle is None:
+            return False
+        try:
+            return top_level_at(pos) is window_handle
+        except Exception:
+            return False
+
+    def _input_bar_foreground_allowed(self) -> bool:
+        """非置顶模式下，只有桌宠处于前台窗口时才允许输入栏显示。"""
+        if bool(getattr(self, "always_on_top_enabled", False)):
+            return True
+        return self._is_pet_foreground_window()
+
+    def _is_pet_foreground_window(self) -> bool:
+        """判断桌宠是否为当前前台窗口，优先使用 Windows 原生前台 HWND。"""
+        if sys.platform == "win32":
+            try:
+                import ctypes
+
+                hwnd = int(self.winId())
+                if hwnd:
+                    return int(ctypes.windll.user32.GetForegroundWindow()) == hwnd
+            except Exception:
+                pass
+
+        active_window = QApplication.activeWindow()
+        if active_window is not None:
+            return (
+                active_window is self
+                or active_window.window() is self
+                or self.isAncestorOf(active_window)
+            )
+        try:
+            return bool(self.isActiveWindow())
+        except Exception:
+            return False
 
     def _input_bar_pinned(self) -> bool:
         """输入栏在以下任一情况保持常显，避免用户操作中途被收起。
@@ -1719,6 +1774,8 @@ class PetWindow(QWidget):
         """
         # 设置/历史窗口打开时不固定输入栏，配合 hover 禁用一起彻底收起。
         if self._any_dialog_open():
+            return False
+        if not self._input_bar_foreground_allowed():
             return False
         return (
             self.input_edit.hasFocus()

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -6969,6 +6969,7 @@ def test_input_bar_pinned_while_waiting_reply() -> None:
     class MinimalInputBarWindow:
         _input_bar_pinned = PetWindow._input_bar_pinned
         _any_dialog_open = lambda _self: False
+        _input_bar_foreground_allowed = lambda _self: True
 
     window = MinimalInputBarWindow()
     window.input_edit = _DummyEditableInput("")
@@ -8846,6 +8847,195 @@ def test_local_rect_to_global_keeps_size_and_uses_main_window_origin() -> None:
     assert result.size() == rect.size()
     assert result.topLeft() == host.mapToGlobal(QPoint(10, 20))
     host.deleteLater()
+
+
+def test_cursor_in_pet_region_requires_exposed_pet_window(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    qtcore = pytest.importorskip("PySide6.QtCore")
+    import app.ui.pet_window as pet_window_module
+    from app.ui.pet_window import PetWindow
+
+    class MinimalWindow:
+        _cursor_in_pet_region = PetWindow._cursor_in_pet_region
+        _cursor_over_exposed_pet_window = PetWindow._cursor_over_exposed_pet_window
+        _input_bar_foreground_allowed = PetWindow._input_bar_foreground_allowed
+        always_on_top_enabled = True
+
+        def _any_dialog_open(self) -> bool:
+            return False
+
+        def isVisible(self) -> bool:  # noqa: N802 - Qt API 兼容命名。
+            return True
+
+        def frameGeometry(self):  # type: ignore[no-untyped-def]
+            return qtcore.QRect(0, 0, 120, 80)
+
+        def windowHandle(self):  # type: ignore[no-untyped-def]
+            return object()
+
+        def isAncestorOf(self, _widget) -> bool:  # noqa: N802 - Qt API 兼容命名。
+            return False
+
+    pos = qtcore.QPoint(20, 20)
+    window = MinimalWindow()
+    monkeypatch.setattr(pet_window_module.QCursor, "pos", lambda: pos)
+    monkeypatch.setattr(pet_window_module.QApplication, "widgetAt", lambda _pos: None)
+    monkeypatch.setattr(pet_window_module.QApplication, "topLevelAt", lambda _pos: None, raising=False)
+
+    # 坐标在窗口矩形内，但光标下方实际不是桌宠时，不应触发 hover 浮现。
+    assert window._cursor_in_pet_region() is False
+
+
+def test_cursor_in_pet_region_accepts_exposed_child_widget(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    qtcore = pytest.importorskip("PySide6.QtCore")
+    import app.ui.pet_window as pet_window_module
+    from app.ui.pet_window import PetWindow
+
+    class MinimalWindow:
+        _cursor_in_pet_region = PetWindow._cursor_in_pet_region
+        _cursor_over_exposed_pet_window = PetWindow._cursor_over_exposed_pet_window
+        _input_bar_foreground_allowed = PetWindow._input_bar_foreground_allowed
+        always_on_top_enabled = True
+
+        def _any_dialog_open(self) -> bool:
+            return False
+
+        def isVisible(self) -> bool:  # noqa: N802 - Qt API 兼容命名。
+            return True
+
+        def frameGeometry(self):  # type: ignore[no-untyped-def]
+            return qtcore.QRect(0, 0, 120, 80)
+
+        def isAncestorOf(self, _widget) -> bool:  # noqa: N802 - Qt API 兼容命名。
+            return False
+
+    class ChildWidget:
+        def __init__(self, window: MinimalWindow) -> None:
+            self._window = window
+
+        def window(self) -> MinimalWindow:
+            return self._window
+
+    pos = qtcore.QPoint(20, 20)
+    window = MinimalWindow()
+    child = ChildWidget(window)
+    monkeypatch.setattr(pet_window_module.QCursor, "pos", lambda: pos)
+    monkeypatch.setattr(pet_window_module.QApplication, "widgetAt", lambda _pos: child)
+
+    assert window._cursor_in_pet_region() is True
+
+
+def test_cursor_in_pet_region_blocks_non_topmost_background_window(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    qtcore = pytest.importorskip("PySide6.QtCore")
+    import app.ui.pet_window as pet_window_module
+    from app.ui.pet_window import PetWindow
+
+    class MinimalWindow:
+        _cursor_in_pet_region = PetWindow._cursor_in_pet_region
+        _cursor_over_exposed_pet_window = PetWindow._cursor_over_exposed_pet_window
+        _input_bar_foreground_allowed = PetWindow._input_bar_foreground_allowed
+        _is_pet_foreground_window = PetWindow._is_pet_foreground_window
+        always_on_top_enabled = False
+
+        def _any_dialog_open(self) -> bool:
+            return False
+
+        def isVisible(self) -> bool:  # noqa: N802 - Qt API 兼容命名。
+            return True
+
+        def frameGeometry(self):  # type: ignore[no-untyped-def]
+            return qtcore.QRect(0, 0, 120, 80)
+
+        def isAncestorOf(self, _widget) -> bool:  # noqa: N802 - Qt API 兼容命名。
+            return False
+
+        def isActiveWindow(self) -> bool:  # noqa: N802 - Qt API 兼容命名。
+            return False
+
+    class ChildWidget:
+        def __init__(self, window: MinimalWindow) -> None:
+            self._window = window
+
+        def window(self) -> MinimalWindow:
+            return self._window
+
+    pos = qtcore.QPoint(20, 20)
+    window = MinimalWindow()
+    child = ChildWidget(window)
+    monkeypatch.setattr(pet_window_module.sys, "platform", "linux")
+    monkeypatch.setattr(pet_window_module.QCursor, "pos", lambda: pos)
+    monkeypatch.setattr(pet_window_module.QApplication, "activeWindow", lambda: None)
+    monkeypatch.setattr(pet_window_module.QApplication, "widgetAt", lambda _pos: child)
+
+    assert window._cursor_in_pet_region() is False
+
+
+def test_cursor_in_pet_region_allows_non_topmost_foreground_window(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    qtcore = pytest.importorskip("PySide6.QtCore")
+    import app.ui.pet_window as pet_window_module
+    from app.ui.pet_window import PetWindow
+
+    class MinimalWindow:
+        _cursor_in_pet_region = PetWindow._cursor_in_pet_region
+        _cursor_over_exposed_pet_window = PetWindow._cursor_over_exposed_pet_window
+        _input_bar_foreground_allowed = PetWindow._input_bar_foreground_allowed
+        _is_pet_foreground_window = PetWindow._is_pet_foreground_window
+        always_on_top_enabled = False
+
+        def _any_dialog_open(self) -> bool:
+            return False
+
+        def isVisible(self) -> bool:  # noqa: N802 - Qt API 兼容命名。
+            return True
+
+        def frameGeometry(self):  # type: ignore[no-untyped-def]
+            return qtcore.QRect(0, 0, 120, 80)
+
+        def isAncestorOf(self, _widget) -> bool:  # noqa: N802 - Qt API 兼容命名。
+            return False
+
+    class ChildWidget:
+        def __init__(self, window: MinimalWindow) -> None:
+            self._window = window
+
+        def window(self) -> MinimalWindow:
+            return self._window
+
+    pos = qtcore.QPoint(20, 20)
+    window = MinimalWindow()
+    child = ChildWidget(window)
+    monkeypatch.setattr(pet_window_module.sys, "platform", "linux")
+    monkeypatch.setattr(pet_window_module.QCursor, "pos", lambda: pos)
+    monkeypatch.setattr(pet_window_module.QApplication, "activeWindow", lambda: child)
+    monkeypatch.setattr(pet_window_module.QApplication, "widgetAt", lambda _pos: child)
+
+    assert window._cursor_in_pet_region() is True
+
+
+def test_input_bar_pinned_requires_foreground_when_not_topmost() -> None:
+    from app.ui.pet_window import PetWindow
+
+    class InputStub:
+        def hasFocus(self) -> bool:  # noqa: N802 - Qt API 兼容命名。
+            return False
+
+        def text(self) -> str:
+            return "未发送文本"
+
+    class MinimalWindow:
+        _input_bar_pinned = PetWindow._input_bar_pinned
+        _input_bar_foreground_allowed = PetWindow._input_bar_foreground_allowed
+        always_on_top_enabled = False
+        input_edit = InputStub()
+        reply_waiting_ui_active = False
+        pending_tool_action = None
+
+        def _any_dialog_open(self) -> bool:
+            return False
+
+        def _is_pet_foreground_window(self) -> bool:
+            return False
+
+    assert MinimalWindow()._input_bar_pinned() is False
 
 
 def test_input_bar_animator_visibility_follows_hover_and_pin() -> None:


### PR DESCRIPTION
## 变更内容

- 调整桌宠输入栏 hover 判定：光标坐标在窗口矩形内时，还需要确认光标下方实际命中的是桌宠窗口或其子控件。
- 非置顶模式下，仅当桌宠为前台窗口时允许输入栏浮现或保持固定。
- 补充 UI 单元测试，覆盖被遮挡窗口、前台窗口、置顶模式与输入栏 pinned 判定。

## 背景

Related to #81

该问题的根因是原先仅用主窗口 `frameGeometry()` 判断光标是否位于桌宠区域。桌宠被其他窗口遮挡时，坐标仍可能落在桌宠几何范围内，从而误触发输入栏浮现。

## 验证

- `python -m pytest tests/ui/test_pet_window.py`：203 passed，存在 4 个 pytest 配置项 warning。