### PR TITLE
fix: 修复点击桌宠误聚焦输入栏

### DIFF
--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -1200,8 +1200,19 @@ class PetWindow(QWidget):
     def close_plugins(self) -> None:
         self.plugin_manager.shutdown_all()
 
+    def _clear_input_focus_for_pet_interaction(self) -> None:
+        """点击/拖动桌宠本体时解除输入框焦点，避免输入栏被误判为常显。"""
+        input_edit = getattr(self, "input_edit", None)
+        has_focus = getattr(input_edit, "hasFocus", None)
+        if not callable(has_focus) or not has_focus():
+            return
+        clear_focus = getattr(input_edit, "clearFocus", None)
+        if callable(clear_focus):
+            clear_focus()
+
     def _handle_mouse_press(self, event: QMouseEvent, source_widget: QWidget | None = None) -> bool:
         if event.button() == Qt.MouseButton.LeftButton:
+            self._clear_input_focus_for_pet_interaction()
             self.drag_anchor = self._drag_anchor_from_event(event, source_widget)
             event.accept()
             return True

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -1009,6 +1009,60 @@ def test_pet_window_context_menu_opens_on_right_release_not_press() -> None:
     assert window.context_menu_positions == [release_event.position().toPoint()]
 
 
+def test_pet_window_left_press_clears_input_focus_without_clearing_text() -> None:
+    qtcore = pytest.importorskip("PySide6.QtCore")
+    from app.ui.pet_window import PetWindow
+
+    class MouseEventStub:
+        def __init__(self) -> None:
+            self.accepted = False
+            self._position = qtcore.QPointF(40, 60)
+
+        def button(self):  # type: ignore[no-untyped-def]
+            return qtcore.Qt.MouseButton.LeftButton
+
+        def position(self):  # type: ignore[no-untyped-def]
+            return self._position
+
+        def accept(self) -> None:
+            self.accepted = True
+
+    class InputStub:
+        def __init__(self) -> None:
+            self._text = "还没发出去的话"
+            self.focused = True
+            self.clear_focus_count = 0
+
+        def hasFocus(self) -> bool:  # noqa: N802 - Qt API 兼容命名。
+            return self.focused
+
+        def clearFocus(self) -> None:  # noqa: N802 - Qt API 兼容命名。
+            self.focused = False
+            self.clear_focus_count += 1
+
+        def text(self) -> str:
+            return self._text
+
+    class MinimalWindow:
+        _handle_mouse_press = PetWindow._handle_mouse_press
+        _drag_anchor_from_event = PetWindow._drag_anchor_from_event
+        _clear_input_focus_for_pet_interaction = PetWindow._clear_input_focus_for_pet_interaction
+
+        def __init__(self) -> None:
+            self.input_edit = InputStub()
+            self.drag_anchor = None
+
+    window = MinimalWindow()
+    press_event = MouseEventStub()
+
+    assert window._handle_mouse_press(press_event) is True
+    assert window.input_edit.clear_focus_count == 1
+    assert not window.input_edit.hasFocus()
+    assert window.input_edit.text() == "还没发出去的话"
+    assert window.drag_anchor == qtcore.QPoint(40, 60)
+    assert press_event.accepted
+
+
 def test_pet_window_drag_uses_window_local_anchor_not_frame_geometry() -> None:
     qtcore = pytest.importorskip("PySide6.QtCore")
     from app.ui.pet_window import PetWindow
@@ -1055,6 +1109,7 @@ def test_pet_window_drag_uses_window_local_anchor_not_frame_geometry() -> None:
         _handle_mouse_move = PetWindow._handle_mouse_move
         _handle_mouse_release = PetWindow._handle_mouse_release
         _drag_anchor_from_event = PetWindow._drag_anchor_from_event
+        _clear_input_focus_for_pet_interaction = PetWindow._clear_input_focus_for_pet_interaction
 
         def __init__(self) -> None:
             self.drag_anchor = None
@@ -1130,6 +1185,7 @@ def test_pet_window_drag_maps_child_widget_anchor_to_window_coordinates() -> Non
         _handle_mouse_press = PetWindow._handle_mouse_press
         _handle_mouse_move = PetWindow._handle_mouse_move
         _drag_anchor_from_event = PetWindow._drag_anchor_from_event
+        _clear_input_focus_for_pet_interaction = PetWindow._clear_input_focus_for_pet_interaction
 
         def __init__(self) -> None:
             self.drag_anchor = None


### PR DESCRIPTION
## 变更说明
- 点击或拖动桌宠本体时，主动解除输入框焦点。
- 避免 `input_edit.hasFocus()` 误触发输入栏常显，导致自动隐藏失效。
- 保持点击输入框本身的正常聚焦与输入行为不变。

## 测试验证
- `.\runtime\python.exe -m pytest tests\ui\test_pet_window.py -q`
- `.\runtime\python.exe -m pytest tests\ui\test_input_bar_animator.py tests\ui\test_pet_window.py -q`