### PR TITLE
feat: add Windows auto updater

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -69,10 +69,31 @@ jobs:
 
       - name: Create bundle archive
         shell: pwsh
-        # 显式排除 data/：发布包绝不携带用户数据目录，覆盖解压才不会冲掉用户配置
+        # 白名单打包：只放运行软件需要的内容，不带测试、文档、仓库配置和示例图片。
         run: |
-          $items = Get-ChildItem -Exclude 'data', '*.zip' | ForEach-Object { $_.Name }
-          Compress-Archive -Path $items -DestinationPath "$env:BUNDLE_ARCHIVE" -Force
+          $items = @(
+            'app',
+            'plugins',
+            'runtime',
+            'third_party',
+            'tools',
+            'install.bat',
+            'LICENSE',
+            'main.py',
+            'requirements.txt',
+            'start.bat',
+            'start_studio.bat',
+            'update.bat',
+            'VERSION'
+          ) | Where-Object { Test-Path -LiteralPath $_ }
+          $stage = New-Item -ItemType Directory -Path "bundle-stage" -Force
+          foreach ($item in $items) {
+            Copy-Item -LiteralPath $item -Destination $stage.FullName -Recurse -Force
+          }
+          Get-ChildItem -LiteralPath $stage.FullName -Recurse -Force -Directory -Filter '__pycache__' | Remove-Item -Recurse -Force
+          Get-ChildItem -LiteralPath $stage.FullName -Recurse -Force -Include '*.pyc','*.pyo','*.log' | Remove-Item -Force
+          Remove-Item -LiteralPath (Join-Path $stage.FullName 'tools/_write_test.py') -Force -ErrorAction SilentlyContinue
+          Compress-Archive -Path (Join-Path $stage.FullName '*') -DestinationPath "$env:BUNDLE_ARCHIVE" -Force
 
       - name: Upload package artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,7 @@ jobs:
           - os: windows-latest
             platform: windows-x64
             artifact: sakura-${{ needs.tag.outputs.TAG }}-windows-x64.zip
+            update_artifact: sakura-${{ needs.tag.outputs.TAG }}-windows-x64-update.zip
             runtime_artifact: runtime-windows-x64.zip
             embed_url: https://www.python.org/ftp/python/3.12.8/python-3.12.8-embed-amd64.zip
     runs-on: ${{ matrix.os }}
@@ -198,12 +199,77 @@ jobs:
       - name: Create bundle archive (Windows)
         if: matrix.platform == 'windows-x64'
         shell: pwsh
-        run: Compress-Archive -Path * -DestinationPath "${{ matrix.artifact }}" -Force
+        run: |
+          $items = @(
+            'app',
+            'plugins',
+            'runtime',
+            'third_party',
+            'tools',
+            'install.bat',
+            'LICENSE',
+            'main.py',
+            'requirements.txt',
+            'start.bat',
+            'start_studio.bat',
+            'update.bat',
+            'VERSION'
+          ) | Where-Object { Test-Path -LiteralPath $_ }
+          $stage = New-Item -ItemType Directory -Path "bundle-stage" -Force
+          foreach ($item in $items) {
+            Copy-Item -LiteralPath $item -Destination $stage.FullName -Recurse -Force
+          }
+          Get-ChildItem -LiteralPath $stage.FullName -Recurse -Force -Directory -Filter '__pycache__' | Remove-Item -Recurse -Force
+          Get-ChildItem -LiteralPath $stage.FullName -Recurse -Force -Include '*.pyc','*.pyo','*.log' | Remove-Item -Force
+          Remove-Item -LiteralPath (Join-Path $stage.FullName 'tools/_write_test.py') -Force -ErrorAction SilentlyContinue
+          Compress-Archive -Path (Join-Path $stage.FullName '*') -DestinationPath "${{ matrix.artifact }}" -Force
+
+      - name: Create update archive (Windows)
+        if: matrix.platform == 'windows-x64'
+        shell: pwsh
+        run: |
+          $items = @(
+            'app',
+            'plugins',
+            'third_party',
+            'tools',
+            'install.bat',
+            'LICENSE',
+            'main.py',
+            'requirements.txt',
+            'start.bat',
+            'start_studio.bat',
+            'update.bat',
+            'VERSION'
+          ) | Where-Object { Test-Path -LiteralPath $_ }
+          $stage = New-Item -ItemType Directory -Path "update-stage" -Force
+          foreach ($item in $items) {
+            Copy-Item -LiteralPath $item -Destination $stage.FullName -Recurse -Force
+          }
+          Get-ChildItem -LiteralPath $stage.FullName -Recurse -Force -Directory -Filter '__pycache__' | Remove-Item -Recurse -Force
+          Get-ChildItem -LiteralPath $stage.FullName -Recurse -Force -Include '*.pyc','*.pyo','*.log' | Remove-Item -Force
+          Remove-Item -LiteralPath (Join-Path $stage.FullName 'tools/_write_test.py') -Force -ErrorAction SilentlyContinue
+          Compress-Archive -Path (Join-Path $stage.FullName '*') -DestinationPath "${{ matrix.update_artifact }}" -Force
 
       - name: Create runtime archive (Windows)
         if: matrix.platform == 'windows-x64'
         shell: pwsh
         run: Compress-Archive -Path runtime -DestinationPath "${{ matrix.runtime_artifact }}" -Force
+
+      - name: Create update manifest (Windows)
+        if: matrix.platform == 'windows-x64'
+        shell: pwsh
+        run: |
+          $version = (Get-Content VERSION -First 1).Trim().TrimStart('v')
+          $sha256 = (Get-FileHash "${{ matrix.update_artifact }}" -Algorithm SHA256).Hash.ToLowerInvariant()
+          $manifest = [ordered]@{
+            version = $version
+            tag = "${{ needs.tag.outputs.TAG }}"
+            prerelease = [System.Boolean]::Parse("${{ needs.tag.outputs.PRERELEASE }}")
+            windows_x64_update_url = "https://github.com/Rvosy/sakura/releases/download/${{ needs.tag.outputs.TAG }}/${{ matrix.update_artifact }}"
+            sha256 = $sha256
+          }
+          $manifest | ConvertTo-Json | Set-Content -Path sakura-update.json -Encoding utf8NoBOM
 
       - name: Create runtime archive (macOS)
         if: matrix.platform != 'windows-x64'
@@ -214,10 +280,11 @@ jobs:
         if: matrix.platform != 'windows-x64'
         shell: bash
         run: |
-          zip -rq "${{ matrix.artifact }}" . \
-            -x '.git/*' '*.pyc' '__pycache__/*' \
-            'data/tts_bundles/*' '*.egg-info/*' '*.dist-info/*' \
-            'tests/*' 'pytest.ini'
+          zip -rq "${{ matrix.artifact }}" \
+            app plugins runtime third_party tools \
+            LICENSE main.py requirements.txt VERSION \
+            scripts/install.sh scripts/start.sh install.command start.command \
+            -x '*.pyc' '*/__pycache__/*' '*.egg-info/*' '*.dist-info/*' 'tools/_write_test.py'
 
       - name: Upload to release
         uses: softprops/action-gh-release@v2
@@ -225,7 +292,23 @@ jobs:
           tag_name: ${{ needs.tag.outputs.TAG }}
           files: |
             ${{ matrix.artifact }}
+            ${{ matrix.update_artifact }}
             ${{ matrix.runtime_artifact }}
+
+      - name: Upload update manifest to sakura-assets
+        if: matrix.platform == 'windows-x64'
+        env:
+          GH_TOKEN: ${{ secrets.SAKURA_ASSETS_TOKEN }}
+        shell: bash
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "SAKURA_ASSETS_TOKEN is required to publish sakura-update.json"
+            exit 1
+          fi
+          gh release upload assets-latest \
+            sakura-update.json \
+            --repo Rvosy/sakura-assets \
+            --clobber
 
   attach-assets:
     needs: [tag, release, bundle]

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import uuid
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from tools import update
+
+
+class FakeResponse:
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+        self._offset = 0
+
+    def __enter__(self) -> "FakeResponse":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def read(self, size: int = -1) -> bytes:
+        if self._offset >= len(self._data):
+            return b""
+        if size < 0:
+            size = len(self._data) - self._offset
+        chunk = self._data[self._offset : self._offset + size]
+        self._offset += len(chunk)
+        return chunk
+
+
+def test_fetch_manifest_validates_required_fields() -> None:
+    def fake_urlopen(_request, timeout: int):  # type: ignore[no-untyped-def]
+        assert timeout == 30
+        return FakeResponse(b'{"version":"1.0.0"}')
+
+    with pytest.raises(update.UpdateError, match="缺少必要字段"):
+        update.fetch_manifest(urlopen=fake_urlopen)
+
+
+def test_update_check_reports_latest() -> None:
+    tmp_path = _runtime_root("check_latest")
+    (tmp_path / "VERSION").write_text("1.0.0\n", encoding="utf-8")
+    manifest = _manifest("1.0.0", b"unused")
+    out = io.StringIO()
+
+    result = update.run_update(
+        tmp_path,
+        check_only=True,
+        urlopen=_urlopen_for_manifest(manifest),
+        out=out,
+    )
+
+    assert result == 0
+    assert "当前已是最新版本" in out.getvalue()
+
+
+def test_update_check_reports_newer_prerelease() -> None:
+    tmp_path = _runtime_root("check_newer_prerelease")
+    (tmp_path / "VERSION").write_text("1.0.0-dev\n", encoding="utf-8")
+    manifest = _manifest("1.0.0", b"unused")
+    out = io.StringIO()
+
+    result = update.run_update(
+        tmp_path,
+        check_only=True,
+        urlopen=_urlopen_for_manifest(manifest),
+        out=out,
+    )
+
+    assert result == 0
+    assert "发现新版本：1.0.0-dev -> 1.0.0" in out.getvalue()
+
+
+def test_download_file_rejects_sha256_mismatch() -> None:
+    tmp_path = _runtime_root("sha_mismatch")
+
+    def fake_urlopen(_request, timeout: int):  # type: ignore[no-untyped-def]
+        assert timeout == 600
+        return FakeResponse(b"bad")
+
+    with pytest.raises(update.UpdateError, match="sha256"):
+        update.download_file(
+            "https://example.test/update.zip",
+            tmp_path / "update.zip",
+            expected_sha256="0" * 64,
+            urlopen=fake_urlopen,
+        )
+    assert not (tmp_path / "update.zip.part").exists()
+
+
+def test_format_user_error_keeps_raw_error_and_solution() -> None:
+    message = update.format_user_error(update.UpdateError("下载更新清单失败：HTTP Error 404: Not Found"))
+
+    assert "可能原因" in message
+    assert "解决办法" in message
+    assert "--------------" in message
+    assert "原始报错" not in message
+    assert "HTTP Error 404: Not Found" in message
+    assert "sakura-update.json" in message
+
+
+def test_format_user_error_explains_dependency_failure() -> None:
+    error = update.subprocess.CalledProcessError(1, ["python", "-m", "pip", "install"])
+    message = update.format_user_error(error)
+
+    assert "依赖安装失败" in message
+    assert "install.bat" in message
+    assert "returned non-zero exit status 1" in message
+
+
+def test_apply_update_archive_skips_user_paths() -> None:
+    tmp_path = _runtime_root("skip_user_paths")
+    archive = tmp_path / "update.zip"
+    _write_zip(
+        archive,
+        {
+            "VERSION": "1.1.0\n",
+            "app/new.py": "new",
+            "assets/setup_01.webp": "replace",
+            "data/config/api.yaml": "replace",
+            "docs/SETUP.md": "replace",
+            "runtime/python.exe": "replace",
+            "characters/user.txt": "replace",
+            "tts/model.bin": "replace",
+            "plugins/playwright_browser/config.json": "replace",
+        },
+    )
+    (tmp_path / "data/config").mkdir(parents=True)
+    (tmp_path / "data/config/api.yaml").write_text("keep", encoding="utf-8")
+    (tmp_path / "assets").mkdir()
+    (tmp_path / "assets/setup_01.webp").write_text("keep", encoding="utf-8")
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs/SETUP.md").write_text("keep", encoding="utf-8")
+    (tmp_path / "runtime").mkdir()
+    (tmp_path / "runtime/python.exe").write_text("keep", encoding="utf-8")
+    (tmp_path / "characters").mkdir()
+    (tmp_path / "characters/user.txt").write_text("keep", encoding="utf-8")
+    (tmp_path / "tts").mkdir()
+    (tmp_path / "tts/model.bin").write_text("keep", encoding="utf-8")
+    (tmp_path / "plugins/playwright_browser").mkdir(parents=True)
+    (tmp_path / "plugins/playwright_browser/config.json").write_text("keep", encoding="utf-8")
+
+    written = update.apply_update_archive(archive, tmp_path)
+
+    assert tmp_path / "app/new.py" in written
+    assert (tmp_path / "app/new.py").read_text(encoding="utf-8") == "new"
+    assert (tmp_path / "assets/setup_01.webp").read_text(encoding="utf-8") == "keep"
+    assert (tmp_path / "data/config/api.yaml").read_text(encoding="utf-8") == "keep"
+    assert (tmp_path / "docs/SETUP.md").read_text(encoding="utf-8") == "keep"
+    assert (tmp_path / "runtime/python.exe").read_text(encoding="utf-8") == "keep"
+    assert (tmp_path / "characters/user.txt").read_text(encoding="utf-8") == "keep"
+    assert (tmp_path / "tts/model.bin").read_text(encoding="utf-8") == "keep"
+    assert (tmp_path / "plugins/playwright_browser/config.json").read_text(encoding="utf-8") == "keep"
+
+
+def test_run_update_installs_dependencies_only_when_requirements_changed() -> None:
+    tmp_path = _runtime_root("requirements_changed")
+    (tmp_path / "VERSION").write_text("1.0.0\n", encoding="utf-8")
+    (tmp_path / "requirements.txt").write_text("old\n", encoding="utf-8")
+    (tmp_path / "runtime").mkdir()
+    (tmp_path / "runtime/python.exe").write_text("fake", encoding="utf-8")
+    archive = _zip_bytes({"VERSION": "1.1.0\n", "requirements.txt": "new\n"})
+    manifest = _manifest("1.1.0", archive)
+    installs: list[Path] = []
+
+    result = update.run_update(
+        tmp_path,
+        urlopen=_urlopen_for_manifest_and_archive(manifest, archive),
+        out=io.StringIO(),
+        running_check=lambda _base: False,
+        dependency_installer=lambda base, _python: installs.append(base),
+    )
+
+    assert result == 0
+    assert (tmp_path / "requirements.txt").read_text(encoding="utf-8") == "new\n"
+    assert installs == [tmp_path.resolve()]
+
+
+def _manifest(version: str, archive: bytes) -> bytes:
+    return json.dumps(
+        {
+            "version": version,
+            "tag": f"v{version}",
+            "prerelease": "-" in version,
+            "windows_x64_update_url": "https://example.test/update.zip",
+            "sha256": hashlib.sha256(archive).hexdigest(),
+        }
+    ).encode("utf-8")
+
+
+def _urlopen_for_manifest(manifest: bytes):  # type: ignore[no-untyped-def]
+    def fake_urlopen(request, _timeout=None, timeout=None):  # type: ignore[no-untyped-def]
+        assert "sakura-update.json" in getattr(request, "full_url", str(request))
+        return FakeResponse(manifest)
+
+    return fake_urlopen
+
+
+def _urlopen_for_manifest_and_archive(manifest: bytes, archive: bytes):  # type: ignore[no-untyped-def]
+    def fake_urlopen(request, _timeout=None, timeout=None):  # type: ignore[no-untyped-def]
+        url = getattr(request, "full_url", str(request))
+        if url.endswith("update.zip"):
+            return FakeResponse(archive)
+        return FakeResponse(manifest)
+
+    return fake_urlopen
+
+
+def _write_zip(path: Path, files: dict[str, str]) -> None:
+    with zipfile.ZipFile(path, "w") as zf:
+        for name, content in files.items():
+            zf.writestr(name, content)
+
+
+def _zip_bytes(files: dict[str, str]) -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as zf:
+        for name, content in files.items():
+            zf.writestr(name, content)
+    return buffer.getvalue()
+
+
+def _runtime_root(name: str) -> Path:
+    root = Path(__file__).resolve().parents[2] / "__pycache__" / "test_runtime" / "update" / name / uuid.uuid4().hex
+    root.mkdir(parents=True, exist_ok=True)
+    return root

--- a/tools/update.py
+++ b/tools/update.py
@@ -1,0 +1,446 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import urllib.request
+import uuid
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Callable, TextIO
+
+
+MANIFEST_URL = "https://github.com/Rvosy/sakura-assets/releases/download/assets-latest/sakura-update.json"
+USER_AGENT = "SakuraUpdater/1.0"
+CHUNK_SIZE = 1024 * 1024
+SKIP_ROOTS = {
+    ".agents",
+    ".git",
+    ".github",
+    ".mypy_cache",
+    ".playwright-mcp",
+    ".pytest_cache",
+    ".ruff_cache",
+    "__pycache__",
+    "assets",
+    "characters",
+    "data",
+    "docs",
+    "runtime",
+    "scripts",
+    "spec",
+    "temp",
+    "tests",
+    "tts",
+}
+SKIP_FILES = {
+    ("plugins", "playwright_browser", "config.json"),
+}
+
+
+class UpdateError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class UpdateManifest:
+    version: str
+    tag: str
+    prerelease: bool
+    windows_x64_update_url: str
+    sha256: str
+
+
+def read_local_version(base_dir: Path) -> str:
+    try:
+        text = (base_dir / "VERSION").read_text(encoding="utf-8")
+    except OSError as exc:
+        raise UpdateError("未找到 VERSION，无法判断当前版本。") from exc
+    version = text.splitlines()[0].strip() if text.strip() else ""
+    if not version:
+        raise UpdateError("VERSION 为空，无法判断当前版本。")
+    return normalize_version(version)
+
+
+def normalize_version(version: str) -> str:
+    return str(version).strip().lstrip("v").strip()
+
+
+def version_key(version: str) -> tuple[int, int, int, int, int]:
+    clean = normalize_version(version)
+    core, sep, _suffix = clean.partition("-")
+    nums = []
+    for part in core.split("."):
+        if part.isdigit():
+            nums.append(int(part))
+        else:
+            digits = "".join(ch for ch in part if ch.isdigit())
+            nums.append(int(digits or 0))
+    while len(nums) < 4:
+        nums.append(0)
+    return (*nums[:4], -1 if sep else 0)
+
+
+def is_newer(remote_version: str, local_version: str) -> bool:
+    return version_key(remote_version) > version_key(local_version)
+
+
+def fetch_manifest(
+    manifest_url: str = MANIFEST_URL,
+    *,
+    urlopen: Callable[..., Any] = urllib.request.urlopen,
+) -> UpdateManifest:
+    request = urllib.request.Request(
+        manifest_url,
+        headers={"User-Agent": USER_AGENT, "Accept": "application/json"},
+    )
+    try:
+        with urlopen(request, timeout=30) as response:
+            data = response.read()
+    except OSError as exc:
+        raise UpdateError(f"下载更新清单失败：{exc}") from exc
+    try:
+        raw = json.loads(data.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise UpdateError("更新清单不是有效 JSON。") from exc
+    return parse_manifest(raw)
+
+
+def parse_manifest(raw: Any) -> UpdateManifest:
+    if not isinstance(raw, dict):
+        raise UpdateError("更新清单格式错误。")
+    version = normalize_version(str(raw.get("version") or ""))
+    tag = str(raw.get("tag") or "").strip()
+    url = str(raw.get("windows_x64_update_url") or "").strip()
+    sha256 = str(raw.get("sha256") or "").strip().lower()
+    if not version or not tag or not url or not sha256:
+        raise UpdateError("更新清单缺少必要字段。")
+    if len(sha256) != 64 or any(ch not in "0123456789abcdef" for ch in sha256):
+        raise UpdateError("更新清单中的 sha256 无效。")
+    return UpdateManifest(
+        version=version,
+        tag=tag,
+        prerelease=bool(raw.get("prerelease", False)),
+        windows_x64_update_url=url,
+        sha256=sha256,
+    )
+
+
+def download_file(
+    url: str,
+    target: Path,
+    *,
+    expected_sha256: str,
+    urlopen: Callable[..., Any] = urllib.request.urlopen,
+) -> str:
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    part = target.with_name(f"{target.name}.part")
+    digest = hashlib.sha256()
+    try:
+        with urlopen(request, timeout=600) as response, part.open("wb") as out:
+            while True:
+                chunk = response.read(CHUNK_SIZE)
+                if not chunk:
+                    break
+                digest.update(chunk)
+                out.write(chunk)
+    except OSError as exc:
+        part.unlink(missing_ok=True)
+        raise UpdateError(f"下载升级包失败：{exc}") from exc
+    actual = digest.hexdigest()
+    if actual.lower() != expected_sha256.lower():
+        part.unlink(missing_ok=True)
+        raise UpdateError("升级包 sha256 校验失败。")
+    part.replace(target)
+    return actual
+
+
+def validate_update_archive(archive: Path, manifest: UpdateManifest) -> None:
+    try:
+        with zipfile.ZipFile(archive) as zf:
+            version = _read_zip_version(zf)
+            bad_member = zf.testzip()
+    except zipfile.BadZipFile as exc:
+        raise UpdateError("升级包不是有效 zip 文件。") from exc
+    if bad_member:
+        raise UpdateError(f"升级包内文件损坏：{bad_member}")
+    if normalize_version(version) != manifest.version:
+        raise UpdateError(f"升级包版本不匹配：{version} != {manifest.version}")
+
+
+def apply_update_archive(archive: Path, base_dir: Path) -> list[Path]:
+    base_dir = base_dir.resolve()
+    written: list[Path] = []
+    temp_root = _updater_temp_root(base_dir)
+    backup_dir = _make_temp_dir(temp_root, "backup-")
+    try:
+        with zipfile.ZipFile(archive) as zf:
+            for info in zf.infolist():
+                parts = _zip_parts(info.filename)
+                if not parts or should_skip_update_path(parts):
+                    continue
+                target = (base_dir / Path(*parts)).resolve()
+                if not _is_relative_to(target, base_dir):
+                    raise UpdateError(f"升级包包含非法路径：{info.filename}")
+                if info.is_dir():
+                    target.mkdir(parents=True, exist_ok=True)
+                    continue
+                _backup_file(target, backup_dir / Path(*parts))
+                written.append(target)
+                target.parent.mkdir(parents=True, exist_ok=True)
+                with zf.open(info) as src, target.open("wb") as dst:
+                    shutil.copyfileobj(src, dst)
+    except Exception:
+        _rollback_files(base_dir, backup_dir, written)
+        raise
+    finally:
+        shutil.rmtree(backup_dir, ignore_errors=True)
+    return written
+
+
+def should_skip_update_path(parts: tuple[str, ...]) -> bool:
+    lower = tuple(part.lower() for part in parts)
+    if lower[0] in SKIP_ROOTS:
+        return True
+    if "__pycache__" in lower:
+        return True
+    if lower in SKIP_FILES:
+        return True
+    name = lower[-1]
+    return name.endswith((".pyc", ".pyo", ".log", ".zip"))
+
+
+def is_sakura_running(base_dir: Path) -> bool:
+    if sys.platform != "win32":
+        return False
+    env = os.environ.copy()
+    env["SAKURA_UPDATE_ROOT"] = str(base_dir.resolve())
+    command = (
+        "$root=[IO.Path]::GetFullPath($env:SAKURA_UPDATE_ROOT);"
+        "$p=Get-CimInstance Win32_Process | Where-Object {"
+        "$_.CommandLine -and $_.CommandLine -like '*main.py*' -and "
+        "$_.CommandLine -like ('*' + $root + '*')"
+        "} | Select-Object -First 1 -ExpandProperty ProcessId;"
+        "if ($p) { exit 1 } else { exit 0 }"
+    )
+    result = subprocess.run(
+        ["powershell", "-NoProfile", "-Command", command],
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    return result.returncode == 1
+
+
+def install_dependencies(base_dir: Path, python_exe: Path) -> None:
+    requirements = base_dir / "requirements.txt"
+    if not requirements.exists():
+        return
+    cmd = [
+        str(python_exe),
+        "-m",
+        "pip",
+        "install",
+        "-r",
+        str(requirements),
+        "-i",
+        "https://mirrors.aliyun.com/pypi/simple",
+        "--extra-index-url",
+        "https://pypi.tuna.tsinghua.edu.cn/simple",
+        "--extra-index-url",
+        "https://pypi.org/simple",
+        "--no-warn-script-location",
+    ]
+    subprocess.run(cmd, cwd=base_dir, check=True)
+
+
+def run_update(
+    base_dir: Path,
+    *,
+    check_only: bool = False,
+    manifest_url: str = MANIFEST_URL,
+    urlopen: Callable[..., Any] = urllib.request.urlopen,
+    out: TextIO = sys.stdout,
+    running_check: Callable[[Path], bool] = is_sakura_running,
+    dependency_installer: Callable[[Path, Path], None] = install_dependencies,
+) -> int:
+    base_dir = base_dir.resolve()
+    local_version = read_local_version(base_dir)
+    manifest = fetch_manifest(manifest_url, urlopen=urlopen)
+    if not is_newer(manifest.version, local_version):
+        print(f"当前已是最新版本：{local_version}", file=out)
+        return 0
+    print(f"发现新版本：{local_version} -> {manifest.version}", file=out)
+    if check_only:
+        print("仅检查更新，未下载升级包。", file=out)
+        return 0
+    if running_check(base_dir):
+        raise UpdateError("检测到 Sakura 正在运行，请先关闭 Sakura 后再升级。")
+
+    python_exe = base_dir / "runtime" / "python.exe"
+    old_requirements = _file_sha256(base_dir / "requirements.txt")
+    temp_dir = _make_temp_dir(_updater_temp_root(base_dir), "download-")
+    try:
+        archive = temp_dir / "sakura-update.zip"
+        download_file(
+            manifest.windows_x64_update_url,
+            archive,
+            expected_sha256=manifest.sha256,
+            urlopen=urlopen,
+        )
+        validate_update_archive(archive, manifest)
+        written = apply_update_archive(archive, base_dir)
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+    print(f"已更新 {len(written)} 个文件。", file=out)
+
+    new_requirements = _file_sha256(base_dir / "requirements.txt")
+    if old_requirements != new_requirements:
+        print("requirements.txt 已变化，正在更新依赖...", file=out)
+        dependency_installer(base_dir, python_exe)
+    print("升级完成。", file=out)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Sakura Windows 自动升级脚本")
+    parser.add_argument("--check", action="store_true", help="只检查更新，不下载和覆盖文件")
+    parser.add_argument("--manifest-url", default=MANIFEST_URL, help=argparse.SUPPRESS)
+    args = parser.parse_args(argv)
+    base_dir = Path(__file__).resolve().parents[1]
+    try:
+        return run_update(base_dir, check_only=args.check, manifest_url=args.manifest_url)
+    except (UpdateError, subprocess.CalledProcessError, OSError) as exc:
+        print(format_user_error(exc), file=sys.stderr)
+        return 1
+
+
+def format_user_error(exc: BaseException) -> str:
+    raw = str(exc) or repr(exc)
+    reason, solution = _friendly_error_help(exc, raw)
+    return "\n".join(
+        [
+            "",
+            "[Sakura update failed]",
+            f"可能原因：{reason}",
+            f"解决办法：{solution}",
+            "",
+            "--------------",
+            raw,
+        ]
+    )
+
+
+def _friendly_error_help(exc: BaseException, raw: str) -> tuple[str, str]:
+    text = raw.lower()
+    if "正在运行" in raw:
+        return "Sakura 还没有完全关闭，部分文件正在被占用。", "先退出 Sakura，再重新双击 update.bat。"
+    if "http error 404" in text and "更新清单" in raw:
+        return "更新清单还没发布，或 sakura-assets 里的 sakura-update.json 不存在。", "等发布流程跑完后再试；急用就手动下载完整包覆盖升级。"
+    if "下载更新清单失败" in raw:
+        return "无法读取更新清单，常见原因是网络、代理、GitHub 连接失败。", "换网络或代理后重试；仍失败就手动下载完整包。"
+    if "下载升级包失败" in raw:
+        return "升级包下载中断，常见原因是网络不稳定或 GitHub 下载被代理拦截。", "重试 update.bat；仍失败就手动下载完整包。"
+    if "sha256" in text:
+        return "下载到的升级包和清单校验值不一致，文件可能不完整或发布附件不匹配。", "重新运行 update.bat；多次失败请带截图反馈。"
+    if "json" in text or "更新清单" in raw:
+        return "更新清单格式不对，通常是发布流程生成或上传的 sakura-update.json 有问题。", "等待作者修复清单后重试；请带截图反馈。"
+    if "version" in text:
+        return "本地或升级包缺少版本信息，脚本无法确认该升到哪个版本。", "重新下载完整包；如果是作者测试包，请带截图反馈。"
+    if "zip" in text or "损坏" in raw or "版本不匹配" in raw:
+        return "升级包不可用，可能下载不完整、附件上传错了，或版本不匹配。", "重新运行 update.bat；仍失败就手动下载完整包。"
+    if "非法路径" in raw:
+        return "升级包里出现了不安全的文件路径，脚本已停止覆盖。", "不要继续使用这个升级包，请带截图反馈。"
+    if "permission" in text or "拒绝访问" in raw or "覆盖目录" in raw or "占用" in raw:
+        return "文件被占用或当前目录没有写入权限。", "关闭 Sakura 和杀毒软件占用后重试；必要时用管理员权限运行。"
+    if isinstance(exc, subprocess.CalledProcessError) or "pip" in text or "requirements" in text:
+        return "程序文件已更新，但依赖安装失败。", "检查网络后运行 install.bat；如果 Sakura 能正常启动，也可以先不处理。"
+    return "升级过程中遇到未分类错误。", "重试一次；如果还失败，请把这个窗口截图发给作者。"
+
+
+def _read_zip_version(zf: zipfile.ZipFile) -> str:
+    for info in zf.infolist():
+        parts = _zip_parts(info.filename)
+        if parts == ("VERSION",):
+            return zf.read(info).decode("utf-8").splitlines()[0].strip()
+    raise UpdateError("升级包缺少 VERSION。")
+
+
+def _zip_parts(name: str) -> tuple[str, ...]:
+    normalized = name.replace("\\", "/")
+    path = PurePosixPath(normalized)
+    parts = tuple(part for part in path.parts if part not in ("", "."))
+    if path.is_absolute() or ".." in parts or any(":" in part for part in parts):
+        raise UpdateError(f"升级包包含非法路径：{name}")
+    return parts
+
+
+def _backup_file(target: Path, backup: Path) -> None:
+    if not target.exists():
+        return
+    if target.is_dir():
+        raise UpdateError(f"无法用文件覆盖目录：{target}")
+    backup.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(target, backup)
+
+
+def _rollback_files(base_dir: Path, backup_dir: Path, written: list[Path]) -> None:
+    for target in reversed(written):
+        try:
+            rel = target.relative_to(base_dir)
+        except ValueError:
+            continue
+        backup = backup_dir / rel
+        if backup.exists():
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(backup, target)
+        elif target.exists():
+            target.unlink()
+
+
+def _file_sha256(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        while True:
+            chunk = file.read(CHUNK_SIZE)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _is_relative_to(path: Path, base: Path) -> bool:
+    try:
+        path.relative_to(base)
+    except ValueError:
+        return False
+    return True
+
+
+def _updater_temp_root(base_dir: Path) -> Path:
+    root = base_dir / "data" / "cache" / "updater"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _make_temp_dir(root: Path, prefix: str) -> Path:
+    for _ in range(10):
+        path = root / f"{prefix}{uuid.uuid4().hex}"
+        try:
+            path.mkdir(parents=True)
+        except FileExistsError:
+            continue
+        return path
+    raise UpdateError("无法创建升级临时目录。")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/update.bat
+++ b/update.bat
@@ -1,0 +1,17 @@
+@echo off
+chcp 65001 > nul
+set "PRJ_ROOT=%~dp0"
+set "PYTHON_EXE=%PRJ_ROOT%runtime\python.exe"
+
+if not exist "%PYTHON_EXE%" (
+    echo [ERROR] runtime\python.exe not found.
+    echo         Download the full Sakura package from GitHub Releases and try again.
+    pause
+    exit /b 1
+)
+
+cd /d "%PRJ_ROOT%"
+"%PYTHON_EXE%" "%PRJ_ROOT%tools\update.py" %*
+set "EXIT_CODE=%ERRORLEVEL%"
+pause
+exit /b %EXIT_CODE%


### PR DESCRIPTION
## Summary
- add update.bat + tools/update.py for manifest-based Windows updates
- publish a runtime-free update zip and sakura-update.json during release
- slim release/package archives to runtime-required files only

## Tests
- ./runtime/python.exe -m pytest tests/unit/test_update.py -q

## Notes
- release workflow requires SAKURA_ASSETS_TOKEN with write access to Rvosy/sakura-assets
