### PR TITLE
feat(mcp): platform-aware desktop-control MCP toggle + macOS server

### DIFF
--- a/app/agent/mcp/__init__.py
+++ b/app/agent/mcp/__init__.py
@@ -3,12 +3,17 @@ from __future__ import annotations
 from app.agent.mcp.config import MCPConfig, MCPServerConfig, load_mcp_config
 from app.agent.mcp.provider import MCPToolProvider, register_mcp_tools_from_config
 from app.agent.mcp.settings import (
+    DESKTOP_MCP_EXPERIMENTAL_TEXT,
+    DesktopMCP,
     MCPRuntimeSettings,
     WINDOWS_MCP_EXPERIMENTAL_TEXT,
     normalize_mcp_runtime_settings,
+    resolve_desktop_mcp,
 )
 
 __all__ = [
+    "DESKTOP_MCP_EXPERIMENTAL_TEXT",
+    "DesktopMCP",
     "MCPConfig",
     "MCPServerConfig",
     "MCPRuntimeSettings",
@@ -17,4 +22,5 @@ __all__ = [
     "load_mcp_config",
     "normalize_mcp_runtime_settings",
     "register_mcp_tools_from_config",
+    "resolve_desktop_mcp",
 ]

--- a/app/agent/mcp/settings.py
+++ b/app/agent/mcp/settings.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass
 from dataclasses import replace
 
@@ -7,21 +8,53 @@ from app.agent.mcp.config import MCPConfig
 
 
 WINDOWS_MCP_ENABLED_KEY = "WINDOWS_MCP_ENABLED"
-WINDOWS_MCP_AVAILABLE = True
-WINDOWS_MCP_EXPERIMENTAL_TEXT = "实验性功能，供想要尝鲜的用户使用；可能不稳定，请谨慎开启"
+# 文案与平台无关；保留旧常量名做向后兼容别名。
+DESKTOP_MCP_EXPERIMENTAL_TEXT = "实验性功能，供想要尝鲜的用户使用；可能不稳定，请谨慎开启"
+WINDOWS_MCP_EXPERIMENTAL_TEXT = DESKTOP_MCP_EXPERIMENTAL_TEXT
+
+
+@dataclass(frozen=True)
+class DesktopMCP:
+    """某平台对应的桌面控制 MCP：mcp.yaml 里的 server 名 + UI 显示名。"""
+
+    server_name: str
+    label: str
+
+
+# 平台 -> 桌面控制 MCP；不在表内的平台视为暂不支持（如 Linux）。
+_DESKTOP_MCP_BY_PLATFORM: dict[str, DesktopMCP] = {
+    "win32": DesktopMCP(server_name="windows", label="Windows MCP"),
+    "darwin": DesktopMCP(server_name="macos", label="macOS MCP"),
+}
+
+
+def resolve_desktop_mcp(platform: str | None = None) -> DesktopMCP | None:
+    """返回当前（或指定）平台的桌面控制 MCP；不支持的平台返回 None。"""
+
+    key = sys.platform if platform is None else platform
+    return _DESKTOP_MCP_BY_PLATFORM.get(key)
+
+
+# 当前平台是否提供桌面控制 MCP；旧名保留以兼容既有引用。
+DESKTOP_MCP_AVAILABLE = resolve_desktop_mcp() is not None
+WINDOWS_MCP_AVAILABLE = DESKTOP_MCP_AVAILABLE
 
 
 @dataclass(frozen=True)
 class MCPRuntimeSettings:
-    """MCP 运行时开关；由 data/config/system_config.yaml 提供。"""
+    """MCP 运行时开关；由 data/config/system_config.yaml 提供。
+
+    字段名 windows_enabled 与持久化键 WINDOWS_MCP_ENABLED 保留做向后兼容，
+    语义为“启用当前平台对应的桌面控制 MCP”。
+    """
 
     windows_enabled: bool = False
 
 
 def normalize_mcp_runtime_settings(settings: MCPRuntimeSettings) -> MCPRuntimeSettings:
-    """归一化 MCP 运行时开关，保留全局屏蔽能力的兜底。"""
+    """归一化 MCP 运行时开关；当前平台无桌面控制 MCP 时强制关闭。"""
 
-    if WINDOWS_MCP_AVAILABLE:
+    if resolve_desktop_mcp() is not None:
         return settings
     return replace(settings, windows_enabled=False)
 
@@ -30,12 +63,19 @@ def apply_mcp_runtime_settings(
     config: MCPConfig,
     settings: MCPRuntimeSettings,
 ) -> MCPConfig:
-    """按运行时开关覆盖需要重启加载的 MCP server。"""
+    """按运行时开关覆盖当前平台对应桌面控制 MCP server 的启停。
+
+    只动当前平台那一个 server（其余平台的 server 保持 mcp.yaml 中的原状，
+    因此 Windows 上的 macos server、macOS 上的 windows server 都不会被误启用）。
+    """
 
     normalized_settings = normalize_mcp_runtime_settings(settings)
+    desktop = resolve_desktop_mcp()
+    if desktop is None:
+        return config
     servers = [
         replace(server, enabled=normalized_settings.windows_enabled)
-        if server.name == "windows"
+        if server.name == desktop.server_name
         else server
         for server in config.servers
     ]

--- a/app/agent/mcp/settings.py
+++ b/app/agent/mcp/settings.py
@@ -52,11 +52,14 @@ class MCPRuntimeSettings:
 
 
 def normalize_mcp_runtime_settings(settings: MCPRuntimeSettings) -> MCPRuntimeSettings:
-    """归一化 MCP 运行时开关；当前平台无桌面控制 MCP 时强制关闭。"""
+    """归一化 MCP 运行时开关。
 
-    if resolve_desktop_mcp() is not None:
-        return settings
-    return replace(settings, windows_enabled=False)
+    桌面控制开关是用户偏好，跨平台原样保留（持久化忠实回写）；是否真正启用某个
+    server 由 apply_mcp_runtime_settings 按当前平台决定——不支持的平台不会启用任何
+    server，因此无需在此抹掉用户偏好。
+    """
+
+    return settings
 
 
 def apply_mcp_runtime_settings(

--- a/app/agent/mcp/settings.py
+++ b/app/agent/mcp/settings.py
@@ -26,6 +26,9 @@ _DESKTOP_MCP_BY_PLATFORM: dict[str, DesktopMCP] = {
     "win32": DesktopMCP(server_name="windows", label="Windows MCP"),
     "darwin": DesktopMCP(server_name="macos", label="macOS MCP"),
 }
+_DESKTOP_MCP_SERVER_NAMES = frozenset(
+    desktop.server_name for desktop in _DESKTOP_MCP_BY_PLATFORM.values()
+)
 
 
 def resolve_desktop_mcp(platform: str | None = None) -> DesktopMCP | None:
@@ -74,11 +77,16 @@ def apply_mcp_runtime_settings(
 
     normalized_settings = normalize_mcp_runtime_settings(settings)
     desktop = resolve_desktop_mcp()
-    if desktop is None:
-        return config
     servers = [
-        replace(server, enabled=normalized_settings.windows_enabled)
-        if server.name == desktop.server_name
+        replace(
+            server,
+            enabled=(
+                normalized_settings.windows_enabled
+                if desktop is not None and server.name == desktop.server_name
+                else False
+            ),
+        )
+        if server.name in _DESKTOP_MCP_SERVER_NAMES
         else server
         for server in config.servers
     ]

--- a/app/config/default_configs.py
+++ b/app/config/default_configs.py
@@ -2,7 +2,7 @@
 
 mcp.yaml / plugins.yaml 不再随发布包携带（否则覆盖升级会用默认值
 覆盖用户修改过的配置），改为首次启动/文件缺失时在此生成。
-已存在的文件一律不动——这是覆盖升级安全性的硬约束。
+已存在的文件只补齐缺失的内置默认项，不覆盖用户已有配置。
 """
 
 from __future__ import annotations
@@ -124,6 +124,8 @@ def ensure_default_configs(base_dir: Path) -> list[str]:
     ):
         try:
             if target.exists():
+                if target == paths.mcp_config():
+                    _backfill_mcp_config(target)
                 continue
             atomic_write_text(target, content, encoding="utf-8", backup=False)
             created.append(target.name)
@@ -136,3 +138,39 @@ def ensure_default_configs(base_dir: Path) -> list[str]:
     if created:
         debug_log("Config", "默认配置已生成", {"created": created})
     return created
+
+
+def _backfill_mcp_config(path: Path) -> None:
+    try:
+        import yaml
+    except ImportError as exc:
+        debug_log("Config", "默认 MCP 配置补齐失败", {"path": str(path), "error": str(exc)})
+        return
+
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        defaults = yaml.safe_load(_DEFAULT_MCP_YAML)
+    except (OSError, yaml.YAMLError) as exc:
+        debug_log("Config", "默认 MCP 配置补齐失败", {"path": str(path), "error": str(exc)})
+        return
+    if not isinstance(data, dict) or not isinstance(defaults, dict):
+        return
+    servers = data.get("servers")
+    default_servers = defaults.get("servers")
+    if not isinstance(servers, dict) or not isinstance(default_servers, dict):
+        return
+    if "macos" in servers or not {"web", "windows"}.issubset(servers):
+        return
+    macos_server = default_servers.get("macos")
+    if not isinstance(macos_server, dict):
+        return
+    servers["macos"] = macos_server
+    try:
+        atomic_write_text(
+            path,
+            yaml.safe_dump(data, allow_unicode=True, sort_keys=False),
+            encoding="utf-8",
+            backup=True,
+        )
+    except OSError as exc:
+        debug_log("Config", "默认 MCP 配置补齐失败", {"path": str(path), "error": str(exc)})

--- a/app/config/default_configs.py
+++ b/app/config/default_configs.py
@@ -72,6 +72,35 @@ servers:
       Screenshot:
         risk: medium
         requires_confirmation: false
+  macos:
+    enabled: false
+    transport: stdio
+    command: "{uvx}"
+    args:
+      - "macos-mcp"
+    env:
+      ANONYMIZED_TELEMETRY: "false"
+    name_prefix: macos__
+    call_timeout: 30
+    risk: high
+    requires_confirmation: true
+    include_tools:
+      - App
+      - Snapshot
+      - Click
+      - Type
+      - Wait
+    exclude_tools:
+      - Shell
+      - Scrape
+      - Notification
+      - Move
+      - Scroll
+      - Shortcut
+    tool_policies:
+      Snapshot:
+        risk: medium
+        requires_confirmation: false
 """
 
 # 内置插件的默认启停（与各插件 plugin.yaml 的 manifest 默认一致）

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -5476,7 +5476,7 @@ class PetWindow(QWidget):
         if api_changed:
             message += "\n\n长期记忆系统正在后台刷新 API 配置。"
         if mcp_restart_required:
-            message += "\n\nWindows MCP 开关需要重启 Sakura 后才会生效。"
+            message += "\n\n桌面控制 MCP 开关需要重启 Sakura 后才会生效。"
         if startup_settings_changed:
             message += "\n\n登录自启动设置已更新。"
         if getattr(dialog, "result_plugin_config_changed", False):

--- a/app/ui/settings/pages/sections.py
+++ b/app/ui/settings/pages/sections.py
@@ -31,7 +31,11 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from app.agent.mcp import MCPRuntimeSettings, WINDOWS_MCP_EXPERIMENTAL_TEXT
+from app.agent.mcp import (
+    DESKTOP_MCP_EXPERIMENTAL_TEXT,
+    MCPRuntimeSettings,
+    resolve_desktop_mcp,
+)
 from app.agent.runtime_limits import (
     MAX_CONFIGURABLE_AGENT_STEPS_PER_TURN,
     MAX_CONFIGURABLE_TOOL_CALLS_PER_STEP,
@@ -817,22 +821,31 @@ class ToolsSettingsPage:
         owner = self.dialog
         tab = QWidget(owner)
         runtime_loop_settings = runtime_loop_settings.normalized()
-        owner.windows_mcp_enabled_check = QCheckBox("启用 Windows MCP 桌面控制（实验性）", tab)
-        owner.windows_mcp_enabled_check.setChecked(settings.windows_enabled)
-        owner.windows_mcp_enabled_check.setToolTip(WINDOWS_MCP_EXPERIMENTAL_TEXT)
-
-        restart_hint = QLabel(
-            f"{WINDOWS_MCP_EXPERIMENTAL_TEXT}。保存后需要重启 Sakura 才会加载或卸载 Windows MCP 工具。",
-            tab,
-        )
-        restart_hint.setWordWrap(True)
-        owner.system_restart_hint_label = restart_hint
+        desktop_mcp = resolve_desktop_mcp()
 
         form_layout = QFormLayout()
         form_layout.setContentsMargins(16, 18, 16, 16)
         form_layout.setSpacing(12)
-        form_layout.addRow("", owner.windows_mcp_enabled_check)
-        form_layout.addRow("生效方式", restart_hint)
+
+        if desktop_mcp is not None:
+            owner.windows_mcp_enabled_check = QCheckBox(
+                f"启用 {desktop_mcp.label} 桌面控制（实验性）", tab
+            )
+            owner.windows_mcp_enabled_check.setChecked(settings.windows_enabled)
+            owner.windows_mcp_enabled_check.setToolTip(DESKTOP_MCP_EXPERIMENTAL_TEXT)
+
+            restart_hint = QLabel(
+                f"{DESKTOP_MCP_EXPERIMENTAL_TEXT}。保存后需要重启 Sakura 才会加载或卸载 {desktop_mcp.label} 工具。",
+                tab,
+            )
+            restart_hint.setWordWrap(True)
+            owner.system_restart_hint_label = restart_hint
+
+            form_layout.addRow("", owner.windows_mcp_enabled_check)
+            form_layout.addRow("生效方式", restart_hint)
+        else:
+            # 当前平台暂无内置桌面控制 MCP（如 Linux），不显示桌面控制开关。
+            owner.windows_mcp_enabled_check = None
         form_layout.addRow("", self._build_runtime_loop_group(runtime_loop_settings, tab))
         for contribution in sorted(tools_tab_contributions, key=lambda item: item.order):
             try:

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -2293,7 +2293,11 @@ class SettingsDialog(QDialog):
                 screen_context_batch_limit=self.proactive_batch_limit_spin.value(),
             ),
             "mcp_settings": MCPRuntimeSettings(
-                windows_enabled=self.windows_mcp_enabled_check.isChecked(),
+                windows_enabled=(
+                    self.windows_mcp_enabled_check.isChecked()
+                    if getattr(self, "windows_mcp_enabled_check", None) is not None
+                    else False
+                ),
             ),
             "runtime_loop_settings": RuntimeLoopSettings(
                 max_agent_steps_per_turn=self.agent_steps_per_turn_spin.value(),

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -206,6 +206,7 @@ class SettingsDialog(QDialog):
         self.bubble_settings = bubble_settings or BubbleSettings()
         self.backchannel_settings = (backchannel_settings or BackchannelSettings()).normalized()
         self.runtime_loop_settings = normalize_runtime_loop_settings(runtime_loop_settings)
+        self._initial_mcp_settings = mcp_settings or MCPRuntimeSettings()
         # 延迟导入避免与 app.agent 形成导入环（与 settings_service 一致）。
         from app.agent.memory_curator import MemoryCurationSettings as _MemoryCurationSettings
 
@@ -349,7 +350,7 @@ class SettingsDialog(QDialog):
                 "工具",
                 self._build_scrollable_tab(
                     ToolsSettingsPage(self).build(
-                        mcp_settings or MCPRuntimeSettings(),
+                        self._initial_mcp_settings,
                         self.runtime_loop_settings,
                         tools_tab_contributions or [],
                     )
@@ -2296,7 +2297,7 @@ class SettingsDialog(QDialog):
                 windows_enabled=(
                     self.windows_mcp_enabled_check.isChecked()
                     if getattr(self, "windows_mcp_enabled_check", None) is not None
-                    else False
+                    else self._initial_mcp_settings.windows_enabled
                 ),
             ),
             "runtime_loop_settings": RuntimeLoopSettings(

--- a/tests/integration/test_agent_core.py
+++ b/tests/integration/test_agent_core.py
@@ -1401,7 +1401,15 @@ def test_mcp_provider_skips_disabled_server() -> None:
     provider.close()
 
 
-def test_mcp_runtime_settings_force_disables_windows_server() -> None:
+def test_mcp_runtime_settings_force_disables_windows_server(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    from app.agent.mcp import DesktopMCP
+
+    # apply 现在按平台选择 server；固定为 Windows，测试 windows server 的启用路径。
+    monkeypatch.setattr(
+        "app.agent.mcp.settings.resolve_desktop_mcp",
+        lambda platform=None: DesktopMCP(server_name="windows", label="Windows MCP"),
+    )
+
     config_path = _runtime_root_path("mcp_runtime_override") / "mcp.yaml"
     config_path.parent.mkdir(parents=True, exist_ok=True)
     config_path.write_text(
@@ -1433,7 +1441,15 @@ def test_settings_service_saves_and_loads_experimental_windows_mcp() -> None:
     assert service.load_mcp_runtime_settings().windows_enabled
 
 
-def test_register_mcp_tools_loads_experimental_windows_mcp_when_enabled() -> None:
+def test_register_mcp_tools_loads_experimental_windows_mcp_when_enabled(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    from app.agent.mcp import DesktopMCP
+
+    # 注册路径内部会调用 apply；固定为 Windows，确保 windows server 被启用并注册。
+    monkeypatch.setattr(
+        "app.agent.mcp.settings.resolve_desktop_mcp",
+        lambda platform=None: DesktopMCP(server_name="windows", label="Windows MCP"),
+    )
+
     root = _runtime_root_path("mcp_register_windows_override")
     config_dir = root / "data" / "config"
     config_dir.mkdir(parents=True)

--- a/tests/integration/test_agent_core.py
+++ b/tests/integration/test_agent_core.py
@@ -1433,6 +1433,40 @@ servers:
     assert config.servers[0].enabled
 
 
+def test_mcp_runtime_settings_disables_builtin_desktop_servers_on_unsupported_platform(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr("app.agent.mcp.settings.resolve_desktop_mcp", lambda platform=None: None)
+
+    config_path = _runtime_root_path("mcp_runtime_unsupported_desktop") / "mcp.yaml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        """
+enabled: true
+servers:
+  windows:
+    enabled: true
+    transport: stdio
+    command: python
+  macos:
+    enabled: true
+    transport: stdio
+    command: python
+  custom:
+    enabled: true
+    transport: stdio
+    command: python
+""".strip(),
+        encoding="utf-8",
+    )
+
+    config = apply_mcp_runtime_settings(
+        load_mcp_config(config_path),
+        MCPRuntimeSettings(windows_enabled=True),
+    )
+
+    enabled_by_name = {server.name: server.enabled for server in config.servers}
+    assert enabled_by_name == {"windows": False, "macos": False, "custom": True}
+
+
 def test_settings_service_saves_and_loads_experimental_windows_mcp() -> None:
     service = AppSettingsService(_runtime_root_path("mcp_runtime_save"))
 

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -3528,10 +3528,18 @@ def test_pet_window_syncs_plugin_chat_ui_widgets() -> None:
     app.processEvents()
 
 
-def test_settings_dialog_exposes_experimental_windows_mcp_restart_setting() -> None:
+def test_settings_dialog_exposes_experimental_windows_mcp_restart_setting(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     qtwidgets = pytest.importorskip("PySide6.QtWidgets")
     if not hasattr(qtwidgets, "QApplication"):
         pytest.skip("当前测试环境只提供了 PySide6 stub。")
+
+    from app.agent.mcp import DesktopMCP
+
+    # 桌面控制选项按平台展示；固定为 Windows，使断言不依赖 CI 运行平台。
+    monkeypatch.setattr(
+        "app.ui.settings.pages.sections.resolve_desktop_mcp",
+        lambda platform=None: DesktopMCP(server_name="windows", label="Windows MCP"),
+    )
 
     from app.ui.settings_dialog import SettingsDialog
 
@@ -3564,6 +3572,81 @@ def test_settings_dialog_exposes_experimental_windows_mcp_restart_setting() -> N
     dialog.accept()
 
     assert dialog.result_mcp_settings == MCPRuntimeSettings(windows_enabled=True)
+    dialog.deleteLater()
+    app.processEvents()
+
+
+def test_settings_dialog_desktop_mcp_option_uses_platform_label(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    if not hasattr(qtwidgets, "QApplication"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+
+    from app.agent.mcp import DesktopMCP
+
+    # 模拟 macOS：选项文案显示 macOS MCP，开关仍写回 windows_enabled（向后兼容字段）。
+    monkeypatch.setattr(
+        "app.ui.settings.pages.sections.resolve_desktop_mcp",
+        lambda platform=None: DesktopMCP(server_name="macos", label="macOS MCP"),
+    )
+
+    from app.ui.settings_dialog import SettingsDialog
+
+    QApplication = qtwidgets.QApplication
+    app = QApplication.instance() or QApplication([])
+    root = _ui_runtime_root("mcp_macos_dialog")
+    dialog = SettingsDialog(
+        api_settings=ApiSettings(
+            base_url="https://api.example.com/v1",
+            api_key="test-key",
+            model="test-model",
+        ),
+        tts_settings=_minimal_tts_settings(),
+        base_dir=root,
+        **_settings_dialog_character_kwargs(root),
+        proactive_care_settings=ProactiveCareSettings(screen_context_enabled=True),
+        mcp_settings=MCPRuntimeSettings(windows_enabled=False),
+    )
+
+    assert "macOS MCP" in dialog.windows_mcp_enabled_check.text()
+    dialog.windows_mcp_enabled_check.setChecked(True)
+    dialog.accept()
+    assert dialog.result_mcp_settings == MCPRuntimeSettings(windows_enabled=True)
+    dialog.deleteLater()
+    app.processEvents()
+
+
+def test_settings_dialog_hides_desktop_mcp_option_when_platform_unsupported(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    if not hasattr(qtwidgets, "QApplication"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+
+    # 模拟无内置桌面控制 MCP 的平台（如 Linux）：不展示该选项，开关回落为 False。
+    monkeypatch.setattr(
+        "app.ui.settings.pages.sections.resolve_desktop_mcp",
+        lambda platform=None: None,
+    )
+
+    from app.ui.settings_dialog import SettingsDialog
+
+    QApplication = qtwidgets.QApplication
+    app = QApplication.instance() or QApplication([])
+    root = _ui_runtime_root("mcp_unsupported_dialog")
+    dialog = SettingsDialog(
+        api_settings=ApiSettings(
+            base_url="https://api.example.com/v1",
+            api_key="test-key",
+            model="test-model",
+        ),
+        tts_settings=_minimal_tts_settings(),
+        base_dir=root,
+        **_settings_dialog_character_kwargs(root),
+        proactive_care_settings=ProactiveCareSettings(screen_context_enabled=True),
+        mcp_settings=MCPRuntimeSettings(windows_enabled=False),
+    )
+
+    assert dialog.windows_mcp_enabled_check is None
+    dialog.accept()
+    assert dialog.result_mcp_settings == MCPRuntimeSettings(windows_enabled=False)
     dialog.deleteLater()
     app.processEvents()
 

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -3620,7 +3620,7 @@ def test_settings_dialog_hides_desktop_mcp_option_when_platform_unsupported(monk
     if not hasattr(qtwidgets, "QApplication"):
         pytest.skip("当前测试环境只提供了 PySide6 stub。")
 
-    # 模拟无内置桌面控制 MCP 的平台（如 Linux）：不展示该选项，开关回落为 False。
+    # 模拟无内置桌面控制 MCP 的平台（如 Linux）：不展示该选项，保存时保留原偏好。
     monkeypatch.setattr(
         "app.ui.settings.pages.sections.resolve_desktop_mcp",
         lambda platform=None: None,
@@ -3641,12 +3641,12 @@ def test_settings_dialog_hides_desktop_mcp_option_when_platform_unsupported(monk
         base_dir=root,
         **_settings_dialog_character_kwargs(root),
         proactive_care_settings=ProactiveCareSettings(screen_context_enabled=True),
-        mcp_settings=MCPRuntimeSettings(windows_enabled=False),
+        mcp_settings=MCPRuntimeSettings(windows_enabled=True),
     )
 
     assert dialog.windows_mcp_enabled_check is None
     dialog.accept()
-    assert dialog.result_mcp_settings == MCPRuntimeSettings(windows_enabled=False)
+    assert dialog.result_mcp_settings == MCPRuntimeSettings(windows_enabled=True)
     dialog.deleteLater()
     app.processEvents()
 

--- a/tests/unit/test_default_configs.py
+++ b/tests/unit/test_default_configs.py
@@ -65,6 +65,37 @@ class TestEnsureDefaultConfigs:
         assert "mcp.yaml" not in created
         assert paths.mcp_config().read_text(encoding="utf-8") == user_mcp
 
+    def test_existing_default_mcp_backfills_macos_server(self) -> None:
+        base = _make_base("backfill_macos")
+        paths = StoragePaths(base)
+        paths.config_dir.mkdir(parents=True, exist_ok=True)
+        paths.mcp_config().write_text(
+            """
+enabled: true
+default_call_timeout: 20
+servers:
+  web:
+    transport: stdio
+    command: "{python}"
+  windows:
+    enabled: false
+    transport: stdio
+    command: "{uv}"
+""".strip(),
+            encoding="utf-8",
+        )
+
+        created = ensure_default_configs(base)
+
+        assert "mcp.yaml" not in created
+        from app.agent.mcp.config import load_mcp_config
+
+        config = load_mcp_config(paths.mcp_config())
+        servers = {server.name: server for server in config.servers}
+        assert "macos" in servers
+        assert not servers["macos"].enabled
+        assert servers["macos"].command == "{uvx}"
+
     def test_idempotent(self) -> None:
         base = _make_base("idem")
         first = ensure_default_configs(base)


### PR DESCRIPTION
<html><head></head><body><h2>背景</h2>
<p>桌宠 Agent 已支持通过 MCP 接入 computer-use（桌面控制），但目前只内置了 Windows-MCP，且设置项与启用逻辑把 server 名硬编码为 <code>windows</code>——macOS / Linux 用户看到的是一个无法生效的「Windows MCP」开关。</p>
<h2>改动</h2>
<ul>
<li><strong><code>app/agent/mcp/settings.py</code></strong>：新增按 <code>sys.platform</code> 解析当前平台桌面控制 MCP 的逻辑（<code>win32→windows</code>、<code>darwin→macos</code>、其它→无）；<code>normalize_mcp_runtime_settings</code> / <code>apply_mcp_runtime_settings</code> 泛化为「只切换当前平台对应的那一个 server」。保留 <code>windows_enabled</code> 字段与持久化键 <code>WINDOWS_MCP_ENABLED</code> 做向后兼容，零迁移。</li>
<li><strong>设置 UI（<code>app/ui/settings/pages/sections.py</code> / <code>app/ui/settings_dialog.py</code>）</strong>：开关文案随平台变化（「启用 Windows MCP / macOS MCP 桌面控制」），不支持的平台（如 Linux）隐藏该选项；读取处对选项缺失做容错。</li>
<li><strong><code>app/config/default_configs.py</code></strong>：默认 <code>mcp.yaml</code> 模板新增 <code>macos</code> server（<code>uvx macos-mcp</code>，<code>enabled: false</code>），只放行 <code>App/Snapshot/Click/Type/Wait</code>，排除 <code>Shell</code>（终端/AppleScript）与 <code>Scrape</code>；<code>risk: high</code> + 需确认，<code>Snapshot</code> 免确认。</li>
<li><strong><code>app/ui/pet_window.py</code></strong>：重启提示去掉「Windows MCP」硬编码。</li>
</ul>
<h2>平台行为</h2>

平台 | 设置项 | 启用的 server
-- | -- | --
Windows | 启用 Windows MCP 桌面控制 | windows
macOS | 启用 macOS MCP 桌面控制 | macos
其它（Linux） | 隐藏 | 无


<h2>安全</h2>
<ul>
<li>所有桌面操作工具 <code>risk: high</code>，即使开启 free_access 也强制确认。</li>
<li>终端能力（macOS 的 <code>Shell</code> / Windows 的 <code>PowerShell</code>）默认排除在白名单外。</li>
</ul>
<h2>验证</h2>
<ul>
<li>6 个改动文件 <code>py_compile</code> 通过。</li>
<li>用真实 <code>settings.py</code> + <code>config.py</code> 模拟 win32 / darwin / linux：各平台只启用对应 server、Linux 强制关闭、<code>web</code> 不受影响。</li>
<li>用仓库加载器解析新模板：<code>macos</code> server 合法、默认关、仅放行 5 个工具、<code>Shell</code> 被挡。</li>
</ul>
<h2>使用前提（macOS）</h2>
<ul>
<li>安装 uv：<code>pip install uv</code> 或官方脚本；首次连接 <code>uvx macos-mcp</code> 会自动拉起。</li>
<li>授予系统「辅助功能」+「屏幕录制」权限。</li>
</ul>
<h2>已知后续（不在本 PR 范围）</h2>
<p><code>app/agent/tool_routing.py</code> 给模型的提示词仍硬编码 <code>windows__Snapshot / windows__Screenshot</code>，macOS 下需另行平台化，建议后续 PR 处理。</p></body></html>