### PR TITLE
fix: keep input bar active with secondary windows

### DIFF
--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -537,8 +537,7 @@ class PetWindow(QWidget):
         self.always_on_top_enabled = self._load_always_on_top_enabled()
         # 普通副窗口打开期间临时压低桌宠的实际置顶层级，避免副窗口被桌宠盖住；不改变用户配置。
         self._secondary_windows_suppress_topmost = False
-        self._secondary_windows_hide_input_bar = False
-        # 副窗口可见期间暂停桌宠后台 hover 轮询，减少与副窗口下拉弹层抢占合成器。
+        # 副窗口可见期间暂停桌宠气泡后台 hover 轮询，减少与副窗口下拉弹层抢占合成器。
         self._secondary_windows_background_quiesced = False
         self._registered_secondary_windows: set[QWidget] = set()
         self.history_window: HistoryWindow | None = None
@@ -1521,11 +1520,11 @@ class PetWindow(QWidget):
         controller = getattr(self, "bubble_auto_hide", None)
         if controller is not None:
             controller.handle_pet_clicked()
-        # 无副窗口/对话框占用且模型未在思考时，让输入栏现身并把焦点移入输入框。
+        # 模型未在思考时，让输入栏现身并把焦点移入输入框。
         # 先 set_force_visible(True) 使 input_card 同步 show()（hidden widget 无法接收焦点），
         # 设完焦点后立即释放 force_visible——_input_bar_pinned 会通过焦点继续维持可见。
         # 思考中不浮现：避免用户点击桌宠时反而让输入栏被焦点固定、无法随思考态收起。
-        if not self._any_dialog_open() and not getattr(self, "reply_waiting_ui_active", False):
+        if not getattr(self, "reply_waiting_ui_active", False):
             animator = getattr(self, "input_bar_animator", None)
             input_edit = getattr(self, "input_edit", None)
             if animator is not None:
@@ -2228,16 +2227,6 @@ class PetWindow(QWidget):
             if self._is_secondary_window_visible(dialog):
                 dialog.raise_()
 
-    def _any_dialog_open(self) -> bool:
-        for dialog in (
-            getattr(self, "settings_dialog", None),
-            getattr(self, "history_window", None),
-            getattr(self, "runtime_log_window", None),
-        ):
-            if self._is_secondary_window_visible(dialog):
-                return True
-        return False
-
     def _update_tray_icon_pixmap(self, pixmap: QPixmap) -> None:
         _ = pixmap
         if hasattr(self, "tray_icon"):
@@ -2509,9 +2498,6 @@ class PetWindow(QWidget):
         return make_blurred_pixmap(cropped, radius=4.0, downscale=2)
 
     def _cursor_in_pet_region(self) -> bool:
-        # 普通副窗口打开时禁用输入栏浮现，避免盖住对话框。
-        if self._any_dialog_open():
-            return False
         if not self._input_bar_foreground_allowed():
             return False
         # 单窗口重构后气泡/输入栏已并入主窗口，主窗口几何即桌宠整体区域；
@@ -2578,9 +2564,6 @@ class PetWindow(QWidget):
         注意：不把「对话进行中(active_interaction_id)」和「等待模型回复」算进来；
         思考中只更新输入区状态，不强制输入栏常显。
         """
-        # 设置/历史窗口打开时不固定输入栏，配合 hover 禁用一起彻底收起。
-        if self._any_dialog_open():
-            return False
         if not self._input_bar_foreground_allowed():
             return False
         return (
@@ -5755,7 +5738,6 @@ class PetWindow(QWidget):
     def _present_registered_secondary_window(self, window: QWidget) -> None:
         """打开已登记的普通副窗口，并在显示前临时取消桌宠实际置顶。"""
         self._set_secondary_windows_topmost_suppressed(True)
-        self._set_secondary_windows_input_bar_hidden(True)
         _present_secondary_window(window)
         self._sync_secondary_window_state()
 
@@ -5792,7 +5774,6 @@ class PetWindow(QWidget):
             for window in tuple(getattr(self, "_registered_secondary_windows", set()))
         )
         self._set_secondary_windows_topmost_suppressed(has_visible_secondary_window)
-        self._set_secondary_windows_input_bar_hidden(has_visible_secondary_window)
         set_background_quiesced = getattr(
             self,
             "_set_secondary_windows_background_quiesced",
@@ -5802,22 +5783,19 @@ class PetWindow(QWidget):
             set_background_quiesced(has_visible_secondary_window)
 
     def _set_secondary_windows_background_quiesced(self, quiesced: bool) -> None:
-        """副窗口可见期间暂停桌宠后台 hover 轮询，关闭后恢复。
+        """副窗口可见期间暂停气泡后台 hover 轮询，关闭后恢复。
 
-        设置/历史/日志窗口打开时输入栏已被强制隐藏、hover 也不生效，此时轮询纯属
-        无谓的原生命中测试与重绘，会与副窗口（尤其设置里的下拉弹层）抢占合成器。
-        仅停/起轮询计时器，零视觉变化。
+        输入栏不能被副窗口占用，仍需持续 hover 轮询；这里只让气泡自动隐藏控制器安静。
         """
         quiesced = bool(quiesced)
         if quiesced == bool(getattr(self, "_secondary_windows_background_quiesced", False)):
             return
         self._secondary_windows_background_quiesced = quiesced
         polling_enabled = not quiesced
-        for controller_attr in ("input_bar_animator", "bubble_auto_hide"):
-            controller = getattr(self, controller_attr, None)
-            set_polling_enabled = getattr(controller, "set_polling_enabled", None)
-            if callable(set_polling_enabled):
-                set_polling_enabled(polling_enabled)
+        controller = getattr(self, "bubble_auto_hide", None)
+        set_polling_enabled = getattr(controller, "set_polling_enabled", None)
+        if callable(set_polling_enabled):
+            set_polling_enabled(polling_enabled)
 
     def _is_secondary_window_visible(self, window: object | None) -> bool:
         if window is None:
@@ -5829,17 +5807,6 @@ class PetWindow(QWidget):
             except RuntimeError:
                 return False
         return bool(getattr(window, "visible", False))
-
-    def _set_secondary_windows_input_bar_hidden(self, hidden: bool) -> None:
-        """副窗口打开期间强制隐藏输入栏，避免输入区挡住副窗口。"""
-        hidden = bool(hidden)
-        if hidden == bool(getattr(self, "_secondary_windows_hide_input_bar", False)):
-            return
-        self._secondary_windows_hide_input_bar = hidden
-        input_bar_animator = getattr(self, "input_bar_animator", None)
-        set_force_hidden = getattr(input_bar_animator, "set_force_hidden", None)
-        if callable(set_force_hidden):
-            set_force_hidden(hidden)
 
     def _set_secondary_windows_topmost_suppressed(self, suppressed: bool) -> None:
         """副窗口存活期间临时取消桌宠原生置顶，关闭后按用户配置恢复。"""

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -296,7 +296,6 @@ def test_show_runtime_log_uses_non_modal_show(monkeypatch) -> None:  # type: ign
 
     class Host(qtwidgets.QWidget):
         show_runtime_log = pet_window_module.PetWindow.show_runtime_log
-        _any_dialog_open = pet_window_module.PetWindow._any_dialog_open
         _prepare_secondary_window = pet_window_module.PetWindow._prepare_secondary_window
         _present_registered_secondary_window = (
             pet_window_module.PetWindow._present_registered_secondary_window
@@ -304,9 +303,6 @@ def test_show_runtime_log_uses_non_modal_show(monkeypatch) -> None:  # type: ign
         _register_secondary_window = pet_window_module.PetWindow._register_secondary_window
         _sync_secondary_window_state = pet_window_module.PetWindow._sync_secondary_window_state
         _is_secondary_window_visible = pet_window_module.PetWindow._is_secondary_window_visible
-        _set_secondary_windows_input_bar_hidden = (
-            pet_window_module.PetWindow._set_secondary_windows_input_bar_hidden
-        )
         _set_secondary_windows_topmost_suppressed = (
             pet_window_module.PetWindow._set_secondary_windows_topmost_suppressed
         )
@@ -324,7 +320,6 @@ def test_show_runtime_log_uses_non_modal_show(monkeypatch) -> None:  # type: ign
 
     assert events == ["theme", "refresh:True", "show", "raise", "activate"]
     assert host.runtime_log_window.kwargs["parent"] is host
-    assert host._any_dialog_open() is True
 
     host.deleteLater()
     app.processEvents()
@@ -6701,13 +6696,12 @@ def test_show_settings_reuses_active_dialog_from_tray(monkeypatch) -> None:  # t
     assert getattr(window, "settings_dialog", None) is not None
 
 
-def test_show_settings_hides_input_bar_and_temporarily_suppresses_topmost_without_reapplying_flags(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_show_settings_temporarily_suppresses_topmost_without_reapplying_flags(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     import app.ui.pet_window as pet_window_module
     from app.ui.pet_window import PetWindow
 
     api_settings = ApiSettings("https://api.example.com/v1", "test-key", "test-model")
     tts_settings = _minimal_tts_settings()
-    input_hidden_events: list[bool] = []
     native_sync_events: list[bool] = []
     apply_flag_events: list[str] = []
     raise_events: list[str] = []
@@ -6722,10 +6716,6 @@ def test_show_settings_hides_input_bar_and_temporarily_suppresses_topmost_withou
     class MemoryStoreStub:
         pass
 
-    class InputBarAnimatorStub:
-        def set_force_hidden(self, value: bool) -> None:
-            input_hidden_events.append(value)
-
     class DialogStub(_NonModalSettingsDialogStub):
         _dialog_result = pet_window_module.QDialog.DialogCode.Rejected
 
@@ -6736,7 +6726,6 @@ def test_show_settings_hides_input_bar_and_temporarily_suppresses_topmost_withou
         MemoryStoreStub(),
     )
     window.always_on_top_enabled = True
-    window.input_bar_animator = InputBarAnimatorStub()
     window._sync_native_topmost_state = (
         lambda: native_sync_events.append(window._secondary_windows_suppress_topmost)
     )
@@ -6747,24 +6736,18 @@ def test_show_settings_hides_input_bar_and_temporarily_suppresses_topmost_withou
 
     window.show_settings()
 
-    assert input_hidden_events == [True, False]
     assert native_sync_events == [True, False]
     assert apply_flag_events == []
     assert raise_events == ["raise"]
     assert window._secondary_windows_suppress_topmost is False
 
 
-def test_registered_secondary_window_suppresses_topmost_and_input_until_hidden() -> None:
+def test_registered_secondary_window_suppresses_topmost_until_hidden() -> None:
     import app.ui.pet_window as pet_window_module
     from app.ui.pet_window import PetWindow
 
-    input_hidden_events: list[bool] = []
     native_sync_events: list[bool] = []
     raise_events: list[str] = []
-
-    class InputBarAnimatorStub:
-        def set_force_hidden(self, value: bool) -> None:
-            input_hidden_events.append(value)
 
     class SecondaryWindowStub:
         visible = False
@@ -6792,16 +6775,13 @@ def test_registered_secondary_window_suppresses_topmost_and_input_until_hidden()
         _register_secondary_window = PetWindow._register_secondary_window
         _sync_secondary_window_state = PetWindow._sync_secondary_window_state
         _is_secondary_window_visible = PetWindow._is_secondary_window_visible
-        _set_secondary_windows_input_bar_hidden = PetWindow._set_secondary_windows_input_bar_hidden
         _set_secondary_windows_topmost_suppressed = PetWindow._set_secondary_windows_topmost_suppressed
 
         always_on_top_enabled = True
-        input_bar_animator = InputBarAnimatorStub()
 
         def __init__(self) -> None:
             self._registered_secondary_windows = set()
             self._secondary_windows_suppress_topmost = False
-            self._secondary_windows_hide_input_bar = False
 
         def _sync_native_topmost_state(self) -> None:
             native_sync_events.append(self._secondary_windows_suppress_topmost)
@@ -6818,15 +6798,45 @@ def test_registered_secondary_window_suppresses_topmost_and_input_until_hidden()
     host._register_secondary_window(window)  # type: ignore[arg-type]
     host._present_registered_secondary_window(window)  # type: ignore[arg-type]
 
-    assert input_hidden_events == [True]
     assert native_sync_events == [True]
 
     window.visible = False
     host._sync_secondary_window_state()
 
-    assert input_hidden_events == [True, False]
     assert native_sync_events == [True, False]
     assert raise_events == ["raise"]
+
+
+def test_secondary_window_quiesce_leaves_input_bar_polling_enabled() -> None:
+    from app.ui.pet_window import PetWindow
+
+    input_polling_events: list[bool] = []
+    bubble_polling_events: list[bool] = []
+
+    class ControllerStub:
+        def __init__(self, events: list[bool]) -> None:
+            self._events = events
+
+        def set_polling_enabled(self, enabled: bool) -> None:
+            self._events.append(enabled)
+
+    class Host:
+        _set_secondary_windows_background_quiesced = (
+            PetWindow._set_secondary_windows_background_quiesced
+        )
+
+        def __init__(self) -> None:
+            self._secondary_windows_background_quiesced = False
+            self.input_bar_animator = ControllerStub(input_polling_events)
+            self.bubble_auto_hide = ControllerStub(bubble_polling_events)
+
+    host = Host()
+
+    host._set_secondary_windows_background_quiesced(True)
+    host._set_secondary_windows_background_quiesced(False)
+
+    assert input_polling_events == []
+    assert bubble_polling_events == [False, True]
 
 
 def test_show_settings_saves_and_applies_subtitle_display_speed(monkeypatch) -> None:  # type: ignore[no-untyped-def]
@@ -8818,7 +8828,6 @@ def test_input_bar_not_pinned_just_because_reply_is_waiting() -> None:
 
     class MinimalInputBarWindow:
         _input_bar_pinned = PetWindow._input_bar_pinned
-        _any_dialog_open = lambda _self: False
         _input_bar_foreground_allowed = lambda _self: True
 
     window = MinimalInputBarWindow()
@@ -8831,6 +8840,27 @@ def test_input_bar_not_pinned_just_because_reply_is_waiting() -> None:
     window.reply_waiting_ui_active = True
 
     assert not window._input_bar_pinned()
+
+
+def test_input_bar_pinned_ignores_visible_secondary_window() -> None:
+    from app.ui.pet_window import PetWindow
+
+    class MinimalInputBarWindow:
+        _input_bar_pinned = PetWindow._input_bar_pinned
+        _input_bar_foreground_allowed = lambda _self: True
+        settings_dialog = object()
+        history_window = None
+        runtime_log_window = None
+
+        def _is_secondary_window_visible(self, _window) -> bool:  # type: ignore[no-untyped-def]
+            return True
+
+    window = MinimalInputBarWindow()
+    window.input_edit = _DummyEditableInput("未发送文本")
+    window.pending_tool_action = None
+    window.reply_waiting_ui_active = False
+
+    assert window._input_bar_pinned()
 
 
 def test_progress_reply_displays_and_records_assistant_message() -> None:
@@ -10143,9 +10173,6 @@ def _minimal_settings_window(pet_window_cls, settings_service, api_client, memor
         _unregister_secondary_window = pet_window_cls._unregister_secondary_window
         _sync_secondary_window_state = pet_window_cls._sync_secondary_window_state
         _is_secondary_window_visible = pet_window_cls._is_secondary_window_visible
-        _set_secondary_windows_input_bar_hidden = (
-            pet_window_cls._set_secondary_windows_input_bar_hidden
-        )
         _set_secondary_windows_topmost_suppressed = (
             pet_window_cls._set_secondary_windows_topmost_suppressed
         )
@@ -10782,9 +10809,6 @@ def test_cursor_in_pet_region_requires_exposed_pet_window(monkeypatch) -> None: 
         _input_bar_foreground_allowed = PetWindow._input_bar_foreground_allowed
         always_on_top_enabled = True
 
-        def _any_dialog_open(self) -> bool:
-            return False
-
         def isVisible(self) -> bool:  # noqa: N802 - Qt API 兼容命名。
             return True
 
@@ -10817,9 +10841,12 @@ def test_cursor_in_pet_region_accepts_exposed_child_widget(monkeypatch) -> None:
         _cursor_over_exposed_pet_window = PetWindow._cursor_over_exposed_pet_window
         _input_bar_foreground_allowed = PetWindow._input_bar_foreground_allowed
         always_on_top_enabled = True
+        settings_dialog = object()
+        history_window = None
+        runtime_log_window = None
 
-        def _any_dialog_open(self) -> bool:
-            return False
+        def _is_secondary_window_visible(self, _window) -> bool:  # type: ignore[no-untyped-def]
+            return True
 
         def isVisible(self) -> bool:  # noqa: N802 - Qt API 兼容命名。
             return True
@@ -10857,9 +10884,6 @@ def test_cursor_in_pet_region_blocks_non_topmost_background_window(monkeypatch) 
         _input_bar_foreground_allowed = PetWindow._input_bar_foreground_allowed
         _is_pet_foreground_window = PetWindow._is_pet_foreground_window
         always_on_top_enabled = False
-
-        def _any_dialog_open(self) -> bool:
-            return False
 
         def isVisible(self) -> bool:  # noqa: N802 - Qt API 兼容命名。
             return True
@@ -10902,9 +10926,6 @@ def test_cursor_in_pet_region_allows_non_topmost_foreground_window(monkeypatch) 
         _input_bar_foreground_allowed = PetWindow._input_bar_foreground_allowed
         _is_pet_foreground_window = PetWindow._is_pet_foreground_window
         always_on_top_enabled = False
-
-        def _any_dialog_open(self) -> bool:
-            return False
 
         def isVisible(self) -> bool:  # noqa: N802 - Qt API 兼容命名。
             return True
@@ -10950,9 +10971,6 @@ def test_input_bar_pinned_requires_foreground_when_not_topmost() -> None:
         input_edit = InputStub()
         reply_waiting_ui_active = False
         pending_tool_action = None
-
-        def _any_dialog_open(self) -> bool:
-            return False
 
         def _is_pet_foreground_window(self) -> bool:
             return False


### PR DESCRIPTION
## Summary
- stop secondary windows from force-hiding the input bar
- keep input-bar hover polling active while settings/history/log windows are open
- keep secondary-window topmost suppression behavior unchanged

## Tests
- python -m pytest tests\ui\test_pet_window.py tests\ui\test_input_bar_animator.py -k "secondary_window or input_bar or force_visible" -q
