### PR TITLE
feat: 支持跨会话近期上下文续接

### DIFF
--- a/app/agent/context_orchestrator.py
+++ b/app/agent/context_orchestrator.py
@@ -34,9 +34,10 @@ class ContextOrchestrator:
         request: ContextRequest,
         *,
         providers: Sequence[ContextProviderContribution] = (),
+        session_fragments: Iterable[ContextFragment] = (),
         memory_fragments: Iterable[ContextFragment] = (),
     ) -> ContextSnapshot:
-        fragments = [*_builtin_fragments(request), *memory_fragments]
+        fragments = [*_builtin_fragments(request), *session_fragments, *memory_fragments]
         fragments.extend(_collect_provider_fragments(request, providers))
         return self.policy.select(request, fragments)
 

--- a/app/agent/runtime.py
+++ b/app/agent/runtime.py
@@ -19,6 +19,10 @@ from app.agent.screen_tools import (
     SCREEN_OBSERVATION_REQUEST_ACTION,
 )
 from app.agent.screen_policy import ScreenPolicy
+from app.agent.session_state_context import (
+    SESSION_DIGEST_INJECT_MAX_RECENT_MESSAGES,
+    build_session_state_fragment,
+)
 from app.agent.tool_policy import (
     BROWSER_NAVIGATE_TOOL_NAME,
     BROWSER_SNAPSHOT_TOOL_NAME,
@@ -29,6 +33,7 @@ from app.agent.tool_policy import (
 )
 import app.agent.tool_routing as tool_routing
 from app.agent.tools import ToolExecutionResult, ToolRegistry
+from app.storage.chat_history import ChatHistoryStore
 from app.llm.api_client import (
     ApiRequestError,
     ChatMessage,
@@ -60,6 +65,8 @@ from app.plugins.models import ContextProviderContribution, PromptPatchContribut
 
 from app.llm.prompts.runtime import PromptRuntime
 from app.llm.prompts.types import (
+    ContextFragment,
+    ContextRequest,
     ContextSnapshot,
     PromptInspection,
     PromptRecipe,
@@ -78,6 +85,7 @@ class AgentRuntime:
         reply_portraits: list[str] | None = None,
         tools: ToolRegistry | None = None,
         memory: MemoryStore | None = None,
+        history_store: ChatHistoryStore | None = None,
         prompt_patches: list[PromptPatchContribution] | None = None,
         context_providers: list[ContextProviderContribution] | None = None,
         runtime_loop_settings: RuntimeLoopSettings | None = None,
@@ -88,6 +96,7 @@ class AgentRuntime:
         self.reply_portraits = [*reply_portraits] if reply_portraits is not None else []
         self.tools = tools or ToolRegistry()
         self.memory = memory or MemoryStore()
+        self.history_store = history_store
         self.prompt_patches = [*prompt_patches] if prompt_patches is not None else []
         self.context_providers = (
             [*context_providers] if context_providers is not None else []
@@ -124,6 +133,37 @@ class AgentRuntime:
         self.context_providers = (
             [*context_providers] if context_providers is not None else []
         )
+
+    def set_history_store(
+        self,
+        history_store: ChatHistoryStore | None,
+    ) -> None:
+        """同步当前角色的聊天历史存储（跨会话续接的数据来源）。"""
+        self.history_store = history_store
+
+    def _session_state_fragments(
+        self,
+        request: ContextRequest,
+    ) -> tuple[ContextFragment, ...]:
+        store = self.history_store
+        if store is None:
+            return ()
+        # 仅在会话刚开始（实时窗口尚浅）时才回看历史，避免每轮全量读盘与重复注入。
+        if len(request.recent_messages) >= SESSION_DIGEST_INJECT_MAX_RECENT_MESSAGES:
+            return ()
+        try:
+            entries = store.load()
+            fragment = build_session_state_fragment(
+                entries,
+                recent_message_count=len(request.recent_messages),
+                freshness=entries[-1].created_at if entries else "",
+                current_input=request.current_input,
+            )
+        except Exception as exc:  # noqa: BLE001
+            debug_log("SessionState", "最近会话状态读取失败，已跳过", {"error": str(exc)})
+            return ()
+        return (fragment,) if fragment is not None else ()
+
     def get_last_prompt_inspection(self) -> dict[str, Any] | None:
         """返回最近一次 Prompt 构建的脱敏检查结果。"""
 
@@ -175,6 +215,7 @@ class AgentRuntime:
         return self.context_orchestrator.build_snapshot(
             request,
             providers=self.context_providers,
+            session_fragments=self._session_state_fragments(request),
             memory_fragments=recall.fragments,
         )
 
@@ -379,6 +420,7 @@ class AgentRuntime:
                 snapshot = self.context_orchestrator.build_snapshot(
                     request,
                     providers=self.context_providers,
+                    session_fragments=self._session_state_fragments(request),
                     memory_fragments=turn_memory_fragments,
                 )
                 prompt_build = (

--- a/app/agent/session_state_context.py
+++ b/app/agent/session_state_context.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+from app.llm.prompts.runtime import estimate_prompt_tokens
+from app.llm.prompts.types import ContextFragment
+from app.storage.chat_history import ChatHistoryEntry
+from app.storage.history_digest import DigestLine, clean_recent_dialogue
+
+
+# 当前会话窗口已经有这么多条最近消息时，不再注入跨会话历史切片：
+# 此时上次会话的尾巴已被本次实时对话覆盖，再注入只是重复 token。
+SESSION_DIGEST_INJECT_MAX_RECENT_MESSAGES = 2
+SESSION_STATE_TOKEN_BUDGET = 1024
+
+_INTRO = "最近会话状态（历史事实，不是用户新消息；请自然参考，不要机械复述）："
+
+
+def build_session_state_fragment(
+    entries: Sequence[ChatHistoryEntry],
+    *,
+    recent_message_count: int = 0,
+    freshness: str = "",
+    current_input: str = "",
+) -> ContextFragment | None:
+    """把上次会话尾部清洗后的对话渲染成跨会话续接上下文。
+
+    仅在会话刚开始（实时窗口尚浅）时注入；内容直接来自持久化的聊天历史，
+    读取时现算，对突然关闭天然免疫。
+    """
+
+    if recent_message_count >= SESSION_DIGEST_INJECT_MAX_RECENT_MESSAGES:
+        return None
+    lines = clean_recent_dialogue(entries, current_input=current_input)
+    if not lines:
+        return None
+    body = [_INTRO, "最近对话："]
+    rendered_lines = [_render_line(line) for line in lines]
+    while estimate_prompt_tokens("\n".join([*body, *rendered_lines])) > SESSION_STATE_TOKEN_BUDGET:
+        rendered_lines.pop(0)
+    body.extend(rendered_lines)
+    return ContextFragment(
+        fragment_id="session_state.recent_history",
+        source="session_state",
+        content="\n".join(body),
+        trust="untrusted",
+        priority=75,
+        freshness=freshness,
+        token_budget=SESSION_STATE_TOKEN_BUDGET,
+        sensitivity="private",
+        cache_scope="turn",
+    )
+
+
+def _render_line(line: DigestLine) -> str:
+    speaker = "用户" if line.role == "user" else "Sakura"
+    return f"- {speaker}：{line.content}"

--- a/app/core/bootstrap.py
+++ b/app/core/bootstrap.py
@@ -141,6 +141,7 @@ def build_initial_app_context(base_dir: Path, startup_state: StartupState | None
     plugin_manager = PluginManager(base_dir=base_dir, resource_registry=resource_registry)
     mcp_settings = settings_service.load_mcp_runtime_settings()
     runtime_loop_settings = settings_service.load_runtime_loop_settings()
+    history_store = create_history_store(base_dir, character_profile)
     agent_runtime = AgentRuntime(
         api_client=api_client,
         system_prompt=system_prompt,
@@ -148,9 +149,9 @@ def build_initial_app_context(base_dir: Path, startup_state: StartupState | None
         reply_portraits=character_profile.portrait_choices,
         tools=tool_registry,
         memory=memory_store,
+        history_store=history_store,
         runtime_loop_settings=runtime_loop_settings,
     )
-    history_store = create_history_store(base_dir, character_profile)
     runtime_event_log = create_runtime_event_log(base_dir, character_profile)
     visual_observation_store = create_visual_observation_store(base_dir, character_profile)
     debug_log_settings = settings_service.load_debug_log_settings()

--- a/app/storage/history_digest.py
+++ b/app/storage/history_digest.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Sequence
+
+from app.storage.chat_history import ChatHistoryEntry
+
+
+# 注入跨会话上下文时，最多回看多少条最近对话。
+MAX_DIGEST_MESSAGES = 12
+MAX_DIGEST_TEXT_CHARS = 220
+
+
+_VISUAL_MARKER_RE = re.compile(
+    r"\[Sakura 已(?:附加手动框选截图|自主观察屏幕)(?:，视觉记录\s+visual_id=[^\]\s]+)?\]"
+)
+_VISUAL_ID_SUFFIX_RE = re.compile(r"，视觉记录\s+visual_id=[^\]\s]+")
+_PUNCT_RE = re.compile(r"[\s，。！？!?、,.~～…]+")
+_LOW_SIGNAL_USER_TEXTS = {
+    "hi",
+    "hello",
+    "ok",
+    "嗯",
+    "哦",
+    "好",
+    "好的",
+    "可以",
+    "收到",
+    "明白",
+    "谢谢",
+    "感谢",
+    "你好",
+    "晚上好",
+    "早上好",
+    "下午好",
+    "是的",
+    "对",
+}
+_PROCESS_ASSISTANT_PATTERNS = (
+    "正在确认",
+    "我继续推进",
+    "稍等",
+    "处理中",
+    "我先看一下",
+    "开始确认",
+)
+
+
+@dataclass(frozen=True)
+class DigestLine:
+    role: str
+    content: str
+
+
+def clean_recent_dialogue(
+    entries: Sequence[ChatHistoryEntry],
+    *,
+    limit: int = MAX_DIGEST_MESSAGES,
+    current_input: str = "",
+) -> list[DigestLine]:
+    """从聊天历史尾部提取一段清洗后的最近对话，用于跨会话续接。
+
+    只保留 user/assistant 文本，去掉视觉标记等下次会话解析不了的脏数据，
+    并丢弃无信息量的应答与纯过程性回复。结果是尽力而为的上下文提示，不要求精确。
+    """
+
+    lines: list[DigestLine] = []
+    for index, entry in enumerate(entries):
+        role = str(entry.role).strip()
+        if role not in {"user", "assistant"}:
+            continue
+        if (
+            current_input
+            and index == len(entries) - 1
+            and role == "user"
+            and _truncate(entry.content) == _truncate(current_input)
+        ):
+            continue
+        raw = entry.content
+        if role == "assistant" and entry.translation.strip():
+            raw = entry.translation
+        content = _truncate(raw)
+        if not content:
+            continue
+        if role == "user" and _is_low_signal_user_text(content):
+            continue
+        if role == "assistant" and _is_process_assistant_text(content):
+            continue
+        lines.append(DigestLine(role=role, content=content))
+    if not lines:
+        return []
+    return lines[-max(1, limit):]
+
+
+def _is_low_signal_user_text(text: str) -> bool:
+    normalized = _PUNCT_RE.sub("", text).strip().lower()
+    if not normalized:
+        return True
+    if normalized in _LOW_SIGNAL_USER_TEXTS:
+        return True
+    return len(normalized) <= 1
+
+
+def _is_process_assistant_text(text: str) -> bool:
+    return any(pattern in text for pattern in _PROCESS_ASSISTANT_PATTERNS)
+
+
+def _strip_visual_markers(text: str) -> str:
+    text = _VISUAL_MARKER_RE.sub(" ", text)
+    return _VISUAL_ID_SUFFIX_RE.sub(" ", text)
+
+
+def _normalize_text(text: str) -> str:
+    return " ".join(_strip_visual_markers(text).split())
+
+
+def _truncate(text: str, limit: int = MAX_DIGEST_TEXT_CHARS) -> str:
+    text = _normalize_text(text)
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 1)].rstrip() + "…"

--- a/app/ui/input_bar_animator.py
+++ b/app/ui/input_bar_animator.py
@@ -98,7 +98,7 @@ class InputBarAnimator(QObject):
 
     def sync(self) -> None:
         """外部 pinned 状态（如待确认动作出现）变化时，立即重算可见性。"""
-        self._sync()
+        self._sync(refresh_hover=True)
 
     def set_force_visible(self, value: bool) -> None:
         """外部强制常显开关：开启立即现身，关闭后按常规可见性重算。"""
@@ -107,7 +107,7 @@ class InputBarAnimator(QObject):
             return
         self._force_visible = value
         if self._started and not self._suspended:
-            self._sync()
+            self._sync(refresh_hover=True)
 
     def set_force_hidden(self, value: bool) -> None:
         """外部强制隐藏开关：开启后忽略 hover、焦点和 pinned，关闭后恢复常规显隐。"""
@@ -116,7 +116,7 @@ class InputBarAnimator(QObject):
             return
         self._force_hidden = value
         if self._started and not self._suspended:
-            self._sync()
+            self._sync(refresh_hover=True)
 
     def set_polling_enabled(self, enabled: bool) -> None:
         """临时停/起 hover 轮询（如副窗口打开期间），减少后台无谓的命中测试与重绘。
@@ -162,17 +162,22 @@ class InputBarAnimator(QObject):
 
     # --- 内部逻辑 -----------------------------------------------------------
     def _on_poll(self) -> None:
-        self._hover = bool(self._is_hover_active())
+        self._refresh_hover()
         self._sync()
+
+    def _refresh_hover(self) -> None:
+        self._hover = bool(self._is_hover_active())
 
     def _target_visible(self) -> bool:
         if self._force_hidden:
             return False
         return self._force_visible or self._hover or bool(self._is_pinned())
 
-    def _sync(self) -> None:
+    def _sync(self, *, refresh_hover: bool = False) -> None:
         if self._suspended:
             return
+        if refresh_hover:
+            self._refresh_hover()
         target = self._target_visible()
         if target == self._shown:
             return

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -6217,6 +6217,9 @@ class PetWindow(QWidget):
             self.tray_icon.setIcon(_build_status_tray_icon(self.theme_settings.primary_color))
 
         self.history_store = self._create_history_store(profile)
+        set_history_store = getattr(self.agent_runtime, "set_history_store", None)
+        if callable(set_history_store):
+            set_history_store(self.history_store)
         self.runtime_event_log = self._create_runtime_event_log(profile)
         self.pet_hidden_at = None
         self.visual_observation_store = self._create_visual_observation_store(profile)

--- a/docs/context-token-budget.md
+++ b/docs/context-token-budget.md
@@ -1,0 +1,229 @@
+# 上下文构成现状分析 & Token 预算设计
+
+> 目的：盘清「一轮请求里到底有哪些东西、各占多少」，并给出按 token（而非字符）统一预算的设计，
+> 作为后续「显示预计 token」功能的参考底稿。
+>
+> 状态：设计/参考文档，非已落地实现。日期：2026-06-20。
+
+---
+
+## 1. 现状：一轮请求里到底发了什么
+
+发给模型的 prompt 由 5 块拼成，但**当前只有一部分被纳入了"预算"统计**。
+
+```
+最终 HTTP body.messages（日志实测，N.A.V.I. 角色，新会话首轮）:
+  index 0  system  人格/recipe 静态段            ~4265 chars   ← 静态(可缓存)
+  index 1  system  运行时系统事件(app.started 等)  ~319 chars    ← 动态(临时注入)
+  index 2  user    用户本轮输入                                  ← 动态
+  index 3  system  runtime_context               ~1805 chars   ← 动态(末尾追加)
+           （= 时间 + agent 步数 + 记忆召回 + session_state digest）
+  ＋ tools: 20+ 个工具定义的 JSON（日志实测请求体 ~23KB）        ← 基本静态
+  ＋ 可能的图片(视觉上下文)                                      ← 动态、单独成本模型
+```
+
+### 1.1 数据怎么流进来的（会话内）
+
+```
+self.messages（内存,append-only,只存"干净文本"）
+   ├─ user 文本           app/ui/pet_window.py:3253(约)
+   └─ assistant reply.text app/ui/pet_window.py:3290(约)   ← 工具调用轮次不进这里
+        │
+   发送前（pet_window 发送路径 ~3124-3137）:
+   [*self.messages, 新user]
+     → _add_visual_context_to_messages   （临时，不写回 self.messages）
+     → _add_runtime_event_context_to_messages（临时）
+     → trim_messages_for_model            （裁剪）
+        │
+   api_client 再把 runtime_context 作为最后一条 system 追加
+     app/llm/api_client.py:693  _messages_with_runtime_context  → [*messages, {role, content}]
+```
+
+两个要点：
+- **工具调用/结果不进 `self.messages`**：它们只活在 runtime 内部的 `working_messages`，一轮只留下最终 `reply.text`。
+  好处是对话窗口干净；代价是第 N 轮模型看不到第 1 轮工具返回了什么（除非被写进回复文本或长期记忆）。
+- **持久层 `chat_history.jsonl` 是 append-only JSONL**（`app/storage/chat_history.py:33`），
+  与 Claude Code 的 transcript 模型同源。会话窗口（`self.messages`）每次启动为空，跨会话靠
+  记忆召回 + `session_state` digest 续接（见 `app/agent/session_state_context.py`）。
+
+### 1.2 静态 / 动态分层（与缓存相关）
+
+`PromptRuntime.build`（`app/llm/prompts/runtime.py:196`）把 prompt 拆成两条独立产物：
+- `system_prompt`：只来自 `recipe.blocks`（人格、tools.rules 等），段落带 `cache_scope="static"` + `static_hash`。
+- `runtime_context`：只来自 `ContextSnapshot`（动态片段），追加在消息末尾。
+
+对预算/显示功能的意义：**静态块的 token 可以只算一次并缓存**，每轮真正变化的只有
+对话消息 + runtime_context（+ 偶发图片）。
+
+---
+
+## 2. 现状：裁剪与预算的局限
+
+当前裁剪在 `app/llm/context_trimming.py:10`：
+
+```python
+MAX_MODEL_CONTEXT_MESSAGES = 24
+MAX_MODEL_CONTEXT_CHARS = 40_000
+
+def trim_messages_for_model(messages):
+    recent = messages[-MAX_MODEL_CONTEXT_MESSAGES:]
+    while len(recent) > 1 and _estimate_messages_chars(recent) > MAX_MODEL_CONTEXT_CHARS:
+        recent.pop(0)          # 纯 FIFO 砍头
+    return recent
+```
+
+三个局限：
+1. **按字符不按 token**：CJK ≈ 1 token/字，ASCII ≈ 4 字/token，字符数与真实 token 偏差大且不稳定。
+2. **只统计了对话消息**：system 人格(~4k)、工具定义(~23KB)、runtime_context(~1.8k) 都没算进这 40k 闸门，
+   真实占用远大于"40k 字符"给人的印象。
+3. **没有总窗口概念、没有 headroom、没有溢出兜底**：单条超大消息（大段 OCR/粘贴）仍可能把请求冲到模型上限 → API 报错。
+
+> 注：会话内的"硬遗忘"（FIFO 砍掉的旧消息）一部分被 `memory_curation`（每 3 轮全量读历史并固化要点）
+> 通过记忆召回补回，所以**不建议**为会话内溢出再上一套 LLM 摘要——长期记忆系统已覆盖大半。
+
+---
+
+## 3. 已有可复用资产（不要重造）
+
+| 资产 | 位置 | 作用 |
+|---|---|---|
+| `estimate_prompt_tokens(text)` | `app/llm/prompts/runtime.py:71` | 保守估 token：非 ASCII 每字符 1，连续 ASCII 约 4 字符 1 token |
+| `truncate_to_token_budget(text, budget)` | `app/llm/prompts/runtime.py:89` | 按 token 预算截断文本，返回 (文本, 是否被截断) |
+| `ContextPolicy` 预算 | `app/llm/prompts/runtime.py:23-26,119` | runtime_context 已按 token 预算选择片段（total 4096 / plugin 2048 / memory 1024） |
+| `PromptInspection.estimated_tokens` | `app/llm/prompts/types.py:129-142` | **已逐段 + 汇总**了 system_prompt 与 runtime_context 的估算 token（日志里被 redacted，但值已算出） |
+| `get_last_prompt_inspection()` | `app/agent/runtime.py:151` | 取最近一次 prompt 构建的脱敏检查（含 estimated_tokens） |
+
+**缺口**：`PromptInspection` 只覆盖 system_prompt + runtime_context，**没算**对话消息和工具定义；
+`api_client` **没有解析响应里的 `usage`**（无真实 token 对账，目前只能估）。
+
+---
+
+## 4. Token 预算设计思路
+
+### 4.1 真实 prompt 的 token 构成（要全量统计）
+
+```
+total_prompt_tokens ≈
+    T(system_prompt)          # 已在 PromptInspection 里
+  + T(tools_json)             # 缺：把工具定义序列化后估算
+  + T(conversation_messages)  # 缺：对 trim 后的 request_messages 估算
+  + T(runtime_context)        # 已在 PromptInspection 里
+  + Σ image_cost              # 缺：每图按固定/按尺寸的成本模型估
+```
+
+建议抽象一个统一记账结构（设计草图，非最终实现）：
+
+```python
+@dataclass(frozen=True)
+class PromptTokenEstimate:
+    system_prompt: int       # 静态，可缓存只算一次
+    tools: int               # 基本静态，工具集变化时才重算
+    messages: int            # 动态
+    runtime_context: int     # 动态
+    images: int              # 动态
+    @property
+    def total(self) -> int: ...
+    # 相对窗口
+    context_window: int      # 按模型查
+    reserved_output: int     # 给输出预留的 headroom
+    @property
+    def effective_window(self) -> int:   # = context_window - reserved_output
+        ...
+    @property
+    def usage_ratio(self) -> float:      # total / effective_window
+        ...
+```
+
+### 4.2 模型窗口 + 预留 headroom（借鉴 Claude Code）
+
+当前 Sakura 没有"模型上下文窗口"的配置（`api_client` 只有 model 名 + timeout）。需要补一个
+`model → context_window` 查表（带默认值），并预留输出空间：
+
+```
+effective_window = context_window(model) - reserved_for_output
+```
+
+参考量级（Claude Code，`claude-code-analysis/analysis/04f-context-management.md`）：
+- 默认窗口 200k；带 `[1m]` 的模型用百万级。
+- 预留 `MAX_OUTPUT_TOKENS_FOR_SUMMARY = 20_000`（给压缩/输出留头）。
+- 触发缩减的缓冲 `AUTOCOMPACT_BUFFER_TOKENS = 13_000`。
+
+Sakura 用的 `gemini-3.5-flash` 窗口很大，**日常聊天几乎压不满**，所以 headroom/缩减阈值取保守值即可，
+重点是"有这个概念"而不是精调。
+
+### 4.3 预算化裁剪（替换/补充现有 char 裁剪）
+
+把 `trim_messages_for_model` 从"按字符"升级为"按 token，且对账整体预算"：
+
+```
+budget_for_messages = effective_window
+                      - T(system_prompt) - T(tools) - T(runtime_context)
+                      - safety_margin
+# 然后对 request_messages 做 FIFO，直到 T(messages) <= budget_for_messages
+# 仍保留至少 1 条；可保留最新 user 消息优先级最高
+```
+
+### 4.4 溢出兜底（最小版，不必抄整套熔断）
+
+- 单条消息硬上限：超长则用 `truncate_to_token_budget` 截断（已有函数）。
+- 一次降级重试：整体仍超限时，砍掉最旧一批后重试一次；再失败才报错给用户。
+- 不需要 Claude Code 的连续失败熔断器 / PTL 剥洋葱那种重机械（那是为编码 Agent 的极端大输入设计的）。
+
+---
+
+## 5. 「显示预计 token」功能落地参考
+
+### 5.1 单一计算点
+所有组成在**构建请求、调用 `api_client` 之前**那一刻全部已知（system_prompt、tools、trim 后的
+request_messages、runtime_context）。在这里算一份 `PromptTokenEstimate` 是最干净的：
+- runtime 侧：`AgentRuntime` 构建 snapshot/prompt 处（已有 `PromptInspection`，扩展它即可）。
+- 或 UI 侧：`pet_window` 发送前（它持有 `self.messages`，能在"发送前/输入时"先估）。
+
+### 5.2 利用静态/动态分层做增量更新
+- `system_prompt`、`tools` 基本不变 → **算一次缓存**，角色切换 / 工具集变化时才失效重算。
+- 用户**正在输入**时的"预计 token" = 缓存的(system+tools) + 当前 self.messages + 草稿输入 + 预计 runtime_context。
+  这样可以做到随输入实时更新而几乎零成本。
+
+### 5.3 估算 vs 真实（建议补 usage 对账）
+- 现在只有估算。若想显示"真实用量"，在 `api_client` 解析响应的 `usage`
+  （`prompt_tokens` / `completion_tokens` / 可能的 `cached_tokens`）即可拿到 ground truth，
+  可用于：① 显示真实值；② 反过来校准 `estimate_prompt_tokens` 的系数（CJK/ASCII 比例、工具 JSON 膨胀、每图成本）。
+- 注意 provider 差异：`usage` 字段名/是否返回 cached_tokens 因服务商而异，做容错。
+
+### 5.4 UI 展示建议
+- 主数字：`total / effective_window`（如 `3.2k / 1M`，或百分比环）。
+- 分块明细（可折叠）：人格 / 工具 / 对话 / 动态上下文（记忆+session_state）/ 图片 —— 数据正好对应 §4.1 五块。
+- 接近 headroom 时变色提示。
+- 若已接 usage：并排显示"预计 vs 实际"，顺带体现缓存命中（cached_tokens）带来的省量。
+
+---
+
+## 6. 估算精度与校准要点
+- **CJK vs ASCII**：`estimate_prompt_tokens` 已分别处理；中文为主时偏保守（略高估），可接受。
+- **工具定义**：JSON 结构（括号、键名、type 字段）token 密度和自然语言不同，建议单独用 usage 校准一个膨胀系数。
+- **图片**：视觉上下文按图片 token 成本模型估（多数 provider 按分辨率/patch 计），先用一个保守常数占位。
+- **runtime_context**：已被 `ContextPolicy` 按 token 预算裁过，估算与实际较接近。
+
+---
+
+## 7. 关键文件索引
+- 裁剪：`app/llm/context_trimming.py:10`
+- token 估算/截断：`app/llm/prompts/runtime.py:71`（estimate）、`:89`（truncate）
+- runtime_context 预算与选择：`app/llm/prompts/runtime.py:23-26,119`（ContextPolicy）
+- prompt 构建（静态/动态分层 + inspection）：`app/llm/prompts/runtime.py:196`
+- 检查结构（含 estimated_tokens）：`app/llm/prompts/types.py:114-142`
+- 取最近一次检查：`app/agent/runtime.py:151`
+- runtime_context 追加进消息：`app/llm/api_client.py:693`
+- 发送路径（视觉/事件注入 + 裁剪）：`app/ui/pet_window.py:3124-3137`
+- 持久化 transcript：`app/storage/chat_history.py:33`
+- 跨会话注入片段：`app/agent/session_state_context.py`
+
+## 8. 借鉴 / 不借鉴 Claude Code
+（参考 `claude-code-analysis/analysis/04f-context-management.md`、`04i-session-storage-resume.md`）
+
+**借鉴（便宜高价值）**：按 token 的整体预算、模型窗口 + 预留 headroom、溢出一次性降级、append-only transcript（已是）。
+
+**不借鉴（对桌宠过度工程）**：auto-compact 全套（含连续失败熔断、PTL 剥洋葱、压缩后状态重注入）、
+`/resume` 恢复流水线（JSONL→图重建→snip/parallel-tool-result 修复→运行时接管）、sidechain / remote ingress。
+原因：桌宠故意每次空窗口启动，靠长期记忆 + session_state digest 续接；没有 subagent/跨进程协作；
+所用模型窗口很大，日常聊天压不满。

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -10937,6 +10937,38 @@ def test_input_bar_animator_visibility_follows_hover_and_pin() -> None:
     card.deleteLater()
 
 
+def test_input_bar_animator_force_visible_release_refreshes_hover() -> None:
+    _qt_app_or_skip()
+    from PySide6.QtWidgets import QGraphicsOpacityEffect, QWidget
+    from app.ui.input_bar_animator import InputBarAnimator
+
+    bar = QWidget()
+    card = QWidget()
+    effect = QGraphicsOpacityEffect(card)
+    hover = {"value": True}
+    animator = InputBarAnimator(
+        bar,
+        card,
+        effect,
+        lambda: False,
+        lambda: hover["value"],
+    )
+
+    animator._started = True
+    animator._hover = False
+    animator._shown = False
+
+    animator.set_force_visible(True)
+    assert animator._shown is True
+
+    # 释放强制显示时刷新真实 hover，避免旧缓存把刚唤出的输入栏立刻收回。
+    animator.set_force_visible(False)
+    assert animator._shown is True
+
+    bar.deleteLater()
+    card.deleteLater()
+
+
 def test_input_bar_animator_send_feedback_starts_animation() -> None:
     _qt_app_or_skip()
     from PySide6.QtWidgets import QGraphicsOpacityEffect, QWidget

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -40,6 +40,7 @@ from app.agent.runtime_limits import (
 from app.agent.tools import Tool, ToolRegistry
 from app.llm.api_client import ApiRequestError, ChatMessage, NativeToolCall, OpenAICompatibleClient
 from app.llm.chat_reply import ChatReply, ChatSegment
+from app.storage.chat_history import ChatHistoryEntry
 
 
 def _dummy_system_prompt() -> str:
@@ -74,6 +75,14 @@ def _dummy_api_client() -> MagicMock:
     # 角色对话入口会读取生成参数；返回内置默认温度与空额外参数，保持原有调用行为。
     client.resolve_dialogue_params.return_value = (0.8, {})
     return client
+
+
+class _FakeHistoryStore:
+    def __init__(self, entries: list[ChatHistoryEntry]) -> None:
+        self.entries = entries
+
+    def load(self) -> list[ChatHistoryEntry]:
+        return self.entries
 
 
 class TestRuntimeLimits:
@@ -116,6 +125,70 @@ class TestRuntimeLimits:
         prompt = runtime._build_tool_system_prompt()
 
         assert "每步最多请求 4 个工具，整轮最多 12 个工具" in prompt
+
+    def test_session_state_is_rendered_into_runtime_context(self) -> None:
+        client = _dummy_api_client()
+        runtime = AgentRuntime(
+            client,
+            _dummy_system_prompt(),
+            history_store=_FakeHistoryStore(
+                [
+                    ChatHistoryEntry(
+                        created_at="2026-06-20T12:00:00+08:00",
+                        role="user",
+                        content="帮我继续执行计划",
+                    ),
+                    ChatHistoryEntry(
+                        created_at="2026-06-20T12:00:05+08:00",
+                        role="assistant",
+                        content="好的，已经记下计划的下一步。",
+                    ),
+                    ChatHistoryEntry(
+                        created_at="2026-06-20T12:00:10+08:00",
+                        role="user",
+                        content="本轮问题",
+                    ),
+                ]
+            ),
+        )
+
+        runtime.handle_user_message([ChatMessage(role="user", content="本轮问题")])
+
+        call = client.complete_with_tools.call_args
+        runtime_context = call.kwargs["runtime_context"]
+        request_messages = call.args[1]
+        assert "最近会话状态" in runtime_context
+        assert "继续执行计划" in runtime_context
+        assert "用户：本轮问题" not in runtime_context
+        assert all("最近会话状态" not in str(message.get("content", "")) for message in request_messages)
+
+    def test_session_state_skipped_when_live_window_is_deep(self) -> None:
+        client = _dummy_api_client()
+        runtime = AgentRuntime(
+            client,
+            _dummy_system_prompt(),
+            history_store=_FakeHistoryStore(
+                [
+                    ChatHistoryEntry(
+                        created_at="2026-06-20T12:00:00+08:00",
+                        role="user",
+                        content="帮我继续执行计划",
+                    ),
+                ]
+            ),
+        )
+
+        # 实时窗口已经够深时不再注入跨会话历史切片，避免重复 token。
+        runtime.handle_user_message(
+            [
+                ChatMessage(role="user", content="第一句"),
+                ChatMessage(role="assistant", content="第一句回复"),
+                ChatMessage(role="user", content="继续"),
+            ]
+        )
+
+        runtime_context = client.complete_with_tools.call_args.kwargs["runtime_context"]
+        assert "最近会话状态" not in runtime_context
 
 
 class TestToolCallCountLimits:

--- a/tests/unit/test_history_digest.py
+++ b/tests/unit/test_history_digest.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from app.agent.session_state_context import (
+    SESSION_DIGEST_INJECT_MAX_RECENT_MESSAGES,
+    SESSION_STATE_TOKEN_BUDGET,
+    build_session_state_fragment,
+)
+from app.storage.chat_history import ChatHistoryEntry
+from app.storage.history_digest import (
+    MAX_DIGEST_MESSAGES,
+    clean_recent_dialogue,
+)
+
+
+def _entry(role: str, content: str, *, translation: str = "") -> ChatHistoryEntry:
+    return ChatHistoryEntry(
+        created_at="2026-06-20T12:00:00+08:00",
+        role=role,
+        content=content,
+        translation=translation,
+    )
+
+
+class TestCleanRecentDialogue:
+    def test_keeps_only_user_and_assistant_text(self) -> None:
+        entries = [
+            _entry("system", "ignored"),
+            _entry("user", "帮我导出 CSV"),
+            _entry("assistant", "好的，已经导出。"),
+        ]
+        lines = clean_recent_dialogue(entries)
+        assert [(line.role, line.content) for line in lines] == [
+            ("user", "帮我导出 CSV"),
+            ("assistant", "好的，已经导出。"),
+        ]
+
+    def test_strips_visual_markers(self) -> None:
+        entries = [
+            _entry(
+                "user",
+                "看看这个 [Sakura 已附加手动框选截图，视觉记录 visual_id=abc123]",
+            ),
+        ]
+        lines = clean_recent_dialogue(entries)
+        assert lines
+        assert "visual_id" not in lines[0].content
+        assert "看看这个" in lines[0].content
+
+    def test_prefers_assistant_translation(self) -> None:
+        entries = [_entry("assistant", "原文", translation="译文内容")]
+        lines = clean_recent_dialogue(entries)
+        assert lines[0].content == "译文内容"
+
+    def test_drops_low_signal_user_and_process_assistant(self) -> None:
+        entries = [
+            _entry("user", "嗯"),
+            _entry("assistant", "稍等，处理中"),
+            _entry("user", "把方案改成 B"),
+        ]
+        lines = clean_recent_dialogue(entries)
+        assert [line.content for line in lines] == ["把方案改成 B"]
+
+    def test_limits_to_recent_tail(self) -> None:
+        entries = [_entry("user", f"消息{i}") for i in range(MAX_DIGEST_MESSAGES + 5)]
+        lines = clean_recent_dialogue(entries)
+        assert len(lines) == MAX_DIGEST_MESSAGES
+        assert lines[-1].content == f"消息{MAX_DIGEST_MESSAGES + 4}"
+
+    def test_empty_history(self) -> None:
+        assert clean_recent_dialogue([]) == []
+
+
+class TestBuildSessionStateFragment:
+    def test_renders_recent_dialogue_as_untrusted_fact(self) -> None:
+        entries = [
+            _entry("user", "继续执行计划"),
+            _entry("assistant", "好的，记下下一步。"),
+        ]
+        fragment = build_session_state_fragment(entries, recent_message_count=1)
+        assert fragment is not None
+        assert fragment.source == "session_state"
+        assert fragment.trust == "untrusted"
+        assert "最近会话状态" in fragment.content
+        assert "继续执行计划" in fragment.content
+        assert "用户：" in fragment.content
+        assert "Sakura：" in fragment.content
+
+    def test_skips_when_live_window_deep(self) -> None:
+        entries = [_entry("user", "继续执行计划")]
+        fragment = build_session_state_fragment(
+            entries,
+            recent_message_count=SESSION_DIGEST_INJECT_MAX_RECENT_MESSAGES,
+        )
+        assert fragment is None
+
+    def test_none_when_no_history(self) -> None:
+        assert build_session_state_fragment([], recent_message_count=0) is None
+
+    def test_excludes_current_input_from_history(self) -> None:
+        entries = [_entry("user", "上次任务"), _entry("user", "本轮问题")]
+        fragment = build_session_state_fragment(entries, current_input="本轮问题")
+        assert fragment is not None
+        assert "上次任务" in fragment.content
+        assert "本轮问题" not in fragment.content
+
+    def test_token_budget_keeps_newest_messages(self) -> None:
+        entries = [_entry("user", f"消息{i}：" + "中" * 220) for i in range(MAX_DIGEST_MESSAGES)]
+        fragment = build_session_state_fragment(entries)
+        assert fragment is not None
+        assert fragment.token_budget == SESSION_STATE_TOKEN_BUDGET
+        assert "消息0：" not in fragment.content
+        assert f"消息{MAX_DIGEST_MESSAGES - 1}：" in fragment.content


### PR DESCRIPTION
## 主要改动

- 从持久化聊天历史中提取并清洗近期对话。
- 在新会话开始时注入近期会话状态，减少上下文断层。
- 限制注入条数与 Token 预算，实时对话充足后停止注入。
- 切换角色时同步更新聊天历史存储。
- 修复输入栏取消强制显示时未刷新悬停状态的问题。
- 补充上下文 Token 预算设计文档。

## 测试

- 新增历史摘要清洗与 Token 限制测试。
- 新增 Agent Runtime 会话状态注入测试。
- 新增输入栏悬停状态回归测试。