### PR TITLE
fix: 修复 Studio 角色工坊资源与导出安全

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ characters/
 .mypy_cache/
 .ruff_cache/
 temp/
+tools/studio/workspace/
 
 *.log
 data/chat_history.jsonl

--- a/app/config/character_archive.py
+++ b/app/config/character_archive.py
@@ -216,9 +216,11 @@ def export_character_archive(profile: CharacterProfile, output_path: Path, *, in
             path.is_file()
             and _resolved(path) != _resolved(destination)
             and path.name != "character.json"
-            and (include_voice or not _is_voice_package_file(profile.package_dir, path))
+            and not _is_voice_package_file(profile.package_dir, path)
         )
     ]
+    if include_voice:
+        package_files.extend(_referenced_voice_package_files(profile.package_dir, profile.voice))
     package_archive_names = {
         _archive_path_for_package_file(profile.package_dir, path).as_posix()
         for path in package_files
@@ -312,8 +314,8 @@ def export_character_voice_archive(profile: CharacterProfile, output_path: Path)
 
     voice_files = [
         path
-        for path in (profile.package_dir / VOICE_ARCHIVE_ROOT.as_posix()).rglob("*")
-        if path.is_file() and _resolved(path) != _resolved(destination)
+        for path in _referenced_voice_package_files(profile.package_dir, profile.voice)
+        if _resolved(path) != _resolved(destination)
     ]
     voice_archive_names = {
         _voice_archive_path_for_package_file(profile.package_dir, path).as_posix()
@@ -571,6 +573,53 @@ def _validate_voice_referenced_files(package_dir: Path, voice_data: dict[str, st
         if not path.is_file():
             raise CharacterArchiveError(f"{label}不存在：{path}")
 
+
+
+def _referenced_voice_package_files(package_dir: Path, voice: Any) -> list[Path]:
+    if voice is None:
+        return []
+
+    candidates = [
+        getattr(voice, "gpt_model_path", None),
+        getattr(voice, "sovits_model_path", None),
+        getattr(voice, "tone_ref_path", None),
+    ]
+    candidates.extend(_tone_ref_audio_files(package_dir, getattr(voice, "tone_ref_path", None)))
+
+    package_root = _resolved(package_dir)
+    result: list[Path] = []
+    seen: set[Path] = set()
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        path = _resolved(Path(candidate))
+        try:
+            rel = path.relative_to(package_root)
+        except ValueError:
+            continue
+        if not rel.parts or rel.parts[0] != VOICE_ARCHIVE_ROOT.as_posix():
+            continue
+        if path.is_file() and path not in seen:
+            result.append(path)
+            seen.add(path)
+    return result
+
+
+def _tone_ref_audio_files(package_dir: Path, tone_ref_path: Path | None) -> list[Path]:
+    if tone_ref_path is None or not tone_ref_path.is_file():
+        return []
+    try:
+        lines = tone_ref_path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise CharacterArchiveError(f"语气参考表无法读取：{tone_ref_path}") from exc
+
+    paths: list[Path] = []
+    for raw in lines:
+        audio_text = raw.split("|", 1)[0].strip()
+        if not audio_text:
+            continue
+        paths.append(package_dir / _safe_package_path(audio_text, "参考音频"))
+    return paths
 
 def _write_character_manifest(package_dir: Path, character_data: dict[str, Any]) -> None:
     (package_dir / "character.json").write_text(

--- a/tests/ui/test_studio.py
+++ b/tests/ui/test_studio.py
@@ -259,6 +259,14 @@ def test_voice_model_picker_removes_previous_model(
     panel = VoiceModelPanel()
     panel.bind_package_dir(package_dir)
     panel.gpt_edit.setText("voice/models/old.ckpt")
+    copy_states = []
+    real_copy2 = voice_panel.shutil.copy2
+
+    def fake_copy2(src, dst):  # type: ignore[no-untyped-def]
+        copy_states.append(panel.isEnabled())
+        return real_copy2(src, dst)
+
+    monkeypatch.setattr(voice_panel.shutil, "copy2", fake_copy2)
     monkeypatch.setattr(
         voice_panel.QFileDialog,
         "getOpenFileName",
@@ -267,6 +275,8 @@ def test_voice_model_picker_removes_previous_model(
 
     panel._pick_gpt()
 
+    assert copy_states == [False]
+    assert panel.isEnabled()
     assert panel.gpt_edit.text() == "voice/models/new.ckpt"
     assert not old_model.exists()
     assert (models_dir / "new.ckpt").read_bytes() == b"new"
@@ -343,6 +353,49 @@ def test_export_step_preview_does_not_write_reference_file(
 
     assert not (package_dir / DEFAULT_TONE_REFS).exists()
     assert "Demo" in window._panels["export"].summary_label.text()
+
+
+def test_studio_export_uses_busy_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _qt_app()
+    _disable_audio_player(monkeypatch)
+
+    from tools.studio.app_studio import StudioWindow
+
+    project_root = _studio_runtime_root("studio_export_busy")
+    package_dir = project_root / "tools" / "studio" / "workspace" / "characters" / "demo"
+    (package_dir / "portraits").mkdir(parents=True)
+    (package_dir / "portraits" / "default.png").write_bytes(b"png")
+    window = StudioWindow(project_root=project_root)
+    window._set_doc(
+        CharacterDoc(
+            id="demo",
+            display_name="Demo",
+            default_portrait="portraits/default.png",
+            expressions={"默认": "portraits/default.png"},
+        ),
+        package_dir,
+    )
+    export_states = []
+
+    def fake_export(doc, package, output):  # type: ignore[no-untyped-def]
+        export_states.append(window.isEnabled())
+
+    window.workspace.export = fake_export  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        "tools.studio.app_studio.QFileDialog.getSaveFileName",
+        lambda *_args, **_kwargs: (str(project_root / "demo.char"), ""),
+    )
+    monkeypatch.setattr(
+        "tools.studio.app_studio.QMessageBox.information",
+        lambda *_args, **_kwargs: None,
+    )
+
+    window._on_export()
+
+    assert export_states == [False]
+    assert window.isEnabled()
 
 def test_theme_swatches_keep_individual_colors() -> None:
     _qt_app()

--- a/tests/ui/test_studio.py
+++ b/tests/ui/test_studio.py
@@ -119,6 +119,25 @@ def test_reference_audio_writes_ref_file_and_reply_tones(
     )
 
 
+
+def test_reference_audio_keeps_existing_reply_tones_when_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _qt_app()
+    _disable_audio_player(monkeypatch)
+
+    from tools.studio.panels.voice_panel import ReferenceAudioPanel
+
+    package_dir = _studio_runtime_root("studio_reference_audio_keep_tones") / "character"
+    panel = ReferenceAudioPanel()
+    panel.bind_package_dir(package_dir)
+    doc = CharacterDoc(id="test", display_name="测试", reply_tones=["温柔", "严肃"])
+
+    panel.write_to(doc)
+
+    assert doc.reply_tones == ["温柔", "严肃"]
+    assert not (package_dir / DEFAULT_TONE_REFS).exists()
+
 def test_voice_model_and_reference_audio_merge_one_voice_draft(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/ui/test_studio.py
+++ b/tests/ui/test_studio.py
@@ -160,6 +160,39 @@ def test_voice_model_and_reference_audio_merge_one_voice_draft(
     assert ref_panel.ref_table.verticalHeader().defaultSectionSize() >= 38
 
 
+
+def test_voice_model_picker_removes_previous_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _qt_app()
+    _disable_audio_player(monkeypatch)
+
+    from tools.studio.panels import voice_panel
+    from tools.studio.panels.voice_panel import VoiceModelPanel
+
+    package_dir = _studio_runtime_root("studio_voice_replace") / "character"
+    models_dir = package_dir / "voice" / "models"
+    models_dir.mkdir(parents=True)
+    old_model = models_dir / "old.ckpt"
+    old_model.write_bytes(b"old")
+    source_model = _studio_runtime_root("studio_voice_replace_source") / "new.ckpt"
+    source_model.write_bytes(b"new")
+
+    panel = VoiceModelPanel()
+    panel.bind_package_dir(package_dir)
+    panel.gpt_edit.setText("voice/models/old.ckpt")
+    monkeypatch.setattr(
+        voice_panel.QFileDialog,
+        "getOpenFileName",
+        lambda *_args, **_kwargs: (str(source_model), ""),
+    )
+
+    panel._pick_gpt()
+
+    assert panel.gpt_edit.text() == "voice/models/new.ckpt"
+    assert not old_model.exists()
+    assert (models_dir / "new.ckpt").read_bytes() == b"new"
+
 def test_portrait_panel_edits_portrait_description_tags() -> None:
     _qt_app()
 

--- a/tests/ui/test_studio.py
+++ b/tests/ui/test_studio.py
@@ -54,6 +54,17 @@ def test_workspace_rejects_package_paths_outside_directory() -> None:
     with pytest.raises(WorkspaceError, match="角色卡不能指向角色包外"):
         Workspace(root / "workspace").open_directory(source)
 
+
+def test_workspace_refuses_overwrite_when_disabled() -> None:
+    from tools.studio.workspace import Workspace, WorkspaceError
+
+    root = _studio_runtime_root("studio_workspace_overwrite")
+    workspace = Workspace(root / "workspace")
+    workspace.new_character("demo")
+
+    with pytest.raises(WorkspaceError, match="工作区已存在角色草稿"):
+        workspace.new_character("demo", overwrite=False)
+
 def test_studio_uses_eight_step_wizard_without_toolbar_actions(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -80,6 +91,28 @@ def test_studio_uses_eight_step_wizard_without_toolbar_actions(
     assert not hasattr(window, "new_button")
     assert not hasattr(window, "export_button")
 
+
+
+def test_studio_cancel_workspace_overwrite_confirmation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _qt_app()
+    _disable_audio_player(monkeypatch)
+
+    from PySide6.QtWidgets import QMessageBox
+
+    from tools.studio.app_studio import StudioWindow
+
+    window = StudioWindow(project_root=_studio_runtime_root("studio_overwrite_confirm"))
+    existing = window.workspace.package_dir("demo")
+    existing.mkdir(parents=True)
+    monkeypatch.setattr(
+        "tools.studio.app_studio.QMessageBox.question",
+        lambda *_args, **_kwargs: QMessageBox.StandardButton.No,
+    )
+
+    assert not window._confirm_overwrite_workspace("demo")
+    assert existing.exists()
 
 def test_studio_stepper_and_footer_switch_pages(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/ui/test_studio.py
+++ b/tests/ui/test_studio.py
@@ -28,6 +28,32 @@ def _studio_runtime_root(name: str) -> Path:
     return root
 
 
+
+def test_workspace_rejects_package_paths_outside_directory() -> None:
+    import json
+
+    from tools.studio.workspace import Workspace, WorkspaceError
+
+    root = _studio_runtime_root("studio_workspace_paths")
+    source = root / "source"
+    source.mkdir()
+    (root / "secret.md").write_text("secret", encoding="utf-8")
+    (source / "portrait.png").write_bytes(b"png")
+    (source / "character.json").write_text(
+        json.dumps(
+            {
+                "id": "source",
+                "display_name": "Source",
+                "card": "../secret.md",
+                "portrait": {"default": "portrait.png"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(WorkspaceError, match="角色卡不能指向角色包外"):
+        Workspace(root / "workspace").open_directory(source)
+
 def test_studio_uses_eight_step_wizard_without_toolbar_actions(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/ui/test_studio.py
+++ b/tests/ui/test_studio.py
@@ -284,6 +284,33 @@ def test_portrait_panel_edits_portrait_description_tags() -> None:
     assert doc.default_portrait == "portraits/A010.png"
 
 
+
+def test_export_step_preview_does_not_write_reference_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _qt_app()
+    _disable_audio_player(monkeypatch)
+
+    from tools.studio.app_studio import StudioWindow
+    from tools.studio.character_doc import VoiceDraft
+
+    project_root = _studio_runtime_root("studio_export_preview")
+    package_dir = project_root / "tools" / "studio" / "workspace" / "characters" / "demo"
+    (package_dir / "voice" / "refs" / "tone_refs").mkdir(parents=True)
+    (package_dir / "voice" / "refs" / "tone_refs" / "neutral.wav").write_bytes(b"wav")
+    window = StudioWindow(project_root=project_root)
+    window._set_doc(
+        CharacterDoc(id="demo", display_name="Demo", voice=VoiceDraft()),
+        package_dir,
+    )
+    ref_panel = window._panels["reference_audio"]
+    ref_panel._add_ref_row("voice/refs/tone_refs/neutral.wav", "JA", "hello", "中性")
+
+    window._go_to_step(7)
+
+    assert not (package_dir / DEFAULT_TONE_REFS).exists()
+    assert "Demo" in window._panels["export"].summary_label.text()
+
 def test_theme_swatches_keep_individual_colors() -> None:
     _qt_app()
 

--- a/tests/ui/test_studio.py
+++ b/tests/ui/test_studio.py
@@ -281,6 +281,60 @@ def test_voice_model_picker_removes_previous_model(
     assert not old_model.exists()
     assert (models_dir / "new.ckpt").read_bytes() == b"new"
 
+
+def test_voice_model_panel_validates_model_extensions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _qt_app()
+    _disable_audio_player(monkeypatch)
+
+    from tools.studio.panels.voice_panel import VoiceModelPanel
+
+    panel = VoiceModelPanel()
+    panel.enable_check.setChecked(True)
+    panel.gpt_edit.setText("voice/models/wrong.pth")
+    panel.sovits_edit.setText("voice/models/wrong.ckpt")
+
+    errors = panel.validate(CharacterDoc(id="test", display_name="测试"))
+
+    assert "GPT 模型 必须是 .ckpt 文件" in errors
+    assert "SoVITS 模型 必须是 .pth 文件" in errors
+
+
+def test_voice_model_picker_rejects_wrong_extension(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _qt_app()
+    _disable_audio_player(monkeypatch)
+
+    from tools.studio.panels import voice_panel
+    from tools.studio.panels.voice_panel import VoiceModelPanel
+
+    package_dir = _studio_runtime_root("studio_voice_wrong_ext") / "character"
+    source_model = _studio_runtime_root("studio_voice_wrong_ext_source") / "bad.pth"
+    source_model.write_bytes(b"bad")
+    warnings = []
+
+    panel = VoiceModelPanel()
+    panel.bind_package_dir(package_dir)
+    monkeypatch.setattr(
+        voice_panel.QFileDialog,
+        "getOpenFileName",
+        lambda *_args, **_kwargs: (str(source_model), ""),
+    )
+    monkeypatch.setattr(
+        voice_panel.QMessageBox,
+        "warning",
+        lambda *_args, **_kwargs: warnings.append(True),
+    )
+
+    panel._pick_gpt()
+
+    assert warnings == [True]
+    assert panel.gpt_edit.text() == ""
+    assert not (package_dir / "voice" / "models" / "bad.pth").exists()
+
+
 def test_portrait_panel_edits_portrait_description_tags() -> None:
     _qt_app()
 

--- a/tests/unit/test_character_archive.py
+++ b/tests/unit/test_character_archive.py
@@ -75,6 +75,46 @@ def test_character_archive_manifest_uses_sakura_format() -> None:
     assert "character/voice/refs/tone_refs/neutral.wav" in names
 
 
+
+def test_character_archive_export_only_includes_referenced_voice_files() -> None:
+    root = _runtime_root("referenced_voice_export")
+    profile = _build_character_package(root / "source")
+    (profile.package_dir / "voice" / "models" / "old.ckpt").write_bytes(b"old-gpt")
+    (profile.package_dir / "voice" / "refs" / "tone_refs" / "old.wav").write_bytes(b"old-wav")
+    archive_path = root / "demo.char"
+
+    export_character_archive(profile, archive_path)
+
+    with zipfile.ZipFile(archive_path, "r") as zf:
+        names = set(zf.namelist())
+
+    assert "character/voice/models/gpt.ckpt" in names
+    assert "character/voice/models/sovits.pth" in names
+    assert "character/voice/refs/ref.txt" in names
+    assert "character/voice/refs/tone_refs/neutral.wav" in names
+    assert "character/voice/models/old.ckpt" not in names
+    assert "character/voice/refs/tone_refs/old.wav" not in names
+
+
+def test_character_voice_archive_export_only_includes_referenced_files() -> None:
+    root = _runtime_root("referenced_voice_only_export")
+    profile = _build_character_package(root / "source")
+    (profile.package_dir / "voice" / "models" / "old.ckpt").write_bytes(b"old-gpt")
+    (profile.package_dir / "voice" / "refs" / "tone_refs" / "old.wav").write_bytes(b"old-wav")
+    archive_path = root / "demo.voice"
+
+    export_character_voice_archive(profile, archive_path)
+
+    with zipfile.ZipFile(archive_path, "r") as zf:
+        names = set(zf.namelist())
+
+    assert "voice/models/gpt.ckpt" in names
+    assert "voice/models/sovits.pth" in names
+    assert "voice/refs/ref.txt" in names
+    assert "voice/refs/tone_refs/neutral.wav" in names
+    assert "voice/models/old.ckpt" not in names
+    assert "voice/refs/tone_refs/old.wav" not in names
+
 def test_character_archive_card_only_export_excludes_voice() -> None:
     root = _runtime_root("card_only_export")
     profile = _build_character_package(root / "source")

--- a/tools/studio/app_studio.py
+++ b/tools/studio/app_studio.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor, QFont, QPalette
 from PySide6.QtWidgets import (
     QApplication,
@@ -414,7 +415,14 @@ class StudioWindow(QMainWindow):
         if not path:
             return
         try:
-            self.workspace.export(doc, self._package_dir, Path(path))
+            self.setEnabled(False)
+            QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
+            QApplication.processEvents()
+            try:
+                self.workspace.export(doc, self._package_dir, Path(path))
+            finally:
+                QApplication.restoreOverrideCursor()
+                self.setEnabled(True)
         except CharacterConfigError as exc:
             QMessageBox.warning(self, "校验未通过", f"角色包存在问题，无法导出：\n\n{exc}")
             return

--- a/tools/studio/app_studio.py
+++ b/tools/studio/app_studio.py
@@ -327,6 +327,18 @@ class StudioWindow(QMainWindow):
             errors.extend(self._panels[key].validate(doc))
         return errors
 
+    def _confirm_overwrite_workspace(self, char_id: str) -> bool:
+        if not self.workspace.package_dir(char_id).exists():
+            return True
+        reply = QMessageBox.question(
+            self,
+            "覆盖草稿",
+            f"工作区已存在角色「{char_id}」的草稿，继续会删除旧草稿。是否覆盖？",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        return reply == QMessageBox.StandardButton.Yes
+
     # ---- 按钮处理 ---------------------------------------------------------
 
     def _on_new(self) -> None:
@@ -339,6 +351,8 @@ class StudioWindow(QMainWindow):
         if not char_id or not ID_PATTERN.match(char_id):
             QMessageBox.warning(self, "无效的角色 ID", "角色 ID 只能包含字母、数字、_ . -")
             return
+        if not self._confirm_overwrite_workspace(char_id):
+            return
         pkg, doc = self.workspace.new_character(char_id)
         self._set_doc(doc, pkg)
         self._status_label.setText(f"已新建：{char_id}（请补充立绘并指定默认立绘后再导出）")
@@ -348,8 +362,11 @@ class StudioWindow(QMainWindow):
         directory = QFileDialog.getExistingDirectory(self, "选择角色包目录", start)
         if not directory:
             return
+        src_dir = Path(directory)
+        if not self._confirm_overwrite_workspace(src_dir.name):
+            return
         try:
-            pkg, doc = self.workspace.open_directory(Path(directory))
+            pkg, doc = self.workspace.open_directory(src_dir)
         except Exception as exc:  # noqa: BLE001 - 统一弹窗反馈
             QMessageBox.critical(self, "打开失败", str(exc))
             return

--- a/tools/studio/app_studio.py
+++ b/tools/studio/app_studio.py
@@ -254,7 +254,7 @@ class StudioWindow(QMainWindow):
         if self._doc is None or self._package_dir is None:
             export_panel.set_ready(False)
             return
-        doc = self._write_panels_to_doc()
+        doc = self._write_panels_to_doc(write_files=False)
         if doc is not None:
             export_panel.bind_package_dir(self._package_dir)
             export_panel.load_from(doc)
@@ -310,11 +310,15 @@ class StudioWindow(QMainWindow):
         self._go_to_step(1)
         self._status_label.setText(f"已打开：{package_dir}")
 
-    def _write_panels_to_doc(self) -> CharacterDoc | None:
+    def _write_panels_to_doc(self, *, write_files: bool = True) -> CharacterDoc | None:
         if self._doc is None:
             return None
         for key, _label in STUDIO_STEPS:
-            self._panels[key].write_to(self._doc)
+            panel = self._panels[key]
+            if isinstance(panel, ReferenceAudioPanel):
+                panel.write_to(self._doc, write_files=write_files)
+            else:
+                panel.write_to(self._doc)
         return self._doc
 
     def _collect_validation_errors(self, doc: CharacterDoc) -> list[str]:

--- a/tools/studio/panels/voice_panel.py
+++ b/tools/studio/panels/voice_panel.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import shutil
 from pathlib import Path
 
-from PySide6.QtCore import QUrl
+from PySide6.QtCore import Qt, QUrl
 from PySide6.QtWidgets import (
+    QApplication,
     QAbstractItemView,
     QCheckBox,
     QFileDialog,
@@ -138,8 +139,15 @@ class VoiceModelPanel(StudioPanel):
         path, _ = QFileDialog.getOpenFileName(self, "选择模型文件", "", MODEL_EXTS)
         if path:
             old_rel = edit.text().strip()
-            new_rel = _copy_into(self._package_dir, Path(path), MODELS_SUBDIR)
-            _remove_previous_model(self._package_dir, old_rel, new_rel)
+            self.setEnabled(False)
+            QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
+            QApplication.processEvents()
+            try:
+                new_rel = _copy_into(self._package_dir, Path(path), MODELS_SUBDIR)
+                _remove_previous_model(self._package_dir, old_rel, new_rel)
+            finally:
+                QApplication.restoreOverrideCursor()
+                self.setEnabled(True)
             edit.setText(new_rel)
 
     def load_from(self, doc: CharacterDoc) -> None:

--- a/tools/studio/panels/voice_panel.py
+++ b/tools/studio/panels/voice_panel.py
@@ -271,7 +271,9 @@ class ReferenceAudioPanel(StudioPanel):
 
     def write_to(self, doc: CharacterDoc) -> None:
         rows = self._rows()
-        doc.reply_tones = self._tone_labels(rows)
+        tones = self._tone_labels(rows)
+        if tones:
+            doc.reply_tones = tones
 
         if self._package_dir is not None and (doc.voice is not None or rows):
             ref_path = self._package_dir / DEFAULT_TONE_REFS

--- a/tools/studio/panels/voice_panel.py
+++ b/tools/studio/panels/voice_panel.py
@@ -53,6 +53,18 @@ def _copy_into(package_dir: Path, src: Path, subdir: str) -> str:
     return f"{subdir}/{src.name}"
 
 
+
+def _remove_previous_model(package_dir: Path, old_rel: str, keep_rel: str) -> None:
+    if not old_rel or old_rel == keep_rel:
+        return
+    models_dir = (package_dir / MODELS_SUBDIR).resolve()
+    old_path = (package_dir / old_rel).resolve()
+    try:
+        old_path.relative_to(models_dir)
+    except ValueError:
+        return
+    if old_path.is_file():
+        old_path.unlink(missing_ok=True)
 def _with_button(edit: QLineEdit, text: str, slot) -> QWidget:
     wrap = QWidget()
     wrap.setObjectName("studioInlineField")
@@ -125,7 +137,10 @@ class VoiceModelPanel(StudioPanel):
             return
         path, _ = QFileDialog.getOpenFileName(self, "选择模型文件", "", MODEL_EXTS)
         if path:
-            edit.setText(_copy_into(self._package_dir, Path(path), MODELS_SUBDIR))
+            old_rel = edit.text().strip()
+            new_rel = _copy_into(self._package_dir, Path(path), MODELS_SUBDIR)
+            _remove_previous_model(self._package_dir, old_rel, new_rel)
+            edit.setText(new_rel)
 
     def load_from(self, doc: CharacterDoc) -> None:
         voice = doc.voice

--- a/tools/studio/panels/voice_panel.py
+++ b/tools/studio/panels/voice_panel.py
@@ -269,13 +269,13 @@ class ReferenceAudioPanel(StudioPanel):
                 parts.append("")
             self._add_ref_row(parts[0], parts[1], parts[2], parts[3])
 
-    def write_to(self, doc: CharacterDoc) -> None:
+    def write_to(self, doc: CharacterDoc, *, write_files: bool = True) -> None:
         rows = self._rows()
         tones = self._tone_labels(rows)
         if tones:
             doc.reply_tones = tones
 
-        if self._package_dir is not None and (doc.voice is not None or rows):
+        if write_files and self._package_dir is not None and (doc.voice is not None or rows):
             ref_path = self._package_dir / DEFAULT_TONE_REFS
             ref_path.parent.mkdir(parents=True, exist_ok=True)
             lines = ["|".join(row) for row in rows if any(row)]

--- a/tools/studio/panels/voice_panel.py
+++ b/tools/studio/panels/voice_panel.py
@@ -27,7 +27,10 @@ from PySide6.QtWidgets import (
 from tools.studio.character_doc import DEFAULT_TONE_REFS, CharacterDoc, VoiceDraft
 from tools.studio.panels.base import StudioPanel
 
-MODEL_EXTS = "GPT-SoVITS 模型 (*.ckpt *.pth);;所有文件 (*)"
+GPT_MODEL_EXT = ".ckpt"
+SOVITS_MODEL_EXT = ".pth"
+GPT_MODEL_FILTER = "GPT 模型 (*.ckpt);;所有文件 (*)"
+SOVITS_MODEL_FILTER = "SoVITS 模型 (*.pth);;所有文件 (*)"
 AUDIO_FILTER = "音频 (*.ogg *.wav *.mp3 *.flac);;所有文件 (*)"
 MODELS_SUBDIR = "voice/models"
 TONE_REFS_SUBDIR = "voice/refs/tone_refs"
@@ -128,16 +131,19 @@ class VoiceModelPanel(StudioPanel):
         self.body.setEnabled(enabled)
 
     def _pick_gpt(self) -> None:
-        self._pick_model(self.gpt_edit)
+        self._pick_model(self.gpt_edit, GPT_MODEL_EXT, GPT_MODEL_FILTER, "GPT 模型")
 
     def _pick_sovits(self) -> None:
-        self._pick_model(self.sovits_edit)
+        self._pick_model(self.sovits_edit, SOVITS_MODEL_EXT, SOVITS_MODEL_FILTER, "SoVITS 模型")
 
-    def _pick_model(self, edit: QLineEdit) -> None:
+    def _pick_model(self, edit: QLineEdit, expected_ext: str, file_filter: str, label: str) -> None:
         if self._package_dir is None:
             return
-        path, _ = QFileDialog.getOpenFileName(self, "选择模型文件", "", MODEL_EXTS)
+        path, _ = QFileDialog.getOpenFileName(self, "选择模型文件", "", file_filter)
         if path:
+            if Path(path).suffix.lower() != expected_ext:
+                QMessageBox.warning(self, "模型类型不匹配", f"{label} 请选择 {expected_ext} 文件。")
+                return
             old_rel = edit.text().strip()
             self.setEnabled(False)
             QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
@@ -158,6 +164,19 @@ class VoiceModelPanel(StudioPanel):
         self.sovits_edit.setText(voice.sovits_model or "" if voice else "")
         self.ref_lang_edit.setText(voice.ref_lang if voice else "ja")
         self.text_lang_edit.setText(voice.text_lang if voice else "ja")
+
+    def validate(self, doc: CharacterDoc) -> list[str]:
+        if not self.enable_check.isChecked():
+            return []
+        errors: list[str] = []
+        for label, edit, expected_ext in (
+            ("GPT 模型", self.gpt_edit, GPT_MODEL_EXT),
+            ("SoVITS 模型", self.sovits_edit, SOVITS_MODEL_EXT),
+        ):
+            path_text = edit.text().strip()
+            if path_text and Path(path_text).suffix.lower() != expected_ext:
+                errors.append(f"{label} 必须是 {expected_ext} 文件")
+        return errors
 
     def write_to(self, doc: CharacterDoc) -> None:
         if not self.enable_check.isChecked():

--- a/tools/studio/workspace.py
+++ b/tools/studio/workspace.py
@@ -72,19 +72,19 @@ class Workspace:
 
     # ---- 创建 / 打开 ------------------------------------------------------
 
-    def new_character(self, char_id: str) -> tuple[Path, CharacterDoc]:
+    def new_character(self, char_id: str, *, overwrite: bool = True) -> tuple[Path, CharacterDoc]:
         """新建空白角色包骨架。character.json 在首次保存时才写出。"""
-        pkg = self._prepare_empty_dir(char_id)
+        pkg = self._prepare_empty_dir(char_id, overwrite=overwrite)
         (pkg / "portraits").mkdir(exist_ok=True)
         (pkg / CARD_FILENAME).write_text("", encoding="utf-8")
         return pkg, CharacterDoc(id=char_id, display_name=char_id)
 
-    def open_directory(self, src_dir: Path) -> tuple[Path, CharacterDoc]:
+    def open_directory(self, src_dir: Path, *, overwrite: bool = True) -> tuple[Path, CharacterDoc]:
         """把现有角色包目录复制到工作区后打开（不改动源目录）。"""
         src_dir = Path(src_dir)
         if not (src_dir / "character.json").exists():
             raise WorkspaceError(f"目录不是角色包（缺 character.json）：{src_dir}")
-        pkg = self._prepare_empty_dir(src_dir.name)
+        pkg = self._prepare_empty_dir(src_dir.name, overwrite=overwrite)
         shutil.copytree(src_dir, pkg, dirs_exist_ok=True)
         _validate_package_local_paths(pkg)
         return pkg, CharacterDoc.from_package_dir(pkg)
@@ -125,9 +125,11 @@ class Workspace:
 
     # ---- 内部 -------------------------------------------------------------
 
-    def _prepare_empty_dir(self, char_id: str) -> Path:
+    def _prepare_empty_dir(self, char_id: str, *, overwrite: bool = True) -> Path:
         pkg = self.package_dir(char_id)
         if pkg.exists():
+            if not overwrite:
+                raise WorkspaceError(f"工作区已存在角色草稿：{pkg}")
             shutil.rmtree(pkg)
         pkg.mkdir(parents=True, exist_ok=True)
         return pkg

--- a/tools/studio/workspace.py
+++ b/tools/studio/workspace.py
@@ -11,6 +11,7 @@
 
 from __future__ import annotations
 
+import json
 import shutil
 from pathlib import Path
 
@@ -22,6 +23,42 @@ from tools.studio.character_doc import CARD_FILENAME, CharacterDoc
 
 class WorkspaceError(RuntimeError):
     """工作区操作失败。"""
+
+
+def _validate_package_local_paths(package_dir: Path) -> None:
+    manifest_path = package_dir / "character.json"
+    try:
+        raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise WorkspaceError(f"角色清单无法读取：{manifest_path}") from exc
+    if not isinstance(raw, dict):
+        raise WorkspaceError(f"角色清单必须是 JSON 对象：{manifest_path}")
+
+    _check_local_path(package_dir, raw.get("card"), "角色卡")
+    portrait = raw.get("portrait")
+    if isinstance(portrait, dict):
+        _check_local_path(package_dir, portrait.get("default"), "默认立绘")
+        expressions = portrait.get("expressions")
+        if isinstance(expressions, dict):
+            for label, path_text in expressions.items():
+                _check_local_path(package_dir, path_text, f"{label} 表情立绘")
+    voice = raw.get("voice")
+    if isinstance(voice, dict):
+        _check_local_path(package_dir, voice.get("tone_refs"), "语气参考表")
+        _check_local_path(package_dir, voice.get("gpt_model"), "GPT 模型")
+        _check_local_path(package_dir, voice.get("sovits_model"), "SoVITS 模型")
+
+
+def _check_local_path(package_dir: Path, value: object, label: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        return
+    path = Path(value.strip().strip('"').strip("'"))
+    if path.is_absolute():
+        raise WorkspaceError(f"{label}不能使用绝对路径：{value}")
+    try:
+        (package_dir / path).resolve().relative_to(package_dir.resolve())
+    except ValueError as exc:
+        raise WorkspaceError(f"{label}不能指向角色包外：{value}") from exc
 
 
 class Workspace:
@@ -49,6 +86,7 @@ class Workspace:
             raise WorkspaceError(f"目录不是角色包（缺 character.json）：{src_dir}")
         pkg = self._prepare_empty_dir(src_dir.name)
         shutil.copytree(src_dir, pkg, dirs_exist_ok=True)
+        _validate_package_local_paths(pkg)
         return pkg, CharacterDoc.from_package_dir(pkg)
 
     def open_archive(self, archive_path: Path) -> tuple[Path, CharacterDoc]:
@@ -67,7 +105,9 @@ class Workspace:
 
     def validate(self, package_dir: Path) -> CharacterProfile:
         """用主项目的单包加载器校验，返回 CharacterProfile；失败抛 CharacterConfigError。"""
-        return _load_profile(Path(package_dir) / "character.json")
+        package_dir = Path(package_dir)
+        _validate_package_local_paths(package_dir)
+        return _load_profile(package_dir / "character.json")
 
     def export(
         self,


### PR DESCRIPTION
## 变更内容

- 清理角色工坊导出时的旧语音资源，只打包实际引用的语音模型和参考音频。
- 导入角色时保留 `reply.tones`，并校验 Studio 导入目录、角色包资源路径和语音模型文件类型。
- 导出页预览改为纯内存生成，避免预览动作提前写入磁盘。
- 新建或导入同名草稿前增加覆盖确认，大文件操作增加忙碌反馈。
- 忽略 Studio 工作区运行时文件，避免本地临时产物进入提交。

## 原因

角色工坊当前在导入、预览和导出链路上有几处隐式写盘、路径越界和资源打包范围过宽的问题，容易造成草稿被覆盖、导出包携带无关大文件，或加载到包外资源。

## 影响

- 用户导入/导出角色包时更可预期，减少误覆盖和无关资源膨胀。
- Studio 预览不会留下隐藏文件副作用。
- 对包内资源路径和语音模型类型的校验更严格。

## 验证

- `C:\Users\Rvosy\miniconda3\envs\sakura-pet\python.exe -m pip install -r requirements-dev.txt`
- 全量 pytest：`1224 passed, 3 skipped`
  - 当前 Windows/Python 环境下 `os.mkdir(..., mode=0o700)` 会创建当前用户也无法读取的目录；测试运行时仅在进程内把 pytest 临时目录的 `0o700` 映射为默认可访问权限，未修改仓库代码。
