### PR TITLE
fix: 绕过本地服务请求代理

### DIFF
--- a/app/core/http_client.py
+++ b/app/core/http_client.py
@@ -1,0 +1,59 @@
+"""Small urllib helpers shared by local and remote HTTP clients."""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+import urllib.request
+from typing import Any
+from urllib.parse import urlparse
+
+_LOOPBACK_PROXY_BYPASS_OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+
+
+def is_loopback_url(url: str) -> bool:
+    """Return True when *url* targets this machine's loopback interface."""
+
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return False
+    host = parsed.hostname
+    if not host:
+        return False
+
+    normalized_host = host.rstrip(".").casefold()
+    if normalized_host == "localhost":
+        return True
+
+    try:
+        return ipaddress.ip_address(normalized_host).is_loopback
+    except ValueError:
+        return False
+
+
+def urlopen_direct_for_loopback(
+    url: str | urllib.request.Request,
+    data: bytes | None = None,
+    timeout: Any = socket._GLOBAL_DEFAULT_TIMEOUT,
+):
+    """Open loopback URLs without urllib's environment/system proxy handlers.
+
+    Remote URLs still use urllib.request.urlopen so user-configured proxies keep
+    working for normal API and download traffic.
+    """
+
+    if is_loopback_url(_request_url(url)):
+        if data is None:
+            return _LOOPBACK_PROXY_BYPASS_OPENER.open(url, timeout=timeout)
+        return _LOOPBACK_PROXY_BYPASS_OPENER.open(url, data=data, timeout=timeout)
+    if data is None:
+        return urllib.request.urlopen(url, timeout=timeout)
+    return urllib.request.urlopen(url, data=data, timeout=timeout)
+
+
+def _request_url(url: str | urllib.request.Request) -> str:
+    full_url = getattr(url, "full_url", None)
+    if isinstance(full_url, str):
+        return full_url
+    return str(url)

--- a/app/llm/api_client.py
+++ b/app/llm/api_client.py
@@ -10,9 +10,10 @@ from dataclasses import dataclass
 from typing import Any, Callable
 from urllib.parse import urlparse, urlunparse
 
-from app.llm.chat_reply import ChatReply, parse_chat_reply, sanitize_reply_tones
 from app.core.cancellation import CancelChecker, cancellable_sleep, check_cancelled
 from app.core.debug_log import debug_log, summarize_messages
+from app.core.http_client import urlopen_direct_for_loopback
+from app.llm.chat_reply import ChatReply, parse_chat_reply, sanitize_reply_tones
 from app.llm.prompt_templates import build_segmented_reply_instruction
 
 
@@ -518,7 +519,7 @@ class OpenAICompatibleClient:
             check_cancelled(cancel_checker)
             started_at = time.perf_counter()
             try:
-                with urllib.request.urlopen(
+                with urlopen_direct_for_loopback(
                     request,
                     timeout=self.settings.timeout_seconds,
                 ) as response:

--- a/app/voice/tts_service.py
+++ b/app/voice/tts_service.py
@@ -30,6 +30,7 @@ from urllib.parse import urlencode, urlparse, urlunparse
 
 from app.core.debug_log import debug_log
 from app.core.gui_log import record_tts_service_output
+from app.core.http_client import urlopen_direct_for_loopback
 from app.llm.chat_reply import DEFAULT_TONE
 from app.storage.paths import StoragePaths
 from app.voice.runtime_compat import find_usable_runtime_python, format_runtime_python_issue
@@ -496,7 +497,7 @@ def _probe_gpt_sovits_http(api_url: str, timeout: int) -> bool:
     probe_url = urlunparse(parsed._replace(path=base_path or "/", query=""))
     request = urllib.request.Request(url=probe_url, method="GET")
     try:
-        with urllib.request.urlopen(request, timeout=timeout):
+        with urlopen_direct_for_loopback(request, timeout=timeout):
             pass
     except urllib.error.HTTPError:
         # 任何 HTTP 状态码都说明服务 HTTP 层已就绪
@@ -512,7 +513,7 @@ def _probe_genie_api_url(api_url: str, timeout: int) -> bool:
         method="GET",
     )
     try:
-        with urllib.request.urlopen(request, timeout=timeout) as response:
+        with urlopen_direct_for_loopback(request, timeout=timeout) as response:
             body = response.read()
     except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError, OSError) as exc:
         debug_log("TTS", "Genie API 端点探测失败", {"api_url": api_url, "error": str(exc)})
@@ -1083,7 +1084,7 @@ class TTSServiceSupervisor:
         request = urllib.request.Request(url=url, method="GET")
         try:
             debug_log("TTS", "请求切换权重", {"endpoint": endpoint, "weights_path": weights_path})
-            with urllib.request.urlopen(request, timeout=self.settings.timeout_seconds) as response:
+            with urlopen_direct_for_loopback(request, timeout=self.settings.timeout_seconds) as response:
                 response.read()
                 debug_log(
                     "TTS",
@@ -1504,7 +1505,7 @@ class GenieServiceSupervisor(TTSServiceSupervisor):
             method="POST",
             headers={"Content-Type": "application/json"},
         )
-        with urllib.request.urlopen(request, timeout=timeout) as response:
+        with urlopen_direct_for_loopback(request, timeout=timeout) as response:
             return response.read()
 
     def _genie_character_name(self) -> str:

--- a/app/voice/tts_synthesis.py
+++ b/app/voice/tts_synthesis.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from typing import Protocol
 
 from app.core.debug_log import debug_log
+from app.core.http_client import urlopen_direct_for_loopback
 from app.core.interaction import set_interaction_id
 from app.llm.chat_reply import DEFAULT_TONE
 from app.voice import audio_checks as _audio_checks
@@ -197,7 +198,7 @@ class GPTSoVITSSynthesisEngine:
             )
 
             try:
-                with urllib.request.urlopen(
+                with urlopen_direct_for_loopback(
                     http_request,
                     timeout=settings.timeout_seconds,
                 ) as response:

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -649,6 +649,41 @@ def test_connection_omits_temperature(monkeypatch) -> None:  # type: ignore[no-u
     assert "temperature" not in captured["payload"]
 
 
+def test_local_chat_completion_base_url_uses_loopback_http_helper(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    captured: dict[str, Any] = {}
+    client = OpenAICompatibleClient(
+        ApiSettings(base_url="http://127.0.0.1:11434/v1", api_key="key", model="local-model")
+    )
+
+    class FakeResponse:
+        status = 200
+
+        def __enter__(self):  # type: ignore[no-untyped-def]
+            return self
+
+        def __exit__(self, *_args):  # type: ignore[no-untyped-def]
+            return None
+
+        def read(self) -> bytes:
+            return b'{"choices":[{"message":{"content":"OK"}}]}'
+
+    def fake_urlopen_direct_for_loopback(request, timeout):  # type: ignore[no-untyped-def]
+        captured["url"] = request.full_url
+        captured["timeout"] = timeout
+        return FakeResponse()
+
+    monkeypatch.setattr(
+        "app.llm.api_client.urlopen_direct_for_loopback",
+        fake_urlopen_direct_for_loopback,
+    )
+
+    assert client.test_connection() == "OK"
+    assert captured == {
+        "url": "http://127.0.0.1:11434/v1/chat/completions",
+        "timeout": 60,
+    }
+
+
 def test_list_models_allows_empty_model_but_requires_key() -> None:
     client = OpenAICompatibleClient(ApiSettings("https://api.example.com/v1", "", ""))
 

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import urllib.request
+
+from app.core import http_client
+
+
+def test_is_loopback_url_detects_local_hosts() -> None:
+    assert http_client.is_loopback_url("http://127.0.0.1:9880/tts")
+    assert http_client.is_loopback_url("http://127.12.34.56:9880/tts")
+    assert http_client.is_loopback_url("http://localhost:9880/tts")
+    assert http_client.is_loopback_url("http://[::1]:9880/tts")
+    assert not http_client.is_loopback_url("https://api.example.com/v1")
+    assert not http_client.is_loopback_url("http://192.168.1.20:9880/tts")
+
+
+def test_urlopen_direct_for_loopback_uses_proxyless_opener(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    calls: list[tuple[object, int]] = []
+
+    class FakeOpener:
+        def open(self, url, timeout):  # type: ignore[no-untyped-def]
+            calls.append((url, timeout))
+            return "local-response"
+
+    def fail_standard_urlopen(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("loopback requests must bypass urllib's standard opener")
+
+    monkeypatch.setattr(http_client, "_LOOPBACK_PROXY_BYPASS_OPENER", FakeOpener())
+    monkeypatch.setattr(http_client.urllib.request, "urlopen", fail_standard_urlopen)
+
+    request = urllib.request.Request("http://localhost:9880/tts", data=b"{}", method="POST")
+
+    assert http_client.urlopen_direct_for_loopback(request, timeout=7) == "local-response"
+    assert calls == [(request, 7)]
+
+
+def test_urlopen_direct_for_loopback_keeps_standard_opener_for_remote(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    captured: dict[str, object] = {}
+
+    class FakeOpener:
+        def open(self, *_args, **_kwargs):  # type: ignore[no-untyped-def]
+            raise AssertionError("remote requests should keep urllib's standard opener")
+
+    def fake_standard_urlopen(url, timeout):  # type: ignore[no-untyped-def]
+        captured["url"] = url
+        captured["timeout"] = timeout
+        return "remote-response"
+
+    monkeypatch.setattr(http_client, "_LOOPBACK_PROXY_BYPASS_OPENER", FakeOpener())
+    monkeypatch.setattr(http_client.urllib.request, "urlopen", fake_standard_urlopen)
+
+    request = urllib.request.Request("https://api.example.com/v1/models", method="GET")
+
+    assert http_client.urlopen_direct_for_loopback(request, timeout=11) == "remote-response"
+    assert captured == {"url": request, "timeout": 11}

--- a/tests/unit/test_tts.py
+++ b/tests/unit/test_tts.py
@@ -1128,7 +1128,7 @@ def test_tts_weight_switch_error_includes_endpoint_and_path(monkeypatch) -> None
     def fake_urlopen(*_args: object, **_kwargs: object) -> object:
         raise urllib.error.URLError("bad weights")
 
-    monkeypatch.setattr("app.voice.tts_service.urllib.request.urlopen", fake_urlopen)
+    monkeypatch.setattr("app.voice.tts_service.urlopen_direct_for_loopback", fake_urlopen)
 
     ok = TTSServiceSupervisor._request_weight_switch(
         provider,


### PR DESCRIPTION
## 说明
- 修复 Windows 系统代理劫持本地 GPT-SoVITS / Genie TTS 请求的问题
- 新增 loopback HTTP helper，对 127.0.0.1、localhost、::1 等本地地址禁用 urllib 代理
- 将 TTS 探测、切权重、合成请求以及本地 OpenAI-compatible LLM 请求接入该 helper

## 验证
- .\\runtime\\python.exe -m pytest tests/unit/test_http_client.py tests/unit/test_api_client.py tests/unit/test_tts.py tests/unit/test_tts_service_state.py

Closes #117