### PR TITLE
fix: sync memory curator prompt on character switch

### DIFF
--- a/app/agent/memory.py
+++ b/app/agent/memory.py
@@ -271,6 +271,11 @@ class MemoryStore:
 
         self.scope_id = _normalize_scope_id(scope_id)
 
+    def scoped(self, scope_id: str) -> "ScopedMemoryStore":
+        """创建固定角色 scope 的轻量视图，供后台任务隔离角色切换。"""
+
+        return ScopedMemoryStore(self, scope_id)
+
     def set_api_settings(self, api_settings: "ApiSettings") -> None:
         """API 设置变更后重置 mem0，下次使用新配置重新初始化。"""
 
@@ -1171,6 +1176,51 @@ class MemoryStore:
             self._load_error = error
             self._status = "failed"
             self._status_message = f"长期记忆系统暂时不可用：{error}"
+
+
+class ScopedMemoryStore(MemoryStore):
+    """复用同一个 mem0 运行时，但把业务 scope 固定在创建时的角色上。"""
+
+    def __init__(self, owner: MemoryStore, scope_id: str) -> None:
+        self._owner = owner
+        self.base_dir = owner.base_dir
+        self.api_settings = owner.api_settings
+        self.scope_id = _normalize_scope_id(scope_id)
+        self.memory_client = owner.memory_client
+        self.resource_registry = owner.resource_registry
+        self._loading_started_at = owner._loading_started_at
+
+    def set_scope(self, scope_id: str) -> None:
+        self.scope_id = _normalize_scope_id(scope_id)
+
+    def is_ready(self) -> bool:
+        return self._owner.is_ready()
+
+    def needs_embedding_model_download(self) -> bool:
+        return self._owner.needs_embedding_model_download()
+
+    def close(self) -> None:
+        """视图不拥有底层 mem0 运行时，关闭由 owner 负责。"""
+
+        return None
+
+    def _get_memory(self, *, wait: bool = True) -> Any | None:
+        return self._owner._get_memory(wait=wait)
+
+    def _load_core_profiles(self) -> dict[str, Any]:
+        return self._owner._load_core_profiles()
+
+    def _save_core_profiles(self, profiles: dict[str, Any]) -> None:
+        self._owner._save_core_profiles(profiles)
+
+    def _loading_response(self) -> dict[str, Any]:
+        return self._owner._loading_response()
+
+    def _failed_response(self, error: str) -> dict[str, Any]:
+        return self._owner._failed_response(error)
+
+    def _mark_runtime_failed(self, error: str) -> None:
+        self._owner._mark_runtime_failed(error)
 
 
 def _resolve_base_dir(base_dir: Path | None) -> Path:

--- a/app/agent/memory_curator.py
+++ b/app/agent/memory_curator.py
@@ -142,6 +142,9 @@ class MemoryCurator:
         # 人格卡文本，作为第一人称整理 prompt 的基底；缺省时只用整理任务说明。
         self.system_prompt = (system_prompt or "").strip()
 
+    def set_system_prompt(self, system_prompt: str) -> None:
+        self.system_prompt = (system_prompt or "").strip()
+
     def curate_entries(
         self,
         entries: list[ChatHistoryEntry],

--- a/app/agent/memory_curator.py
+++ b/app/agent/memory_curator.py
@@ -145,6 +145,18 @@ class MemoryCurator:
     def set_system_prompt(self, system_prompt: str) -> None:
         self.system_prompt = (system_prompt or "").strip()
 
+    def snapshot(
+        self,
+        *,
+        memory_store: MemoryStore | None = None,
+        system_prompt: str | None = None,
+    ) -> "MemoryCurator":
+        return MemoryCurator(
+            self.api_client,
+            memory_store or self.memory_store,
+            system_prompt=self.system_prompt if system_prompt is None else system_prompt,
+        )
+
     def curate_entries(
         self,
         entries: list[ChatHistoryEntry],

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -6198,6 +6198,7 @@ class PetWindow(QWidget):
         previous_character_id = self.character_profile.id
         self.character_profile = profile
         self.system_prompt = load_character_system_prompt(profile)
+        self.memory_curator.set_system_prompt(self.system_prompt)
         self.memory_store.set_scope(profile.id)
         self.agent_runtime.update_character(self.system_prompt, profile.reply_tones, profile.portrait_choices)
         self.setWindowTitle(profile.display_name)

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -4298,7 +4298,11 @@ class PetWindow(QWidget):
         self.memory_curation_mode = mode
         self.memory_curation_target_history_count = target_history_count
         self.memory_curation_consumed_turns = consumed_turns
-        worker = MemoryCurationWorker(self.memory_curator, entries)
+        worker_curator = self.memory_curator.snapshot(
+            memory_store=self.memory_store.scoped(self.character_profile.id),
+            system_prompt=self.system_prompt,
+        )
+        worker = MemoryCurationWorker(worker_curator, entries)
         self.resource_manager.spawn_qt_worker(
             worker,
             parent=self,

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -74,6 +74,123 @@ class _DummyPortraitLabel:
         self.visible = True
 
 
+def test_apply_character_syncs_memory_curator_prompt(monkeypatch) -> None:
+    import app.ui.pet_window as pet_window_module
+    from app.ui.pet_window import PetWindow
+
+    events: list[tuple[str, object]] = []
+
+    class ProfileStub:
+        id = "new-character"
+        display_name = "New Character"
+        initial_message = "你好"
+        reply_tones = ["calm"]
+        portrait_choices = ["default"]
+
+    class PreviousProfileStub:
+        id = "old-character"
+
+    class MemoryCuratorStub:
+        def set_system_prompt(self, system_prompt: str) -> None:
+            events.append(("curator_prompt", system_prompt))
+
+    class MemoryStoreStub:
+        def set_scope(self, scope: str) -> None:
+            events.append(("memory_scope", scope))
+
+    class AgentRuntimeStub:
+        def update_character(self, system_prompt, reply_tones, portrait_choices):  # type: ignore[no-untyped-def]
+            events.append(("runtime_character", (system_prompt, reply_tones, portrait_choices)))
+
+        def set_history_store(self, history_store):  # type: ignore[no-untyped-def]
+            events.append(("history_store", history_store))
+
+    class TextSink:
+        def setText(self, text: str) -> None:
+            events.append(("label", text))
+
+        def setPlaceholderText(self, text: str) -> None:
+            events.append(("placeholder", text))
+
+    class PortraitControllerStub:
+        def set_profile(self, profile):  # type: ignore[no-untyped-def]
+            events.append(("portrait", profile.id))
+
+    class SubtitleControllerStub:
+        def cancel_reply_flow(self, initial_message: str) -> None:
+            events.append(("subtitle", initial_message))
+
+    class MinimalWindow:
+        _apply_character = PetWindow._apply_character
+
+        def setWindowTitle(self, title: str) -> None:
+            events.append(("title", title))
+
+        def _normal_input_placeholder_text(self, profile):  # type: ignore[no-untyped-def]
+            return f"Message {profile.display_name}"
+
+        def _portrait_anchor_global(self):  # type: ignore[no-untyped-def]
+            return "anchor"
+
+        def updatesEnabled(self) -> bool:
+            return True
+
+        def setUpdatesEnabled(self, enabled: bool) -> None:
+            events.append(("updates", enabled))
+
+        def _apply_pet_layout(self, *, anchor_global):  # type: ignore[no-untyped-def]
+            events.append(("layout", anchor_global))
+
+        def _load_backchannel_manifest_for(self, profile):  # type: ignore[no-untyped-def]
+            events.append(("backchannel", profile.id))
+
+        def _create_history_store(self, profile):  # type: ignore[no-untyped-def]
+            return f"history:{profile.id}"
+
+        def _create_runtime_event_log(self, profile):  # type: ignore[no-untyped-def]
+            return f"events:{profile.id}"
+
+        def _create_visual_observation_store(self, profile):  # type: ignore[no-untyped-def]
+            return f"visual:{profile.id}"
+
+        def _load_reply_history_from_store(self) -> None:
+            events.append(("reply_history", None))
+
+        def _collapse_auto_fit_bubble_height(self) -> None:
+            events.append(("collapse", None))
+
+        def _emit_plugin_event(self, event_type, payload, *, source):  # type: ignore[no-untyped-def]
+            events.append(("plugin", (event_type, payload, source)))
+
+    monkeypatch.setattr(
+        pet_window_module,
+        "load_character_system_prompt",
+        lambda _profile: "新角色人格卡",
+    )
+
+    window = MinimalWindow()
+    window.character_profile = PreviousProfileStub()
+    window.memory_curator = MemoryCuratorStub()
+    window.memory_store = MemoryStoreStub()
+    window.agent_runtime = AgentRuntimeStub()
+    window.name_label = TextSink()
+    window.input_edit = TextSink()
+    window.portrait_controller = PortraitControllerStub()
+    window.history_window = None
+    window.subtitle_controller = SubtitleControllerStub()
+    window.messages = ["旧消息"]
+
+    window._apply_character(ProfileStub())
+
+    assert window.system_prompt == "新角色人格卡"
+    assert ("curator_prompt", "新角色人格卡") in events
+    assert ("memory_scope", "new-character") in events
+    assert (
+        "runtime_character",
+        ("新角色人格卡", ["calm"], ["default"]),
+    ) in events
+
+
 def test_renderer_replaces_default_portrait_suppresses_png_labels() -> None:
     from app.ui.pet_window import PetWindow
 

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -191,6 +191,107 @@ def test_apply_character_syncs_memory_curator_prompt(monkeypatch) -> None:
     ) in events
 
 
+def test_start_memory_curation_snapshots_prompt_and_scope() -> None:
+    from app.storage.chat_history import ChatHistoryEntry
+    from app.ui.pet_window import PetWindow
+
+    captured: dict[str, object] = {}
+
+    class ProfileStub:
+        id = "old-character"
+
+    class ScopedStoreStub:
+        def __init__(self, scope_id: str) -> None:
+            self.scope_id = scope_id
+
+    class MemoryStoreStub:
+        def __init__(self) -> None:
+            self.scope_id = "old-character"
+            self.scoped_calls: list[str] = []
+
+        def scoped(self, scope_id: str) -> ScopedStoreStub:
+            self.scoped_calls.append(scope_id)
+            return ScopedStoreStub(scope_id)
+
+        def set_scope(self, scope_id: str) -> None:
+            self.scope_id = scope_id
+
+    class CuratorStub:
+        def __init__(self, *, system_prompt: str, memory_store) -> None:  # type: ignore[no-untyped-def]
+            self.system_prompt = system_prompt
+            self.memory_store = memory_store
+
+        def snapshot(self, *, memory_store, system_prompt):  # type: ignore[no-untyped-def]
+            return CuratorStub(system_prompt=system_prompt, memory_store=memory_store)
+
+        def set_system_prompt(self, system_prompt: str) -> None:
+            self.system_prompt = system_prompt
+
+    class WorkerStub:
+        finished = object()
+        failed = object()
+        cancelled = object()
+
+        def __init__(self, curator, entries):  # type: ignore[no-untyped-def]
+            self.curator = curator
+            self.entries = entries
+            captured["worker"] = self
+
+    class ResourceManagerStub:
+        def spawn_qt_worker(self, worker, **kwargs):  # type: ignore[no-untyped-def]
+            captured["spawned_worker"] = worker
+            captured["spawn_kwargs"] = kwargs
+
+    class MinimalWindow:
+        _start_memory_curation = PetWindow._start_memory_curation
+
+        def _handle_memory_curation_finished(self, _result):  # type: ignore[no-untyped-def]
+            pass
+
+        def _handle_memory_curation_failed(self, _message):  # type: ignore[no-untyped-def]
+            pass
+
+        def _handle_memory_curation_cancelled(self):  # type: ignore[no-untyped-def]
+            pass
+
+        def _cleanup_memory_curation_worker(self):  # type: ignore[no-untyped-def]
+            pass
+
+    memory_store = MemoryStoreStub()
+    window = MinimalWindow()
+    window.memory_curation_thread = None
+    window.memory_curator = CuratorStub(
+        system_prompt="旧角色人格卡",
+        memory_store=memory_store,
+    )
+    window.memory_store = memory_store
+    window.character_profile = ProfileStub()
+    window.system_prompt = "旧角色人格卡"
+    window.resource_manager = ResourceManagerStub()
+
+    import app.ui.pet_window as pet_window_module
+
+    original_worker = pet_window_module.MemoryCurationWorker
+    pet_window_module.MemoryCurationWorker = WorkerStub
+    try:
+        window._start_memory_curation(
+            [ChatHistoryEntry("2026-06-01T10:00:00+08:00", "user", "旧角色对话")],
+            mode="auto",
+            target_history_count=1,
+            consumed_turns=1,
+        )
+    finally:
+        pet_window_module.MemoryCurationWorker = original_worker
+
+    memory_store.set_scope("new-character")
+    window.memory_curator.set_system_prompt("新角色人格卡")
+
+    worker = captured["worker"]
+    assert memory_store.scoped_calls == ["old-character"]
+    assert worker.curator.system_prompt == "旧角色人格卡"  # type: ignore[attr-defined]
+    assert worker.curator.memory_store.scope_id == "old-character"  # type: ignore[attr-defined]
+
+
 def test_renderer_replaces_default_portrait_suppresses_png_labels() -> None:
     from app.ui.pet_window import PetWindow
 

--- a/tests/unit/test_memory_curator.py
+++ b/tests/unit/test_memory_curator.py
@@ -47,6 +47,23 @@ def test_curator_adds_memory_from_first_person_view() -> None:
     assert "主人喜欢猫" in user_content
 
 
+def test_curator_updates_system_prompt_for_next_curation() -> None:
+    store = FakeMemoryStore()
+    api = FakeCurationApiClient(['{"operations":[]}', '{"operations":[]}'])
+    curator = MemoryCurator(api, store, system_prompt="旧角色人格卡")
+
+    curator.curate_entries([_entry("user", "第一轮对话")])
+    curator.set_system_prompt("新角色人格卡")
+    curator.curate_entries([_entry("user", "第二轮对话")])
+
+    first_prompt = str(api.calls[0]["system_prompt"])
+    second_prompt = str(api.calls[1]["system_prompt"])
+    assert "旧角色人格卡" in first_prompt
+    assert "新角色人格卡" not in first_prompt
+    assert "新角色人格卡" in second_prompt
+    assert "旧角色人格卡" not in second_prompt
+
+
 def test_curator_updates_and_deletes_existing_memories() -> None:
     store = FakeMemoryStore(
         existing=[

--- a/tests/unit/test_memory_curator.py
+++ b/tests/unit/test_memory_curator.py
@@ -64,6 +64,48 @@ def test_curator_updates_system_prompt_for_next_curation() -> None:
     assert "旧角色人格卡" not in second_prompt
 
 
+def test_curator_snapshot_keeps_prompt_and_store_context() -> None:
+    active_store = FakeMemoryStore()
+    snapshot_store = FakeMemoryStore()
+    api = FakeCurationApiClient(['{"operations":[]}'])
+    curator = MemoryCurator(api, active_store, system_prompt="旧角色人格卡")
+
+    snapshot = curator.snapshot(memory_store=snapshot_store)
+    curator.set_system_prompt("新角色人格卡")
+
+    snapshot.curate_entries([_entry("user", "整理旧角色对话")])
+
+    prompt = str(api.calls[0]["system_prompt"])
+    assert "旧角色人格卡" in prompt
+    assert "新角色人格卡" not in prompt
+    assert snapshot.memory_store is snapshot_store
+
+
+def test_scoped_memory_store_keeps_scope_after_parent_switch() -> None:
+    mem0 = ScopeRecordingMem0()
+    root = _runtime_json_path("scoped_memory_store")
+    root.mkdir(parents=True, exist_ok=True)
+    store = MemoryStore(base_dir=root, scope_id="old-character", memory_client=mem0)
+    scoped_store = store.scoped("old-character")
+
+    store.set_scope("new-character")
+    scoped_store.list_memories(limit=1)
+    scoped_store.create_memory(
+        {"content": "旧角色记忆", "source": "self_curation"},
+        allow_sensitive=True,
+    )
+
+    assert mem0.get_all_calls == [{"user_id": "old-character"}]
+    assert mem0.add_calls == [
+        {
+            "content": "旧角色记忆",
+            "user_id": "old-character",
+            "metadata_scope": "old-character",
+            "infer": False,
+        }
+    ]
+
+
 def test_curator_updates_and_deletes_existing_memories() -> None:
     store = FakeMemoryStore(
         existing=[
@@ -399,6 +441,31 @@ class CancellingCurationApiClient(FakeCurationApiClient):
         raw = super().complete_raw(system_prompt, messages, **chat_params)
         self.token.cancel()
         return raw
+
+
+class ScopeRecordingMem0:
+    def __init__(self) -> None:
+        self.get_all_calls: list[dict[str, str]] = []
+        self.add_calls: list[dict[str, object]] = []
+
+    def get_all(self, *, filters, top_k):  # type: ignore[no-untyped-def]
+        self.get_all_calls.append(dict(filters))
+        return []
+
+    def add(self, content, *, user_id, metadata, infer):  # type: ignore[no-untyped-def]
+        self.add_calls.append(
+            {
+                "content": content,
+                "user_id": user_id,
+                "metadata_scope": metadata.get("scope"),
+                "infer": infer,
+            }
+        )
+        return {
+            "id": "memory-001",
+            "memory": content,
+            "metadata": metadata,
+        }
 
 
 class FakeMem0WithCurationCache:


### PR DESCRIPTION
## Summary
- Add a MemoryCurator setter for refreshing the active character system prompt.
- Sync the curator prompt during PetWindow character switching so memory curation uses the current persona.
- Cover the curator refresh and PetWindow switch path with regression tests.

Fixes #118

## Tests
- .\\runtime\\python.exe -m pytest tests\\unit\\test_memory_curator.py tests\\ui\\test_pet_window.py -k memory