### PR TITLE
fix(llm): 连通性检测不再硬编码 temperature，并放宽温度回退识别

### DIFF
--- a/app/llm/api_client.py
+++ b/app/llm/api_client.py
@@ -677,12 +677,39 @@ def _is_temperature_unsupported_error(exc: ApiRequestError) -> bool:
     text = str(exc).lower()
     if "temperature" not in text:
         return False
+    # 值域错误（如「temperature 必须在 0~2 之间」）属于用户填错配置，应原样抛出，
+    # 不能误判成「模型不支持自定义温度」而静默剥参、悄悄忽略用户设置。
+    range_markers = (
+        "between",
+        "range",
+        "minimum",
+        "maximum",
+        "less than",
+        "greater than",
+        "<=",
+        ">=",
+    )
+    if any(marker in text for marker in range_markers):
+        return False
+    # 不同供应商对「仅支持默认温度」的措辞各异，尽量覆盖以便自动回退。
     markers = (
         "unsupported",
         "not support",
         "does not support",
+        "only support",
         "only the default",
         "default value",
+        "only accept",
+        "not allowed",
+        "can only be",
+        "must be",
+        "cannot be changed",
+        "cannot be modified",
+        "cannot be set",
+        "is fixed",
+        "not configurable",
+        "cannot be configured",
+        "invalid",
     )
     return any(marker in text for marker in markers)
 

--- a/app/llm/api_client.py
+++ b/app/llm/api_client.py
@@ -121,6 +121,8 @@ class OpenAICompatibleClient:
         """发送一次最小聊天请求，验证 Base URL、API Key 和模型是否可用。"""
         self._ensure_chat_config("缺少 API_KEY。请在设置中填写 API Key。")
 
+        # 连通性检测只需验证 Base URL / API Key / 模型可用，不发送 temperature：
+        # 部分模型（如 o1/o3/gpt-5 等推理模型）只接受默认温度，显式传值会直接报错。
         payload = {
             "model": self.settings.model,
             "messages": [
@@ -130,7 +132,6 @@ class OpenAICompatibleClient:
                 },
             ],
             "max_tokens": 8,
-            "temperature": 0,
         }
         data = self._post_chat_completions_with_compatibility_fallbacks(payload)
 

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -11,6 +11,7 @@ from app.llm.api_client import (
     _build_segmented_reply_instruction,
     _build_chat_completion_payload,
     _filter_supported_chat_params,
+    _is_temperature_unsupported_error,
 )
 from app.llm.chat_reply import ChatReply, ChatSegment, parse_chat_reply, sanitize_reply_tones
 
@@ -156,6 +157,36 @@ def test_complete_raw_retries_without_temperature_when_provider_rejects(monkeypa
 
     assert "temperature" in calls[0]
     assert "temperature" not in calls[1]
+
+
+def test_is_temperature_unsupported_error_matches_varied_provider_wordings() -> None:
+    # 各家供应商对「仅支持默认温度」的措辞不一，都应触发自动回退。
+    recoverable = [
+        "Unsupported value: 'temperature' does not support 0.8 with this model."
+        " Only the default (1) value is supported.",
+        "temperature only supports the default value",
+        "temperature is not supported with this model",
+        "temperature must be 1 for this model",
+        "temperature can only be set to the default",
+        "this model only accepts the default temperature",
+        "temperature cannot be modified for reasoning models",
+        "Invalid value for 'temperature'.",
+    ]
+    for message in recoverable:
+        assert _is_temperature_unsupported_error(ApiRequestError(message)), message
+
+
+def test_is_temperature_unsupported_error_ignores_value_range_and_unrelated_errors() -> None:
+    # 值域错误是用户配置问题，应原样抛出；与温度无关的错误更不该误判。
+    non_recoverable = [
+        "temperature must be between 0 and 2",
+        "temperature should be in the range [0, 2]",
+        "temperature must be less than or equal to 2",
+        "invalid api key",
+        "model not found",
+    ]
+    for message in non_recoverable:
+        assert not _is_temperature_unsupported_error(ApiRequestError(message)), message
 
 
 def test_complete_raw_remembers_temperature_unsupported(monkeypatch) -> None:  # type: ignore[no-untyped-def]

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -586,6 +586,38 @@ def test_chat_completions_normalizes_google_ai_studio_base_url(monkeypatch) -> N
     assert captured["url"] == "https://generativelanguage.googleapis.com/v1/openai/chat/completions"
 
 
+def test_connection_omits_temperature(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    import json
+
+    captured: dict[str, Any] = {}
+    client = OpenAICompatibleClient(
+        ApiSettings(base_url="https://api.example.com/v1", api_key="key", model="o3")
+    )
+
+    class FakeResponse:
+        status = 200
+
+        def __enter__(self):  # type: ignore[no-untyped-def]
+            return self
+
+        def __exit__(self, *_args):  # type: ignore[no-untyped-def]
+            return None
+
+        def read(self) -> bytes:
+            return b'{"choices":[{"message":{"content":"OK"}}]}'
+
+    def fake_urlopen(request, timeout):  # type: ignore[no-untyped-def]
+        _ = timeout
+        captured["payload"] = json.loads(request.data.decode("utf-8"))
+        return FakeResponse()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    # 只接受默认温度的模型在检测阶段不应被显式 temperature 拒绝。
+    assert client.test_connection() == "OK"
+    assert "temperature" not in captured["payload"]
+
+
 def test_list_models_allows_empty_model_but_requires_key() -> None:
     client = OpenAICompatibleClient(ApiSettings("https://api.example.com/v1", "", ""))
 


### PR DESCRIPTION
## 背景

API 连通性检测 `OpenAICompatibleClient.test_connection()` 此前固定发送 `temperature=0`。只接受默认温度的模型（o1/o3/gpt-5 等推理模型）会在**检测阶段直接报错**，导致这些模型无法通过设置里的连接测试。

## 改动

**1. 连通性检测移除硬编码 temperature（`app/llm/api_client.py`）**
连通性检测只需验证 Base URL / API Key / 模型可用，不需要确定性，故不再发送 `temperature`，从根上消除这类失败面。

**2. 放宽 `_is_temperature_unsupported_error` 的识别，扩大对话路径的自动回退**
对话路径（`chat()` / `complete_raw()` / `complete_with_tools()`）走 `_post_chat_completions_with_compatibility_fallbacks`，模型一旦因温度报错会自动剥掉 `temperature` 重试并缓存。但此前识别词偏窄，部分供应商措辞（`must be 1` / `can only be` / `invalid value` / `cannot be modified` 等）认不出，导致兜底没触发而直接报错。本次补全常见措辞。

同时加了**值域错误负向守卫**（`between` / `range` / `<=` / `>=` 等）：这类属于用户填错温度值，应原样抛出，避免被误判成「模型不支持自定义温度」而静默吞掉用户配置。

## 测试

- 新增 `test_connection_omits_temperature`：断言检测请求体不含 `temperature`。
- 新增 `test_is_temperature_unsupported_error_matches_varied_provider_wordings` 与 `test_is_temperature_unsupported_error_ignores_value_range_and_unrelated_errors`：覆盖各家措辞与值域/无关错误的边界。
- `tests/unit/test_api_client.py` 全部 36 项通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)