### PR TITLE
fix: 修复 TTS 整合包下载窗口层级与续传

### DIFF
--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -144,6 +144,10 @@ from app.agent.screen_observation import (
     capture_screen_image,
 )
 from app.ui.settings_dialog import SettingsDialog
+from app.ui.tts_bundle_dialog import (
+    cancel_active_tts_bundle_downloads_for_shutdown,
+    has_active_tts_bundle_download,
+)
 from app.ui.portrait_controller import (
     PORTRAIT_BASE_MAX_HEIGHT,
     PORTRAIT_BASE_MAX_WIDTH,
@@ -1269,6 +1273,25 @@ class PetWindow(QWidget):
             suppress()
 
     def closeEvent(self, event) -> None:  # type: ignore[no-untyped-def]
+        if has_active_tts_bundle_download():
+            reply = QMessageBox.question(
+                self,
+                "TTS 下载中",
+                "TTS 整合包正在后台下载。退出 Sakura 会暂停本次下载，已下载部分会保留，下次可继续。\n\n确定要退出吗？",
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                QMessageBox.StandardButton.No,
+            )
+            if reply != QMessageBox.StandardButton.Yes:
+                event.ignore()
+                return
+            if not cancel_active_tts_bundle_downloads_for_shutdown():
+                QMessageBox.information(
+                    self,
+                    "TTS 下载中",
+                    "下载线程仍在停止，请稍后再退出 Sakura。",
+                )
+                event.ignore()
+                return
         self.close_external_tools()
         super().closeEvent(event)
 
@@ -4950,6 +4973,9 @@ class PetWindow(QWidget):
             ),
             on_layout_preview=self._preview_layout,
             memory_curation_settings=getattr(self, "memory_curation_settings", None),
+            on_prepare_secondary_window=self._prepare_secondary_window,
+            on_present_secondary_window=self._present_registered_secondary_window,
+            on_release_secondary_window=self._release_secondary_window,
         )
         self.settings_dialog = dialog
         # 非模态打开：设置窗口开着时仍可正常点击/拖动桌宠。可最小化、有独立任务栏按钮、不置顶。
@@ -5408,7 +5434,7 @@ class PetWindow(QWidget):
         self._apply_window_flags()
         if checked and not bool(getattr(self, "_secondary_windows_suppress_topmost", False)):
             self.raise_()
-        # 已打开的设置/历史/日志窗口需跟随桌宠置顶状态更新，否则桌宠置顶后会反盖住它们。
+        # 已打开的副窗口需跟随桌宠置顶状态更新，否则桌宠置顶后会反盖住它们。
         self._sync_secondary_windows_topmost()
         if hasattr(self, "tray_icon"):
             self.tray_icon.setContextMenu(self._build_menu())
@@ -5416,12 +5442,8 @@ class PetWindow(QWidget):
     def _sync_secondary_windows_topmost(self) -> None:
         """桌宠置顶状态切换时，让已打开的副窗口跟随更新置顶，保持在桌宠之上。"""
         keep_on_top = bool(getattr(self, "always_on_top_enabled", False))
-        for window in (
-            getattr(self, "settings_dialog", None),
-            getattr(self, "history_window", None),
-            getattr(self, "runtime_log_window", None),
-        ):
-            if window is None or not window.isVisible():
+        for window in tuple(getattr(self, "_registered_secondary_windows", set())):
+            if not self._is_secondary_window_visible(window):
                 continue
             _configure_secondary_window(window, keep_on_top=keep_on_top)
             _present_secondary_window(window)
@@ -5781,6 +5803,10 @@ class PetWindow(QWidget):
                 remove_event_filter(self)
             except RuntimeError:
                 pass
+
+    def _release_secondary_window(self, window: QWidget) -> None:
+        self._unregister_secondary_window(window)
+        self._sync_secondary_window_state()
 
     def _is_registered_secondary_window(self, window: object) -> bool:
         registered = getattr(self, "_registered_secondary_windows", None)

--- a/app/ui/settings/pages/sections.py
+++ b/app/ui/settings/pages/sections.py
@@ -561,6 +561,8 @@ class TtsSettingsPage:
             "Windows 可一键下载内置整合包；macOS/Linux 请使用自定义 GPT-SoVITS 接入源码版运行环境。"
         )
         owner.tts_bundle_download_button.clicked.connect(owner._download_gpt_sovits_bundle)
+        owner.tts_bundle_status_label = QLabel("", tab)
+        owner.tts_bundle_status_label.setWordWrap(True)
         owner.tts_provider_combo.currentIndexChanged.connect(
             lambda _index: owner._sync_tts_provider_controls(apply_defaults=True)
         )
@@ -590,6 +592,7 @@ class TtsSettingsPage:
         form_layout.addRow("TTS Python", owner.tts_python_path_edit)
         form_layout.addRow("推理配置", owner.tts_config_path_edit)
         form_layout.addRow("超时", owner.tts_timeout_spin)
+        form_layout.addRow("整合包下载", owner.tts_bundle_status_label)
         owner._tts_form_layout = form_layout
         tab.setLayout(form_layout)
         owner._sync_tts_provider_controls(apply_defaults=_is_bundled_tts_provider(settings.provider))

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -106,7 +106,7 @@ from app.voice.tts_settings import (
     GPTSoVITSTTSSettings,
     TTSConfigError,
 )
-from app.ui.tts_bundle_dialog import TTSBundleDownloadDialog
+from app.ui.tts_bundle_dialog import TTSBundleDownloadDialog, active_tts_bundle_download_dialog
 from app.ui.theme import (
     DEFAULT_THEME_SETTINGS,
     THEME_COLOR_FIELDS,
@@ -171,6 +171,9 @@ class SettingsDialog(QDialog):
         on_layout_preview: Callable[[int, int, int, int, int], None] | None = None,
         proactive_care_settings: ScreenAwarenessSettings | None = None,
         memory_curation_settings=None,
+        on_prepare_secondary_window: Callable[[QWidget], None] | None = None,
+        on_present_secondary_window: Callable[[QWidget], None] | None = None,
+        on_release_secondary_window: Callable[[QWidget], None] | None = None,
     ) -> None:
         super().__init__(parent)
         if screen_awareness_settings is None:
@@ -217,6 +220,9 @@ class SettingsDialog(QDialog):
             reply_segment_pause_ms,
         )
         self.memory_store = memory_store
+        self._on_prepare_secondary_window = on_prepare_secondary_window
+        self._on_present_secondary_window = on_present_secondary_window
+        self._on_release_secondary_window = on_release_secondary_window
         self._all_memories: list[dict[str, object]] = []
         self._visible_memories: list[dict[str, object]] = []
         self._selected_memory_ids: set[str] = set()
@@ -251,6 +257,7 @@ class SettingsDialog(QDialog):
         self._api_model_probe_worker: settings_workers.ApiModelListProbeWorker | None = None
         self._tts_test_thread: QThread | None = None
         self._tts_test_worker: settings_workers.TTSTestWorker | None = None
+        self._tts_bundle_download_dialog: TTSBundleDownloadDialog | None = None
         self._pending_api_accept_values: dict[str, object] | None = None
         self._pending_accept_values: dict[str, object] | None = None
         self._save_button_text: str | None = None
@@ -1754,8 +1761,11 @@ class SettingsDialog(QDialog):
             return
         self._applied_dialog_stylesheet = stylesheet
         self.setStyleSheet(stylesheet)
+        if self._tts_bundle_download_dialog is not None:
+            self._style_tts_bundle_download_dialog(self._tts_bundle_download_dialog)
         inline_styles = {
             "theme_status_label": f"color: {theme.muted_text_color};",
+            "tts_bundle_status_label": f"color: {theme.muted_text_color};",
             "memory_status_label": f"color: {theme.muted_text_color};",
             "memory_selection_label": f"color: {theme.secondary_text_color};",
             "memory_preview_label": f"color: {theme.text_color};",
@@ -2561,27 +2571,92 @@ class SettingsDialog(QDialog):
             cancel_button.setEnabled(not busy)
 
     def _download_gpt_sovits_bundle(self) -> None:
-        dialog = TTSBundleDownloadDialog(self.base_dir, self)
-        if dialog.exec() != QDialog.DialogCode.Accepted or dialog.downloaded_work_dir is None:
+        dialog = self._tts_bundle_download_dialog or active_tts_bundle_download_dialog()
+        if dialog is not None:
+            if self._tts_bundle_download_dialog is None:
+                self._attach_tts_bundle_download_dialog(dialog)
+            self._present_tts_bundle_download_dialog(dialog)
             return
-        provider = getattr(dialog, "downloaded_provider", None) or TTS_PROVIDER_GPT_SOVITS
-        python_path = getattr(dialog, "downloaded_python_path", None)
-        tts_config_path = getattr(dialog, "downloaded_tts_config_path", None)
+
+        dialog = TTSBundleDownloadDialog(self.base_dir)
+        self._attach_tts_bundle_download_dialog(dialog)
+        if hasattr(self, "tts_bundle_status_label"):
+            self.tts_bundle_status_label.setText("TTS 整合包下载窗口已打开，可隐藏到后台。")
+        self.tts_bundle_download_button.setText("查看 TTS 下载")
+        self._present_tts_bundle_download_dialog(dialog)
+
+    def _attach_tts_bundle_download_dialog(self, dialog: TTSBundleDownloadDialog) -> None:
+        self._tts_bundle_download_dialog = dialog
+        self._style_tts_bundle_download_dialog(dialog)
+        prepare_secondary_window = self._on_prepare_secondary_window
+        if prepare_secondary_window is not None:
+            prepare_secondary_window(dialog)
+        dialog.succeeded.connect(self._handle_tts_bundle_download_success)
+        dialog.finished.connect(lambda _result, d=dialog: self._clear_tts_bundle_download_dialog(d))
+        if hasattr(self, "tts_bundle_download_button"):
+            self.tts_bundle_download_button.setText("查看 TTS 下载")
+
+    def _style_tts_bundle_download_dialog(self, dialog: TTSBundleDownloadDialog) -> None:
+        set_style_sheet = getattr(dialog, "setStyleSheet", None)
+        if callable(set_style_sheet):
+            set_style_sheet(self.styleSheet())
+
+    def _present_tts_bundle_download_dialog(self, dialog: TTSBundleDownloadDialog) -> None:
+        present_secondary_window = self._on_present_secondary_window
+        if present_secondary_window is not None:
+            present_secondary_window(dialog)
+            return
+        dialog.show()
+        dialog.raise_()
+        dialog.activateWindow()
+
+    @Slot(object)
+    def _handle_tts_bundle_download_success(self, result: object) -> None:
+        self._apply_tts_bundle_install_result(result)
+        if hasattr(self, "tts_bundle_status_label"):
+            work_dir = getattr(result, "work_dir", None)
+            self.tts_bundle_status_label.setText(f"TTS 整合包已安装：{work_dir}")
+
+    def _apply_tts_bundle_install_result(self, result: object) -> None:
+        work_dir = getattr(result, "work_dir", None)
+        if work_dir is None:
+            return
+        provider = getattr(result, "provider", None) or TTS_PROVIDER_GPT_SOVITS
+        python_path = getattr(result, "python_path", None)
+        tts_config_path = getattr(result, "tts_config_path", None)
         provider_index = self.tts_provider_combo.findData(provider)
         if provider_index >= 0:
             self.tts_provider_combo.setCurrentIndex(provider_index)
-        self.tts_work_dir_edit.setText(str(dialog.downloaded_work_dir))
+        self.tts_work_dir_edit.setText(str(work_dir))
         if python_path is not None:
             self.tts_python_path_edit.setText(str(python_path))
         else:
-            self.tts_python_path_edit.setText(_bundle_python_path_display(provider, dialog.downloaded_work_dir))
+            self.tts_python_path_edit.setText(_bundle_python_path_display(provider, Path(work_dir)))
         if tts_config_path is not None:
             self.tts_config_path_edit.setText(str(tts_config_path))
         else:
-            self.tts_config_path_edit.setText(_bundle_tts_config_display(provider, dialog.downloaded_work_dir))
+            self.tts_config_path_edit.setText(_bundle_tts_config_display(provider, Path(work_dir)))
         self.tts_api_url_edit.setText(_default_tts_api_url(provider))
         self.tts_enabled_check.setChecked(True)
         self._sync_tts_provider_controls()
+
+    def _clear_tts_bundle_download_dialog(self, dialog: TTSBundleDownloadDialog) -> None:
+        if self._tts_bundle_download_dialog is dialog:
+            self._tts_bundle_download_dialog = None
+            self.tts_bundle_download_button.setText("一键下载 TTS 整合包")
+            release_secondary_window = self._on_release_secondary_window
+            if release_secondary_window is not None:
+                release_secondary_window(dialog)
+
+    def has_active_tts_bundle_download(self) -> bool:
+        dialog = self._tts_bundle_download_dialog
+        return bool(dialog is not None and dialog.is_download_running())
+
+    def cancel_tts_bundle_download_for_shutdown(self, timeout_ms: int = 3000) -> bool:
+        dialog = self._tts_bundle_download_dialog
+        if dialog is None:
+            return True
+        return dialog.cancel_for_shutdown(timeout_ms)
 
     @Slot()
     def _sync_tts_provider_controls(self, *, apply_defaults: bool = False) -> None:

--- a/app/ui/theme.py
+++ b/app/ui/theme.py
@@ -534,6 +534,19 @@ QSlider::handle:horizontal:disabled {{
     background: {rgba(theme.muted_text_color, 130)};
     border: 2px solid {rgba(theme.border_color, 92)};
 }}
+QProgressBar {{
+    background: {rgba(theme.input_background_color, 214)};
+    border: 1px solid {rgba(theme.border_color, 132)};
+    border-radius: 7px;
+    color: {theme.secondary_text_color};
+    min-height: 18px;
+    text-align: center;
+}}
+QProgressBar::chunk {{
+    background: {theme.primary_color};
+    border-radius: 6px;
+    margin: 1px;
+}}
 QLineEdit:disabled, QSpinBox:disabled, QDoubleSpinBox:disabled, QTextEdit:disabled, QComboBox:disabled {{
     background: {rgba(mix(theme.panel_background_color, "#808080", 0.16), 172)};
     border: 1px solid {rgba(mix(theme.border_color, "#808080", 0.28), 102)};

--- a/app/ui/tts_bundle_dialog.py
+++ b/app/ui/tts_bundle_dialog.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from PySide6.QtCore import QThread, Signal, Slot
+from PySide6.QtCore import Qt, QThread, Signal, Slot
 from PySide6.QtWidgets import (
     QComboBox,
     QDialog,
@@ -27,12 +27,36 @@ from app.voice.tts_bundle import (
     install_tts_bundle,
     list_nvidia_gpus,
     recommend_tts_bundle,
+    TTSBundleDownloadProgress,
 )
 from app.ui.error_messages import format_failure_message
 
 
+_BACKGROUND_DOWNLOAD_DIALOGS: set["TTSBundleDownloadDialog"] = set()
+
+
+def has_active_tts_bundle_download() -> bool:
+    return any(dialog.is_download_running() for dialog in tuple(_BACKGROUND_DOWNLOAD_DIALOGS))
+
+
+def active_tts_bundle_download_dialog() -> "TTSBundleDownloadDialog" | None:
+    for dialog in tuple(_BACKGROUND_DOWNLOAD_DIALOGS):
+        if dialog.is_download_running() or dialog.isVisible():
+            return dialog
+    return None
+
+
+def cancel_active_tts_bundle_downloads_for_shutdown(timeout_ms: int = 3000) -> bool:
+    active_dialogs = [dialog for dialog in tuple(_BACKGROUND_DOWNLOAD_DIALOGS) if dialog.is_download_running()]
+    if not active_dialogs:
+        return True
+    timeout_per_dialog = max(1, int(timeout_ms / max(1, len(active_dialogs))))
+    return all(dialog.cancel_for_shutdown(timeout_per_dialog) for dialog in active_dialogs)
+
+
 class TTSBundleDownloadThread(QThread):
     progress = Signal(int)
+    download_progress = Signal(object)
     status = Signal(str)
     succeeded = Signal(object)
     failed = Signal(str)
@@ -58,6 +82,7 @@ class TTSBundleDownloadThread(QThread):
                 self.base_dir,
                 check_cancel=_check_cancel,
                 on_progress=self.progress.emit,
+                on_download_progress=self.download_progress.emit,
                 on_status=self.status.emit,
             )
         except DownloadCancelledError:
@@ -70,6 +95,8 @@ class TTSBundleDownloadThread(QThread):
 
 
 class TTSBundleDownloadDialog(QDialog):
+    succeeded = Signal(object)
+
     def __init__(self, base_dir: Path, parent=None) -> None:  # type: ignore[no-untyped-def]
         super().__init__(parent)
         self.base_dir = base_dir
@@ -80,7 +107,14 @@ class TTSBundleDownloadDialog(QDialog):
         self._thread: TTSBundleDownloadThread | None = None
         self._entries = compatible_tts_bundles()
         self.setWindowTitle("下载 TTS 整合包")
+        self.setWindowModality(Qt.WindowModality.NonModal)
+        self.setWindowFlag(Qt.WindowType.WindowTitleHint, True)
+        self.setWindowFlag(Qt.WindowType.WindowSystemMenuHint, True)
+        self.setWindowFlag(Qt.WindowType.WindowMinimizeButtonHint, True)
+        self.setWindowFlag(Qt.WindowType.WindowCloseButtonHint, True)
         self.setMinimumWidth(520)
+        _BACKGROUND_DOWNLOAD_DIALOGS.add(self)
+        self.finished.connect(lambda _result, dialog=self: _BACKGROUND_DOWNLOAD_DIALOGS.discard(dialog))
         self._cleanup_legacy_archives()
 
         gpus = list_nvidia_gpus()
@@ -109,6 +143,9 @@ class TTSBundleDownloadDialog(QDialog):
 
         self.status_label = QLabel("", self)
         self.status_label.setVisible(False)
+        self.detail_label = QLabel("", self)
+        self.detail_label.setWordWrap(True)
+        self.detail_label.setVisible(False)
         self.progress_bar = QProgressBar(self)
         self.progress_bar.setRange(0, 100)
         self.progress_bar.setVisible(False)
@@ -116,8 +153,11 @@ class TTSBundleDownloadDialog(QDialog):
         self.start_button = QPushButton("开始下载", self)
         self.start_button.setEnabled(bool(self._entries))
         self.start_button.clicked.connect(self._start_download)
-        self.cancel_button = QPushButton("关闭", self)
-        self.cancel_button.clicked.connect(self._on_cancel_clicked)
+        self.pause_button = QPushButton("暂停下载", self)
+        self.pause_button.setVisible(False)
+        self.pause_button.clicked.connect(self._cancel_download)
+        self.close_button = QPushButton("关闭", self)
+        self.close_button.clicked.connect(self._on_close_clicked)
 
         form = QFormLayout()
         form.addRow("整合包", self.bundle_combo)
@@ -125,7 +165,8 @@ class TTSBundleDownloadDialog(QDialog):
         buttons = QHBoxLayout()
         buttons.addStretch(1)
         buttons.addWidget(self.start_button)
-        buttons.addWidget(self.cancel_button)
+        buttons.addWidget(self.pause_button)
+        buttons.addWidget(self.close_button)
 
         layout = QVBoxLayout()
         layout.addWidget(self.platform_label)
@@ -133,6 +174,7 @@ class TTSBundleDownloadDialog(QDialog):
         layout.addWidget(self.recommend_label)
         layout.addLayout(form)
         layout.addWidget(self.status_label)
+        layout.addWidget(self.detail_label)
         layout.addWidget(self.progress_bar)
         layout.addLayout(buttons)
         self.setLayout(layout)
@@ -152,9 +194,15 @@ class TTSBundleDownloadDialog(QDialog):
         self.downloaded_tts_config_path = None
         self.bundle_combo.setEnabled(False)
         self.start_button.setEnabled(False)
-        self.cancel_button.setText("取消下载")
-        self.cancel_button.setEnabled(True)
+        self.start_button.setText("开始下载")
+        self.pause_button.setText("暂停下载")
+        self.pause_button.setEnabled(True)
+        self.pause_button.setVisible(True)
+        self.close_button.setText("隐藏到后台")
+        self.close_button.setEnabled(True)
         self.status_label.setVisible(True)
+        self.detail_label.setVisible(True)
+        self.detail_label.setText("")
         self.progress_bar.setVisible(True)
         self.progress_bar.setValue(0)
         self._handle_status("download")
@@ -162,6 +210,7 @@ class TTSBundleDownloadDialog(QDialog):
         thread = TTSBundleDownloadThread(entry, self.base_dir)
         self._thread = thread
         thread.progress.connect(self.progress_bar.setValue)
+        thread.download_progress.connect(self._handle_download_progress)
         thread.status.connect(self._handle_status)
         thread.succeeded.connect(self._handle_success)
         thread.failed.connect(self._handle_failure)
@@ -184,29 +233,47 @@ class TTSBundleDownloadDialog(QDialog):
         self.status_label.setText(text)
 
     @Slot(object)
+    def _handle_download_progress(self, progress: TTSBundleDownloadProgress) -> None:
+        self.progress_bar.setValue(progress.percent)
+        downloaded = _format_bytes(progress.downloaded_bytes)
+        total = _format_bytes(progress.total_bytes)
+        speed = _format_speed(progress.bytes_per_second)
+        prefix = "正在续传" if progress.resumed else "正在下载"
+        self.detail_label.setText(f"{prefix}：{downloaded} / {total}，{speed}")
+
+    @Slot(object)
     def _handle_success(self, result: TTSBundleInstallResult) -> None:
         self.downloaded_work_dir = result.work_dir
         self.downloaded_provider = result.provider
         self.downloaded_python_path = result.python_path
         self.downloaded_tts_config_path = result.tts_config_path
-        QMessageBox.information(self, "下载完成", f"TTS 整合包已就绪：\n{result.work_dir}")
+        self.status_label.setVisible(True)
+        self.status_label.setText("TTS 整合包已就绪")
+        self.detail_label.setVisible(True)
+        self.detail_label.setText(str(result.work_dir))
+        self.succeeded.emit(result)
         self.accept()
 
     @Slot(str)
     def _handle_failure(self, message: str) -> None:
-        QMessageBox.warning(
-            self,
-            "下载失败",
-            format_failure_message(
-                "TTS 整合包没有下载或安装成功。",
-                "请检查网络、代理、磁盘空间和目录权限后重试。",
-                message,
-            ),
-        )
+        if self.isVisible():
+            QMessageBox.warning(
+                self,
+                "下载失败",
+                format_failure_message(
+                    "TTS 整合包没有下载或安装成功。",
+                    "请检查网络、代理、磁盘空间和目录权限后重试，已下载部分会尽量保留供下次继续。",
+                    message,
+                ),
+            )
+        self.status_label.setVisible(True)
+        self.status_label.setText(f"下载失败：{message}")
         self.bundle_combo.setEnabled(bool(self._entries))
         self.start_button.setEnabled(bool(self._entries))
-        self.cancel_button.setText("关闭")
-        self.cancel_button.setEnabled(True)
+        self.start_button.setText("继续下载")
+        self.pause_button.setVisible(False)
+        self.close_button.setText("关闭")
+        self.close_button.setEnabled(True)
         self._thread = None
 
     @Slot()
@@ -218,25 +285,43 @@ class TTSBundleDownloadDialog(QDialog):
         """下载被用户取消后，恢复界面状态。"""
         self.bundle_combo.setEnabled(bool(self._entries))
         self.start_button.setEnabled(bool(self._entries))
-        self.cancel_button.setText("关闭")
-        self.cancel_button.setEnabled(True)
-        self.status_label.setText("下载已取消")
+        self.start_button.setText("继续下载")
+        self.pause_button.setVisible(False)
+        self.close_button.setText("关闭")
+        self.close_button.setEnabled(True)
+        self.status_label.setText("下载已暂停")
+        self.detail_label.setVisible(True)
+        self.detail_label.setText("已下载部分会保留，下次可继续。")
         self._thread = None
 
-    def _on_cancel_clicked(self) -> None:
-        """取消按钮点击：下载中则取消下载，否则关闭对话框。"""
-        if self._thread is not None and self._thread.isRunning():
-            self._cancel_download()
+    def _on_close_clicked(self) -> None:
+        """下载中隐藏到后台，空闲时关闭窗口。"""
+        if self.is_download_running():
+            self.hide()
         else:
             self.reject()
 
     def _cancel_download(self) -> None:
-        """请求取消下载线程。"""
+        """请求暂停下载线程，保留 .part 供下次续传。"""
         thread = self._thread
         if thread is not None:
-            self.status_label.setText("正在取消下载...")
-            self.cancel_button.setEnabled(False)
+            self.status_label.setText("正在暂停下载...")
+            self.detail_label.setVisible(True)
+            self.detail_label.setText("已下载部分会保留，下次可继续。")
+            self.pause_button.setEnabled(False)
             thread.cancel()
+
+    def is_download_running(self) -> bool:
+        thread = self._thread
+        return bool(thread is not None and thread.isRunning())
+
+    def cancel_for_shutdown(self, timeout_ms: int = 3000) -> bool:
+        """应用退出时请求暂停下载，返回线程是否已停止。"""
+        thread = self._thread
+        if thread is None or not thread.isRunning():
+            return True
+        self._cancel_download()
+        return bool(thread.wait(timeout_ms))
 
     def _cleanup_legacy_archives(self) -> None:
         try:
@@ -253,18 +338,17 @@ class TTSBundleDownloadDialog(QDialog):
             )
 
     def reject(self) -> None:
-        if self._thread is not None and self._thread.isRunning():
-            reply = QMessageBox.question(
-                self,
-                "取消下载",
-                "下载正在进行中，确定要取消下载吗？\n已下载的进度将会丢失。",
-                QMessageBox.Yes | QMessageBox.No,
-                QMessageBox.No,
-            )
-            if reply == QMessageBox.Yes:
-                self._cancel_download()
+        if self.is_download_running():
+            self.hide()
             return
         super().reject()
+
+    def closeEvent(self, event) -> None:  # type: ignore[no-untyped-def]
+        if self.is_download_running():
+            event.ignore()
+            self.hide()
+            return
+        super().closeEvent(event)
 
     def _selected_entry(self) -> TTSBundleEntry:
         key = str(self.bundle_combo.currentData() or "")
@@ -272,3 +356,19 @@ class TTSBundleDownloadDialog(QDialog):
             if entry.key == key:
                 return entry
         raise RuntimeError("当前平台没有可一键下载的 TTS 整合包。")
+
+
+def _format_bytes(value: int) -> str:
+    size = float(max(0, value))
+    units = ("B", "KB", "MB", "GB")
+    for unit in units:
+        if size < 1024 or unit == units[-1]:
+            return f"{size:.1f} {unit}" if unit != "B" else f"{int(size)} B"
+        size /= 1024
+    return f"{size:.1f} GB"
+
+
+def _format_speed(bytes_per_second: float) -> str:
+    if bytes_per_second <= 0:
+        return "正在计算速度"
+    return f"{_format_bytes(int(bytes_per_second))}/s"

--- a/app/voice/tts_bundle.py
+++ b/app/voice/tts_bundle.py
@@ -24,6 +24,7 @@ from app.voice.runtime_compat import current_platform_label, current_system_name
 ProgressCallback = Callable[[int], None]
 StatusCallback = Callable[[str], None]
 MigrationProgressCallback = Callable[["TTSBundleMigrationProgress"], None]
+DownloadProgressCallback = Callable[["TTSBundleDownloadProgress"], None]
 
 class DownloadCancelledError(Exception):
     """用户主动取消下载时抛出此异常，调用方据此判断是用户取消而非真正的错误。"""
@@ -91,6 +92,18 @@ class TTSBundleMigrationProgress:
     total_files: int
     copied_bytes: int
     total_bytes: int
+
+
+@dataclass(frozen=True)
+class TTSBundleDownloadProgress:
+    """TTS 整合包下载阶段的详细进度。"""
+
+    status: str
+    downloaded_bytes: int
+    total_bytes: int
+    percent: int
+    resumed: bool = False
+    bytes_per_second: float = 0.0
 
 
 GENIE_TTS = TTSBundleEntry(
@@ -482,6 +495,7 @@ def install_tts_bundle(
     check_cancel: Callable[[], None] | None = None,
     on_progress: ProgressCallback | None = None,
     on_status: StatusCallback | None = None,
+    on_download_progress: DownloadProgressCallback | None = None,
     urlopen: UrlOpenCallable = urllib.request.urlopen,
     extractor: Callable[[Path, Path], str | None] | None = None,
 ) -> TTSBundleInstallResult:
@@ -492,6 +506,7 @@ def install_tts_bundle(
             check_cancel=check_cancel,
             on_progress=on_progress,
             on_status=on_status,
+            on_download_progress=on_download_progress,
             urlopen=urlopen,
             extractor=extractor,
         )
@@ -514,6 +529,7 @@ def download_and_extract_bundle(
     check_cancel: Callable[[], None] | None = None,
     on_progress: ProgressCallback | None = None,
     on_status: StatusCallback | None = None,
+    on_download_progress: DownloadProgressCallback | None = None,
     urlopen: UrlOpenCallable = urllib.request.urlopen,
     extractor: Callable[[Path, Path], str | None] | None = None,
 ) -> Path:
@@ -536,7 +552,14 @@ def download_and_extract_bundle(
     _emit_progress(on_progress, 0)
     if _archive_verification_error(archive, entry, on_progress=on_progress) is not None:
         _emit_status(on_status, "download")
-        _download_archive(entry, archive, on_progress=on_progress, urlopen=urlopen, check_cancel=check_cancel)
+        _download_archive(
+            entry,
+            archive,
+            on_progress=on_progress,
+            on_download_progress=on_download_progress,
+            urlopen=urlopen,
+            check_cancel=check_cancel,
+        )
     _emit_progress(on_progress, _DOWNLOAD_PROGRESS_END)
 
     _emit_status(on_status, "extract")
@@ -991,6 +1014,23 @@ def _emit_status(callback: StatusCallback | None, value: str) -> None:
         callback(value)
 
 
+def _emit_download_progress(
+    callback: DownloadProgressCallback | None,
+    progress: TTSBundleDownloadProgress,
+) -> None:
+    if callback is not None:
+        callback(progress)
+
+
+def _download_percent(downloaded: int, total: int) -> int:
+    if total <= 0:
+        return _DOWNLOAD_PROGRESS_END
+    downloaded = max(0, min(downloaded, total))
+    return _VERIFY_PROGRESS_END + int(
+        (_DOWNLOAD_PROGRESS_END - _VERIFY_PROGRESS_END) * downloaded / total
+    )
+
+
 def _archive_verification_error(
     archive: Path,
     entry: TTSBundleEntry,
@@ -1017,45 +1057,107 @@ def _download_archive(
     archive: Path,
     *,
     on_progress: ProgressCallback | None,
+    on_download_progress: DownloadProgressCallback | None,
     urlopen: UrlOpenCallable,
     check_cancel: Callable[[], None] | None = None,
 ) -> None:
     part = archive.with_name(f"{archive.name}.part")
-    if part.exists():
-        part.unlink()
-    request = urllib.request.Request(
-        entry.download_url,
-        headers={"User-Agent": "Sakura-Desktop-Pet/1.0"},
-    )
-    hasher = hashlib.sha256()
-    downloaded = 0
+    resume_from = part.stat().st_size if part.is_file() else 0
+    if entry.size > 0 and resume_from > entry.size:
+        part.unlink(missing_ok=True)
+        resume_from = 0
+    if resume_from == entry.size and entry.size > 0:
+        actual_sha256 = _sha256_file(part)
+        if actual_sha256.lower() == entry.sha256.lower():
+            replace_with_retry(part, archive)
+            return
+        part.unlink(missing_ok=True)
+        resume_from = 0
+
+    headers = {"User-Agent": "Sakura-Desktop-Pet/1.0"}
+    if resume_from > 0:
+        headers["Range"] = f"bytes={resume_from}-"
+    request = urllib.request.Request(entry.download_url, headers=headers)
+
+    transfer_start = time.monotonic()
+    transfer_start_bytes = resume_from
+    downloaded = resume_from
+    resumed = resume_from > 0
     try:
         with urlopen(request, timeout=600) as response:  # type: ignore[attr-defined]
-            with part.open("wb") as file:
+            status_code = _response_status_code(response)
+            if resumed and status_code != 206:
+                part.unlink(missing_ok=True)
+                downloaded = 0
+                transfer_start_bytes = 0
+                resumed = False
+            mode = "ab" if resumed else "wb"
+            _emit_download_progress(
+                on_download_progress,
+                TTSBundleDownloadProgress(
+                    status="download",
+                    downloaded_bytes=downloaded,
+                    total_bytes=entry.size,
+                    percent=_download_percent(downloaded, entry.size),
+                    resumed=resumed,
+                ),
+            )
+            _emit_progress(on_progress, _download_percent(downloaded, entry.size))
+            with part.open(mode) as file:
                 while True:
                     chunk = response.read(_DOWNLOAD_CHUNK_SIZE)
                     if not chunk:
                         break
                     file.write(chunk)
-                    hasher.update(chunk)
                     if check_cancel is not None:
                         check_cancel()
                     downloaded += len(chunk)
-                    _emit_progress(
-                        on_progress,
-                        _VERIFY_PROGRESS_END
-                        + int((_DOWNLOAD_PROGRESS_END - _VERIFY_PROGRESS_END) * downloaded / entry.size),
+                    progress = _download_percent(downloaded, entry.size)
+                    elapsed = max(0.001, time.monotonic() - transfer_start)
+                    speed = max(0.0, (downloaded - transfer_start_bytes) / elapsed)
+                    _emit_progress(on_progress, progress)
+                    _emit_download_progress(
+                        on_download_progress,
+                        TTSBundleDownloadProgress(
+                            status="download",
+                            downloaded_bytes=downloaded,
+                            total_bytes=entry.size,
+                            percent=progress,
+                            resumed=resumed,
+                            bytes_per_second=speed,
+                        ),
                     )
         if downloaded != entry.size:
             raise RuntimeError(f"文件大小不匹配：期望 {entry.size}，实际 {downloaded}")
-        actual_sha256 = hasher.hexdigest()
+        actual_sha256 = _sha256_file(part)
         if actual_sha256.lower() != entry.sha256.lower():
+            part.unlink(missing_ok=True)
             raise RuntimeError(f"SHA256 不匹配：期望 {entry.sha256}，实际 {actual_sha256}")
         replace_with_retry(part, archive)
+    except DownloadCancelledError:
+        raise
     except Exception:
-        if part.exists():
+        if part.is_file() and entry.size > 0 and part.stat().st_size >= entry.size:
             part.unlink()
         raise
+
+
+def _response_status_code(response: object) -> int | None:
+    getcode = getattr(response, "getcode", None)
+    if callable(getcode):
+        try:
+            code = getcode()
+        except Exception:
+            return None
+        try:
+            return int(code) if code is not None else None
+        except (TypeError, ValueError):
+            return None
+    status = getattr(response, "status", None)
+    try:
+        return int(status) if status is not None else None
+    except (TypeError, ValueError):
+        return None
 
 
 def _sha256_file(

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -24,6 +24,7 @@ from app.ui.theme import (
     ThemeSettings,
     build_message_box_stylesheet,
     build_pet_window_stylesheet,
+    build_settings_dialog_stylesheet,
 )
 from app.agent.proactive_care import ProactiveCareSettings
 from app.agent.screen_awareness import ScreenAwarenessSettings
@@ -3699,6 +3700,70 @@ def test_settings_dialog_exposes_tts_bundle_controls(monkeypatch) -> None:  # ty
     app.processEvents()
 
 
+class _SignalStub:
+    def __init__(self) -> None:
+        self._callbacks = []
+
+    def connect(self, callback) -> None:  # type: ignore[no-untyped-def]
+        self._callbacks.append(callback)
+
+    def emit(self, *args) -> None:  # type: ignore[no-untyped-def]
+        for callback in list(self._callbacks):
+            callback(*args)
+
+
+class _TTSBundleResultStub:
+    def __init__(
+        self,
+        work_dir: Path,
+        provider: str = "gpt-sovits",
+        python_path: Path | None = None,
+        tts_config_path: Path | None = None,
+    ) -> None:
+        self.work_dir = work_dir
+        self.provider = provider
+        self.python_path = python_path
+        self.tts_config_path = tts_config_path
+
+
+def _make_tts_bundle_dialog_stub():
+    class DialogStub:
+        last = None
+        instances = []
+
+        def __init__(self, *_args, **_kwargs) -> None:
+            self.args = _args
+            self.kwargs = _kwargs
+            self.succeeded = _SignalStub()
+            self.finished = _SignalStub()
+            self.show_count = 0
+            self.raised = False
+            self.activated = False
+            self.stylesheets: list[str] = []
+            DialogStub.last = self
+            DialogStub.instances.append(self)
+
+        def setStyleSheet(self, stylesheet: str) -> None:  # noqa: N802 - 匹配 Qt 接口名
+            self.stylesheets.append(stylesheet)
+
+        def styleSheet(self) -> str:  # noqa: N802 - 匹配 Qt 接口名
+            return self.stylesheets[-1] if self.stylesheets else ""
+
+        def show(self) -> None:
+            self.show_count += 1
+
+        def raise_(self) -> None:
+            self.raised = True
+
+        def activateWindow(self) -> None:
+            self.activated = True
+
+        def is_download_running(self) -> bool:
+            return False
+
+    return DialogStub
+
+
 def test_settings_dialog_download_success_fills_tts_work_dir(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     qtwidgets = pytest.importorskip("PySide6.QtWidgets")
     if not hasattr(qtwidgets, "QApplication"):
@@ -3710,13 +3775,7 @@ def test_settings_dialog_download_success_fills_tts_work_dir(monkeypatch) -> Non
     root = _ui_runtime_root("tts_bundle_ui")
     root.mkdir(parents=True, exist_ok=True)
 
-    class DialogStub:
-        def __init__(self, *_args, **_kwargs) -> None:
-            self.downloaded_work_dir = root / "tts" / "gpt"
-
-        def exec(self):  # type: ignore[no-untyped-def]
-            return settings_dialog_module.QDialog.DialogCode.Accepted
-
+    DialogStub = _make_tts_bundle_dialog_stub()
     monkeypatch.setattr(settings_dialog_module, "TTSBundleDownloadDialog", DialogStub)
 
     QApplication = qtwidgets.QApplication
@@ -3735,6 +3794,8 @@ def test_settings_dialog_download_success_fills_tts_work_dir(monkeypatch) -> Non
     )
 
     dialog._download_gpt_sovits_bundle()
+    assert DialogStub.last is not None
+    DialogStub.last.succeeded.emit(_TTSBundleResultStub(root / "tts" / "gpt"))
 
     assert dialog.tts_enabled_check.isChecked()
     assert dialog.tts_api_url_edit.text() == "http://127.0.0.1:9880/tts"
@@ -3753,7 +3814,7 @@ def test_settings_dialog_download_success_fills_tts_work_dir(monkeypatch) -> Non
     app.processEvents()
 
 
-def test_settings_dialog_download_success_fills_genie_provider(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_settings_dialog_download_reuses_active_tts_bundle_window(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     qtwidgets = pytest.importorskip("PySide6.QtWidgets")
     if not hasattr(qtwidgets, "QApplication"):
         pytest.skip("当前测试环境只提供了 PySide6 stub。")
@@ -3761,17 +3822,9 @@ def test_settings_dialog_download_success_fills_genie_provider(monkeypatch) -> N
     import app.ui.settings_dialog as settings_dialog_module
     from app.ui.settings_dialog import SettingsDialog
 
-    root = _ui_runtime_root("tts_bundle_ui")
+    root = _ui_runtime_root("tts_bundle_reuse")
     root.mkdir(parents=True, exist_ok=True)
-
-    class DialogStub:
-        def __init__(self, *_args, **_kwargs) -> None:
-            self.downloaded_work_dir = root / "tts" / "cpu"
-            self.downloaded_provider = "genie-tts"
-
-        def exec(self):  # type: ignore[no-untyped-def]
-            return settings_dialog_module.QDialog.DialogCode.Accepted
-
+    DialogStub = _make_tts_bundle_dialog_stub()
     monkeypatch.setattr(settings_dialog_module, "TTSBundleDownloadDialog", DialogStub)
 
     QApplication = qtwidgets.QApplication
@@ -3790,6 +3843,251 @@ def test_settings_dialog_download_success_fills_genie_provider(monkeypatch) -> N
     )
 
     dialog._download_gpt_sovits_bundle()
+    first = DialogStub.last
+    dialog._download_gpt_sovits_bundle()
+
+    assert DialogStub.instances == [first]
+    assert first.show_count == 2
+    assert first.raised
+    assert first.activated
+    dialog.deleteLater()
+    app.processEvents()
+
+
+def test_settings_dialog_styles_tts_bundle_download_window(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    if not hasattr(qtwidgets, "QApplication"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+
+    import app.ui.settings_dialog as settings_dialog_module
+    from app.ui.settings_dialog import SettingsDialog
+
+    root = _ui_runtime_root("tts_bundle_theme")
+    root.mkdir(parents=True, exist_ok=True)
+    DialogStub = _make_tts_bundle_dialog_stub()
+    monkeypatch.setattr(settings_dialog_module, "TTSBundleDownloadDialog", DialogStub)
+
+    QApplication = qtwidgets.QApplication
+    app = QApplication.instance() or QApplication([])
+    theme = ThemeSettings(
+        primary_color="#123456",
+        accent_color="#654321",
+        text_color="#111111",
+    )
+    dialog = SettingsDialog(
+        api_settings=ApiSettings(
+            base_url="https://api.example.com/v1",
+            api_key="test-key",
+            model="test-model",
+        ),
+        tts_settings=_minimal_tts_settings(),
+        base_dir=root,
+        **_settings_dialog_character_kwargs(root),
+        proactive_care_settings=ProactiveCareSettings(screen_context_enabled=True),
+        mcp_settings=MCPRuntimeSettings(windows_enabled=False),
+        theme_settings=theme,
+    )
+
+    dialog._download_gpt_sovits_bundle()
+    download_dialog = DialogStub.last
+    assert download_dialog is not None
+    assert download_dialog.stylesheets[-1] == dialog.styleSheet()
+    assert "QProgressBar::chunk" in download_dialog.stylesheets[-1]
+    assert "#123456" in download_dialog.stylesheets[-1]
+
+    next_theme = ThemeSettings(
+        primary_color="#abcdef",
+        accent_color="#fedcba",
+        text_color="#222222",
+    )
+    dialog._apply_theme_stylesheet(next_theme)
+
+    assert download_dialog.stylesheets[-1] == build_settings_dialog_stylesheet(next_theme)
+    assert "#abcdef" in download_dialog.stylesheets[-1]
+    dialog.deleteLater()
+    app.processEvents()
+
+
+def test_settings_dialog_tts_bundle_download_uses_secondary_window_callbacks(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    if not hasattr(qtwidgets, "QApplication"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+
+    import app.ui.settings_dialog as settings_dialog_module
+    from app.ui.settings_dialog import SettingsDialog
+
+    root = _ui_runtime_root("tts_bundle_secondary_callbacks")
+    root.mkdir(parents=True, exist_ok=True)
+    DialogStub = _make_tts_bundle_dialog_stub()
+    monkeypatch.setattr(settings_dialog_module, "TTSBundleDownloadDialog", DialogStub)
+    events: list[tuple[str, object]] = []
+
+    QApplication = qtwidgets.QApplication
+    app = QApplication.instance() or QApplication([])
+    dialog = SettingsDialog(
+        api_settings=ApiSettings(
+            base_url="https://api.example.com/v1",
+            api_key="test-key",
+            model="test-model",
+        ),
+        tts_settings=_minimal_tts_settings(),
+        base_dir=root,
+        **_settings_dialog_character_kwargs(root),
+        proactive_care_settings=ProactiveCareSettings(screen_context_enabled=True),
+        mcp_settings=MCPRuntimeSettings(windows_enabled=False),
+        on_prepare_secondary_window=lambda window: events.append(("prepare", window)),
+        on_present_secondary_window=lambda window: events.append(("present", window)),
+        on_release_secondary_window=lambda window: events.append(("release", window)),
+    )
+
+    dialog._download_gpt_sovits_bundle()
+    download_dialog = DialogStub.last
+    assert download_dialog is not None
+    assert events == [("prepare", download_dialog), ("present", download_dialog)]
+    assert download_dialog.show_count == 0
+
+    dialog._download_gpt_sovits_bundle()
+    assert events == [
+        ("prepare", download_dialog),
+        ("present", download_dialog),
+        ("present", download_dialog),
+    ]
+
+    download_dialog.finished.emit(settings_dialog_module.QDialog.DialogCode.Rejected)
+
+    assert events[-1] == ("release", download_dialog)
+    assert dialog._tts_bundle_download_dialog is None
+    assert dialog.tts_bundle_download_button.text() == "一键下载 TTS 整合包"
+    dialog.deleteLater()
+    app.processEvents()
+
+
+def test_settings_dialog_reuses_active_tts_bundle_window_with_secondary_callbacks(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    if not hasattr(qtwidgets, "QApplication"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+
+    import app.ui.settings_dialog as settings_dialog_module
+    from app.ui.settings_dialog import SettingsDialog
+
+    root = _ui_runtime_root("tts_bundle_active_reuse")
+    root.mkdir(parents=True, exist_ok=True)
+    DialogStub = _make_tts_bundle_dialog_stub()
+    active_dialog = DialogStub(root)
+    monkeypatch.setattr(settings_dialog_module, "active_tts_bundle_download_dialog", lambda: active_dialog)
+    monkeypatch.setattr(
+        settings_dialog_module,
+        "TTSBundleDownloadDialog",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("不应新建下载窗口")),
+    )
+    events: list[tuple[str, object]] = []
+
+    QApplication = qtwidgets.QApplication
+    app = QApplication.instance() or QApplication([])
+    dialog = SettingsDialog(
+        api_settings=ApiSettings(
+            base_url="https://api.example.com/v1",
+            api_key="test-key",
+            model="test-model",
+        ),
+        tts_settings=_minimal_tts_settings(),
+        base_dir=root,
+        **_settings_dialog_character_kwargs(root),
+        proactive_care_settings=ProactiveCareSettings(screen_context_enabled=True),
+        mcp_settings=MCPRuntimeSettings(windows_enabled=False),
+        on_prepare_secondary_window=lambda window: events.append(("prepare", window)),
+        on_present_secondary_window=lambda window: events.append(("present", window)),
+    )
+
+    dialog._download_gpt_sovits_bundle()
+
+    assert dialog._tts_bundle_download_dialog is active_dialog
+    assert events == [("prepare", active_dialog), ("present", active_dialog)]
+    assert active_dialog.stylesheets[-1] == dialog.styleSheet()
+    dialog.deleteLater()
+    app.processEvents()
+
+
+def test_settings_dialog_can_close_while_tts_bundle_download_runs(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    if not hasattr(qtwidgets, "QApplication"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+
+    import app.ui.settings_dialog as settings_dialog_module
+    from app.ui.settings_dialog import SettingsDialog
+
+    root = _ui_runtime_root("tts_bundle_close_settings")
+    root.mkdir(parents=True, exist_ok=True)
+
+    QApplication = qtwidgets.QApplication
+    app = QApplication.instance() or QApplication([])
+    dialog = SettingsDialog(
+        api_settings=ApiSettings(
+            base_url="https://api.example.com/v1",
+            api_key="test-key",
+            model="test-model",
+        ),
+        tts_settings=_minimal_tts_settings(),
+        base_dir=root,
+        **_settings_dialog_character_kwargs(root),
+        proactive_care_settings=ProactiveCareSettings(screen_context_enabled=True),
+        mcp_settings=MCPRuntimeSettings(windows_enabled=False),
+    )
+
+    class RunningDownloadStub:
+        def is_download_running(self) -> bool:
+            return True
+
+    dialog._tts_bundle_download_dialog = RunningDownloadStub()  # type: ignore[assignment]
+    monkeypatch.setattr(
+        settings_dialog_module.QMessageBox,
+        "information",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("设置窗口不应阻止关闭")),
+    )
+    finished: list[int] = []
+    dialog.finished.connect(finished.append)
+
+    dialog.reject()
+
+    assert finished == [settings_dialog_module.QDialog.DialogCode.Rejected]
+    dialog.deleteLater()
+    app.processEvents()
+
+
+def test_settings_dialog_download_success_fills_genie_provider(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    if not hasattr(qtwidgets, "QApplication"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+
+    import app.ui.settings_dialog as settings_dialog_module
+    from app.ui.settings_dialog import SettingsDialog
+
+    root = _ui_runtime_root("tts_bundle_ui")
+    root.mkdir(parents=True, exist_ok=True)
+
+    DialogStub = _make_tts_bundle_dialog_stub()
+    monkeypatch.setattr(settings_dialog_module, "TTSBundleDownloadDialog", DialogStub)
+
+    QApplication = qtwidgets.QApplication
+    app = QApplication.instance() or QApplication([])
+    dialog = SettingsDialog(
+        api_settings=ApiSettings(
+            base_url="https://api.example.com/v1",
+            api_key="test-key",
+            model="test-model",
+        ),
+        tts_settings=_minimal_tts_settings(),
+        base_dir=root,
+        **_settings_dialog_character_kwargs(root),
+        proactive_care_settings=ProactiveCareSettings(screen_context_enabled=True),
+        mcp_settings=MCPRuntimeSettings(windows_enabled=False),
+    )
+
+    dialog._download_gpt_sovits_bundle()
+    assert DialogStub.last is not None
+    DialogStub.last.succeeded.emit(
+        _TTSBundleResultStub(root / "tts" / "cpu", provider="genie-tts")
+    )
 
     assert dialog.tts_enabled_check.isChecked()
     assert dialog.tts_provider_combo.currentData() == "genie-tts"
@@ -3840,16 +4138,7 @@ def test_settings_dialog_download_success_fills_macos_gptsovits_paths(monkeypatc
     tts_config_path.parent.mkdir(parents=True, exist_ok=True)
     tts_config_path.write_text("custom: {}", encoding="utf-8")
 
-    class DialogStub:
-        def __init__(self, *_args, **_kwargs) -> None:
-            self.downloaded_work_dir = work_dir
-            self.downloaded_provider = "custom-gpt-sovits"
-            self.downloaded_python_path = python_path
-            self.downloaded_tts_config_path = tts_config_path
-
-        def exec(self):  # type: ignore[no-untyped-def]
-            return settings_dialog_module.QDialog.DialogCode.Accepted
-
+    DialogStub = _make_tts_bundle_dialog_stub()
     monkeypatch.setattr(settings_dialog_module, "TTSBundleDownloadDialog", DialogStub)
 
     QApplication = qtwidgets.QApplication
@@ -3868,6 +4157,15 @@ def test_settings_dialog_download_success_fills_macos_gptsovits_paths(monkeypatc
     )
 
     dialog._download_gpt_sovits_bundle()
+    assert DialogStub.last is not None
+    DialogStub.last.succeeded.emit(
+        _TTSBundleResultStub(
+            work_dir,
+            provider="custom-gpt-sovits",
+            python_path=python_path,
+            tts_config_path=tts_config_path,
+        )
+    )
 
     assert dialog.tts_enabled_check.isChecked()
     assert dialog.tts_provider_combo.currentData() == "custom-gpt-sovits"
@@ -6827,6 +7125,53 @@ def test_registered_secondary_window_suppresses_topmost_and_input_until_hidden()
     assert input_hidden_events == [True, False]
     assert native_sync_events == [True, False]
     assert raise_events == ["raise"]
+
+
+def test_pet_window_syncs_topmost_for_all_registered_secondary_windows(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    import app.ui.pet_window as pet_window_module
+    from app.ui.pet_window import PetWindow
+
+    calls: list[tuple[str, str, bool | None]] = []
+
+    class SecondaryWindowStub:
+        def __init__(self, name: str, visible: bool = True) -> None:
+            self.name = name
+            self.visible = visible
+
+        def isVisible(self) -> bool:  # noqa: N802 - 匹配 Qt 接口名
+            return self.visible
+
+    class Host:
+        _sync_secondary_windows_topmost = PetWindow._sync_secondary_windows_topmost
+        _is_secondary_window_visible = PetWindow._is_secondary_window_visible
+
+        always_on_top_enabled = True
+
+        def __init__(self) -> None:
+            self.first = SecondaryWindowStub("first")
+            self.second = SecondaryWindowStub("second")
+            self.hidden = SecondaryWindowStub("hidden", visible=False)
+            self._registered_secondary_windows = [self.first, self.second, self.hidden]
+
+    monkeypatch.setattr(
+        pet_window_module,
+        "_configure_secondary_window",
+        lambda window, *, keep_on_top: calls.append(("configure", window.name, keep_on_top)),
+    )
+    monkeypatch.setattr(
+        pet_window_module,
+        "_present_secondary_window",
+        lambda window: calls.append(("present", window.name, None)),
+    )
+
+    Host()._sync_secondary_windows_topmost()
+
+    assert calls == [
+        ("configure", "first", True),
+        ("present", "first", None),
+        ("configure", "second", True),
+        ("present", "second", None),
+    ]
 
 
 def test_show_settings_saves_and_applies_subtitle_display_speed(monkeypatch) -> None:  # type: ignore[no-untyped-def]
@@ -10139,6 +10484,7 @@ def _minimal_settings_window(pet_window_cls, settings_service, api_client, memor
         _preview_layout = pet_window_cls._preview_layout
         _prepare_secondary_window = pet_window_cls._prepare_secondary_window
         _present_registered_secondary_window = pet_window_cls._present_registered_secondary_window
+        _release_secondary_window = pet_window_cls._release_secondary_window
         _register_secondary_window = pet_window_cls._register_secondary_window
         _unregister_secondary_window = pet_window_cls._unregister_secondary_window
         _sync_secondary_window_state = pet_window_cls._sync_secondary_window_state

--- a/tests/unit/test_tts_bundle.py
+++ b/tests/unit/test_tts_bundle.py
@@ -23,9 +23,10 @@ from app.voice.tts_bundle import (
 
 
 class FakeResponse:
-    def __init__(self, data: bytes) -> None:
+    def __init__(self, data: bytes, status: int = 200) -> None:
         self._data = data
         self._offset = 0
+        self._status = status
 
     def __enter__(self) -> "FakeResponse":
         return self
@@ -41,6 +42,9 @@ class FakeResponse:
         chunk = self._data[self._offset : self._offset + size]
         self._offset += len(chunk)
         return chunk
+
+    def getcode(self) -> int:
+        return self._status
 
 
 def test_tts_bundle_downloads_to_part_then_verifies_and_extracts() -> None:
@@ -109,7 +113,106 @@ def test_tts_bundle_verifies_cached_archive_with_progress() -> None:
     assert progress[-1] == 100
 
 
-def test_tts_bundle_download_removes_part_on_verification_failure() -> None:
+def test_tts_bundle_resumes_part_download_with_range_request() -> None:
+    root = _runtime_root("bundle_resume")
+    payload = b"sakura-resumable-tts-bundle" * 32
+    prefix = payload[:128]
+    suffix = payload[128:]
+    entry = _entry(payload)
+    archive = root / "tts" / "_dl" / entry.filename
+    archive.parent.mkdir(parents=True, exist_ok=True)
+    archive.with_name(f"{archive.name}.part").write_bytes(prefix)
+    progress: list[tts_bundle.TTSBundleDownloadProgress] = []
+    seen_range: list[str | None] = []
+
+    def fake_urlopen(request, timeout: int):  # type: ignore[no-untyped-def]
+        assert timeout == 600
+        seen_range.append(request.get_header("Range"))
+        return FakeResponse(suffix, status=206)
+
+    def fake_extract(_archive: Path, out_dir: Path) -> str | None:
+        (out_dir / "api_v2.py").write_text("fake", encoding="utf-8")
+        return None
+
+    work_dir = download_and_extract_bundle(
+        entry,
+        root,
+        on_download_progress=progress.append,
+        urlopen=fake_urlopen,
+        extractor=fake_extract,
+    )
+
+    assert work_dir == (root / "tts" / entry.key).resolve()
+    assert seen_range == [f"bytes={len(prefix)}-"]
+    assert any(item.resumed for item in progress)
+    assert not archive.exists()
+    assert not archive.with_name(f"{archive.name}.part").exists()
+
+
+def test_tts_bundle_falls_back_to_full_download_when_range_is_ignored() -> None:
+    root = _runtime_root("bundle_resume_fallback")
+    payload = b"sakura-full-redownload" * 32
+    stale_part = b"stale-partial"
+    entry = _entry(payload)
+    archive = root / "tts" / "_dl" / entry.filename
+    archive.parent.mkdir(parents=True, exist_ok=True)
+    archive.with_name(f"{archive.name}.part").write_bytes(stale_part)
+    progress: list[tts_bundle.TTSBundleDownloadProgress] = []
+    seen_range: list[str | None] = []
+
+    def fake_urlopen(request, timeout: int):  # type: ignore[no-untyped-def]
+        assert timeout == 600
+        seen_range.append(request.get_header("Range"))
+        return FakeResponse(payload, status=200)
+
+    def fake_extract(_archive: Path, out_dir: Path) -> str | None:
+        (out_dir / "api_v2.py").write_text("fake", encoding="utf-8")
+        return None
+
+    work_dir = download_and_extract_bundle(
+        entry,
+        root,
+        on_download_progress=progress.append,
+        urlopen=fake_urlopen,
+        extractor=fake_extract,
+    )
+
+    assert work_dir == (root / "tts" / entry.key).resolve()
+    assert seen_range == [f"bytes={len(stale_part)}-"]
+    assert any(not item.resumed and item.downloaded_bytes == 0 for item in progress)
+    assert not archive.with_name(f"{archive.name}.part").exists()
+
+
+def test_tts_bundle_cancel_preserves_part_for_resume() -> None:
+    root = _runtime_root("bundle_cancel_preserve_part")
+    payload = b"sakura-cancel-resume" * 64
+    entry = _entry(payload)
+    checks = 0
+
+    def fake_urlopen(_request, timeout: int):  # type: ignore[no-untyped-def]
+        assert timeout == 600
+        return FakeResponse(payload)
+
+    def check_cancel() -> None:
+        nonlocal checks
+        checks += 1
+        raise tts_bundle.DownloadCancelledError("pause")
+
+    with pytest.raises(tts_bundle.DownloadCancelledError):
+        download_and_extract_bundle(
+            entry,
+            root,
+            check_cancel=check_cancel,
+            urlopen=fake_urlopen,
+            extractor=lambda *_args: None,
+        )
+
+    archive = root / "tts" / "_dl" / entry.filename
+    assert checks == 1
+    assert archive.with_name(f"{archive.name}.part").read_bytes() == payload
+
+
+def test_tts_bundle_download_preserves_part_on_short_download() -> None:
     root = _runtime_root("bundle_verify_failure")
     payload = b"too-short"
     entry = TTSBundleEntry(
@@ -126,6 +229,30 @@ def test_tts_bundle_download_removes_part_on_verification_failure() -> None:
         return FakeResponse(payload)
 
     with pytest.raises(RuntimeError, match="文件大小不匹配"):
+        download_and_extract_bundle(entry, root, urlopen=fake_urlopen, extractor=lambda *_args: None)
+
+    archive = root / "tts" / "_dl" / entry.filename
+    assert not archive.exists()
+    assert archive.with_name(f"{archive.name}.part").read_bytes() == payload
+
+
+def test_tts_bundle_download_removes_part_on_sha256_failure() -> None:
+    root = _runtime_root("bundle_sha_failure")
+    payload = b"wrong-hash"
+    entry = TTSBundleEntry(
+        key="demo",
+        label="Demo",
+        filename="demo.7z",
+        download_url="https://example.test/demo.7z",
+        size=len(payload),
+        sha256=hashlib.sha256(b"expected").hexdigest(),
+    )
+
+    def fake_urlopen(_request, timeout: int):  # type: ignore[no-untyped-def]
+        assert timeout == 600
+        return FakeResponse(payload)
+
+    with pytest.raises(RuntimeError, match="SHA256 不匹配"):
         download_and_extract_bundle(entry, root, urlopen=fake_urlopen, extractor=lambda *_args: None)
 
     archive = root / "tts" / "_dl" / entry.filename


### PR DESCRIPTION
## 变更内容
- TTS 整合包下载窗口支持后台隐藏、暂停后保留 .part 并续传
- 设置页接管已有下载窗口，下载成功后回填 TTS 配置并显示下载状态
- 下载窗口继承设置主题样式，并接入副窗口置顶管理，避免桌宠置顶时被遮挡
- 补充下载续传、失败清理、弹窗主题和层级管理测试

## 验证
- runtime\python.exe -m pytest tests/unit/test_tts_bundle.py
- runtime\python.exe -m pytest tests/ui/test_pet_window.py -k "tts_bundle or secondary_window or always_on_top"
- runtime\python.exe -m py_compile app/ui/settings_dialog.py app/ui/pet_window.py app/ui/theme.py tests/ui/test_pet_window.py
- git diff --check -- app/ui/settings_dialog.py app/ui/pet_window.py app/ui/theme.py tests/ui/test_pet_window.py

## 备注
- 完整 tests/ui/test_pet_window.py 曾因 Windows pytest 临时目录权限在 3 个 backchannel 用例 setup 阶段失败，其余 242 个用例通过；该问题不是本次改动断言失败。