### PR TITLE
fix: 修复混合 DPI 多屏截图缩放异常

### DIFF
--- a/app/ui/__init__.py
+++ b/app/ui/__init__.py
@@ -6,8 +6,12 @@ from app.ui.manual_screenshot_overlay import (
 )
 from app.ui.portrait_controller import PortraitController
 from app.ui.screen_capture import (
+    ScreenCapture,
+    VirtualDesktopCapture,
+    capture_virtual_desktop,
     capture_virtual_desktop_pixmap,
     crop_logical_region,
+    draw_virtual_desktop_capture,
     logical_to_device_rect,
 )
 from app.ui.styles import PET_WINDOW_STYLEHEET
@@ -19,8 +23,12 @@ __all__ = [
     "MANUAL_SCREENSHOT_MIN_SIZE",
     "ManualScreenshotOverlay",
     "PortraitController",
+    "ScreenCapture",
+    "VirtualDesktopCapture",
+    "capture_virtual_desktop",
     "capture_virtual_desktop_pixmap",
     "crop_logical_region",
+    "draw_virtual_desktop_capture",
     "logical_to_device_rect",
     "PET_WINDOW_STYLEHEET",
     "SubtitleController",

--- a/app/ui/manual_screenshot_overlay.py
+++ b/app/ui/manual_screenshot_overlay.py
@@ -4,7 +4,11 @@ from PySide6.QtCore import QPoint, QRect, Signal, Qt
 from PySide6.QtGui import QColor, QKeyEvent, QMouseEvent, QPainter, QPixmap
 from PySide6.QtWidgets import QWidget
 
-from app.ui.screen_capture import logical_to_device_rect
+from app.ui.screen_capture import (
+    VirtualDesktopCapture,
+    draw_virtual_desktop_capture,
+    logical_to_device_rect,
+)
 
 
 MANUAL_SCREENSHOT_MIN_SIZE = 8
@@ -16,10 +20,26 @@ class ManualScreenshotOverlay(QWidget):
     selected = Signal(object)
     cancelled = Signal()
 
-    def __init__(self, desktop_pixmap: QPixmap, virtual_geometry: QRect) -> None:
+    def __init__(
+        self,
+        desktop_pixmap: QPixmap | VirtualDesktopCapture,
+        virtual_geometry: QRect | None = None,
+    ) -> None:
         super().__init__(None)
-        self.desktop_pixmap = desktop_pixmap
-        self.virtual_geometry = QRect(virtual_geometry)
+        if isinstance(desktop_pixmap, VirtualDesktopCapture):
+            self.desktop_capture = desktop_pixmap
+            self.desktop_pixmap = (
+                desktop_pixmap.screens[0].pixmap if len(desktop_pixmap.screens) == 1 else QPixmap()
+            )
+            self.virtual_geometry = QRect(desktop_pixmap.geometry)
+        else:
+            if virtual_geometry is None:
+                raise TypeError("单张桌面截图必须提供 virtual_geometry。")
+            self.desktop_pixmap = desktop_pixmap
+            self.virtual_geometry = QRect(virtual_geometry)
+            self.desktop_capture = VirtualDesktopCapture.from_pixmap(
+                desktop_pixmap, self.virtual_geometry
+            )
         self.selection_start: QPoint | None = None
         self.selection_end: QPoint | None = None
         self.setWindowFlags(
@@ -35,14 +55,13 @@ class ManualScreenshotOverlay(QWidget):
     def paintEvent(self, event) -> None:  # type: ignore[no-untyped-def]
         del event
         painter = QPainter(self)
-        painter.drawPixmap(self.rect(), self.desktop_pixmap)
+        draw_virtual_desktop_capture(painter, self.desktop_capture)
         painter.fillRect(self.rect(), QColor(0, 0, 0, 95))
 
         selection = self._selection_rect()
         if not selection.isNull():
-            # 覆盖层按逻辑坐标布局，但 desktop_pixmap 是物理像素缓冲，
-            # drawPixmap 的源矩形按物理像素取址，故须把逻辑选区换算成物理像素。
-            painter.drawPixmap(selection, self.desktop_pixmap, self._device_rect(selection))
+            selected = self._crop_selection(selection)
+            painter.drawPixmap(selection, selected)
             painter.fillRect(selection, QColor(255, 255, 255, 28))
             painter.setPen(QColor(74, 170, 214, 245))
             painter.drawRect(selection.adjusted(0, 0, -1, -1))
@@ -75,9 +94,12 @@ class ManualScreenshotOverlay(QWidget):
         ):
             self._cancel()
             return
-        # copy() 按物理像素取址，须用换算后的物理选区，否则截到的是缩半且左上偏移的错误区域。
-        self.selected.emit(self.desktop_pixmap.copy(self._device_rect(selection)))
+        self.selected.emit(self._crop_selection(selection))
         self.close()
+
+    def _crop_selection(self, rect: QRect) -> QPixmap:
+        global_rect = QRect(rect).translated(self.virtual_geometry.topLeft())
+        return self.desktop_capture.crop(global_rect)
 
     def keyPressEvent(self, event: QKeyEvent) -> None:
         if event.key() == Qt.Key.Key_Escape:
@@ -91,7 +113,12 @@ class ManualScreenshotOverlay(QWidget):
         高 DPI 下 desktop_pixmap 按物理像素分配并设了 devicePixelRatio，
         copy()/drawPixmap 源矩形都以物理像素为单位，须乘以该比例。
         """
-        return logical_to_device_rect(self.desktop_pixmap, rect)
+        if len(self.desktop_capture.screens) != 1:
+            raise ValueError("混合 DPI 桌面没有单一的设备像素矩形。")
+        screen = self.desktop_capture.screens[0]
+        global_rect = QRect(rect).translated(self.virtual_geometry.topLeft())
+        screen_local = global_rect.translated(-screen.geometry.topLeft())
+        return logical_to_device_rect(screen.pixmap, screen_local)
 
     def _selection_rect(self) -> QRect:
         if self.selection_start is None or self.selection_end is None:

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -242,9 +242,10 @@ from app.ui import (
     PortraitController,
     SubtitleController,
     ToolConfirmationPanel,
+    VirtualDesktopCapture,
     build_pet_tray_menu,
+    capture_virtual_desktop,
     capture_virtual_desktop_pixmap,
-    crop_logical_region,
 )
 from app.ui.styles import pet_window_stylesheet
 from app.ui.theme import (
@@ -2629,15 +2630,11 @@ class PetWindow(QWidget):
     def _build_blurred_background(self, global_rect: QRect) -> QPixmap | None:
         """截取虚拟桌面，裁出 global_rect（逻辑全局坐标）对应区域并做高斯模糊。
 
-        capture_virtual_desktop_pixmap 返回的是「物理像素缓冲 + devicePixelRatio」的虚拟桌面图：
-        其 rect()/copy() 都按物理像素取址（width()=物理宽，非逻辑宽）。因此必须把逻辑全局坐标
-        乘以 devicePixelRatio 换算成物理像素再裁剪，否则裁出的区域会随坐标增大而向左上偏移，
-        在屏幕边缘表现为模糊背景与真实桌面错位。
+        截图保留每块屏幕自己的 devicePixelRatio；裁剪时按 global_rect 与各屏幕的交集分别换算，
+        因而输入栏跨越不同缩放比例的屏幕时也能保持坐标和内容对齐。
         """
-        desktop_pixmap, virtual_geometry = self._capture_virtual_desktop_pixmap()
-        if desktop_pixmap.isNull():
-            return None
-        cropped = crop_logical_region(desktop_pixmap, virtual_geometry, global_rect)
+        desktop_capture = self._capture_virtual_desktop()
+        cropped = desktop_capture.crop(global_rect)
         if cropped.isNull():
             return None
         # 模糊背景裁剪：用降采样再放大实现毛玻璃效果。
@@ -2872,7 +2869,7 @@ class PetWindow(QWidget):
 
     def _show_manual_screenshot_overlay(self) -> None:
         try:
-            desktop_pixmap, virtual_geometry = self._capture_virtual_desktop_pixmap()
+            desktop_capture = self._capture_virtual_desktop()
         except RuntimeError as exc:
             show_themed_warning(
                 self,
@@ -2886,7 +2883,7 @@ class PetWindow(QWidget):
             log_event("PetWindow", "手动框选截图启动失败", {"error": str(exc)})
             return
 
-        overlay = ManualScreenshotOverlay(desktop_pixmap, virtual_geometry)
+        overlay = ManualScreenshotOverlay(desktop_capture)
         overlay.selected.connect(self._handle_manual_screenshot_selected)
         overlay.cancelled.connect(self._handle_manual_screenshot_cancelled)
         overlay.destroyed.connect(self._clear_manual_screenshot_overlay_ref)
@@ -2897,6 +2894,9 @@ class PetWindow(QWidget):
 
     def _capture_virtual_desktop_pixmap(self) -> tuple[QPixmap, QRect]:
         return capture_virtual_desktop_pixmap()
+
+    def _capture_virtual_desktop(self) -> VirtualDesktopCapture:
+        return capture_virtual_desktop()
 
     @Slot(object)
     def _handle_manual_screenshot_selected(self, pixmap: QPixmap) -> None:

--- a/app/ui/screen_capture.py
+++ b/app/ui/screen_capture.py
@@ -1,106 +1,179 @@
 from __future__ import annotations
 
-from PySide6.QtCore import QRect, Qt
-from PySide6.QtGui import QPainter, QPixmap
+from dataclasses import dataclass
+
+from PySide6.QtCore import QPoint, QRect, Qt
+from PySide6.QtGui import QColor, QPainter, QPixmap
 from PySide6.QtWidgets import QApplication
 
 
-def capture_virtual_desktop_pixmap() -> tuple[QPixmap, QRect]:
-    """截取所有屏幕合并后的虚拟桌面。"""
+@dataclass(frozen=True)
+class ScreenCapture:
+    """一块屏幕的截图及其全局逻辑坐标。"""
+
+    geometry: QRect
+    pixmap: QPixmap
+    device_pixel_ratio: float | None = None
+
+    def __post_init__(self) -> None:
+        if self.device_pixel_ratio is None:
+            object.__setattr__(
+                self,
+                "device_pixel_ratio",
+                self.pixmap.devicePixelRatio() or 1.0,
+            )
+
+
+@dataclass(frozen=True)
+class VirtualDesktopCapture:
+    """保留各屏幕原生 DPR 的虚拟桌面截图。"""
+
+    screens: tuple[ScreenCapture, ...]
+    geometry: QRect
+
+    @classmethod
+    def from_pixmap(cls, pixmap: QPixmap, geometry: QRect) -> VirtualDesktopCapture:
+        """把旧的单 pixmap 截图包装成兼容的虚拟桌面截图。"""
+
+        return cls((ScreenCapture(QRect(geometry), pixmap),), QRect(geometry))
+
+    def crop(self, global_logical_rect: QRect) -> QPixmap:
+        """按各屏 DPR 裁剪并合成全局逻辑区域。"""
+
+        if global_logical_rect.width() <= 0 or global_logical_rect.height() <= 0:
+            return QPixmap()
+
+        intersections = [
+            (screen, global_logical_rect.intersected(screen.geometry))
+            for screen in self.screens
+            if screen.geometry.intersects(global_logical_rect)
+        ]
+        intersections = [(screen, rect) for screen, rect in intersections if not rect.isEmpty()]
+        if not intersections:
+            return QPixmap()
+
+        # 一张 QPixmap 只能携带一个 DPR。输出使用相交屏幕中的最高 DPR，低 DPR
+        # 屏幕内容只在最终合成时缩放，不再错误套用其他屏幕的坐标换算。
+        output_dpr = max(
+            float(screen.device_pixel_ratio or 1.0) for screen, _rect in intersections
+        )
+        output_rect = _scale_logical_rect(
+            QRect(0, 0, global_logical_rect.width(), global_logical_rect.height()),
+            output_dpr,
+        )
+        result = QPixmap(output_rect.size())
+        result.fill(Qt.GlobalColor.transparent)
+
+        painter = QPainter(result)
+        painter.setRenderHint(QPainter.RenderHint.SmoothPixmapTransform, False)
+        for screen, intersection in intersections:
+            screen_local = intersection.translated(-screen.geometry.topLeft())
+            source_rect = logical_to_device_rect(screen.pixmap, screen_local)
+            source_rect = source_rect.intersected(screen.pixmap.rect())
+            if source_rect.isEmpty():
+                continue
+
+            fragment = screen.pixmap.copy(source_rect)
+            fragment.setDevicePixelRatio(1.0)
+            output_local = intersection.translated(-global_logical_rect.topLeft())
+            target_rect = _scale_logical_rect(output_local, output_dpr)
+            painter.drawPixmap(target_rect, fragment, fragment.rect())
+        painter.end()
+        result.setDevicePixelRatio(output_dpr)
+        return result
+
+    def color_at(self, global_logical_pos: QPoint) -> QColor | None:
+        """读取全局逻辑坐标处的颜色。"""
+
+        for screen in self.screens:
+            if not screen.geometry.contains(global_logical_pos):
+                continue
+            local = global_logical_pos - screen.geometry.topLeft()
+            device = logical_to_device_rect(screen.pixmap, QRect(local, local)).topLeft()
+            image = screen.pixmap.toImage()
+            if 0 <= device.x() < image.width() and 0 <= device.y() < image.height():
+                return image.pixelColor(device)
+        return None
+
+
+def capture_virtual_desktop() -> VirtualDesktopCapture:
+    """逐屏截取虚拟桌面，并保留每块屏幕自己的 DPR。"""
 
     screens = QApplication.screens()
     if not screens:
         raise RuntimeError("无法找到可截图的屏幕。")
 
+    captured: list[ScreenCapture] = []
     virtual_geometry = QRect()
     for screen in screens:
-        virtual_geometry = virtual_geometry.united(screen.geometry())
+        geometry = screen.geometry()
+        virtual_geometry = virtual_geometry.united(geometry)
+        pixmap = screen.grabWindow(0)
+        if pixmap.isNull():
+            continue
+        dpr = screen.devicePixelRatio() or 1.0
+        pixmap.setDevicePixelRatio(dpr)
+        captured.append(ScreenCapture(QRect(geometry), pixmap, dpr))
+
     if virtual_geometry.isNull():
         raise RuntimeError("无法获取虚拟桌面区域。")
-
-    # 按物理像素分配缓冲区，避免高 DPI 缩放导致截图模糊。
-    # 注意：返回的 QPixmap 是「物理像素缓冲 + devicePixelRatio」。
-    #   - QPainter / drawPixmap(target, pixmap) 这类按逻辑坐标绘制的接口无需改动；
-    #   - 但 copy()、rect()、width()/height()、drawPixmap(target, pixmap, source) 的
-    #     源矩形都以物理像素为单位，下游若按逻辑坐标裁剪须先乘 devicePixelRatio，
-    #     否则裁出的区域会缩半并随坐标增大向左上偏移（屏幕边缘尤其明显）。
-    max_dpr = max(s.devicePixelRatio() for s in screens)
-    phys_w = round(virtual_geometry.width() * max_dpr)
-    phys_h = round(virtual_geometry.height() * max_dpr)
-    desktop_pixmap = QPixmap(phys_w, phys_h)
-    desktop_pixmap.setDevicePixelRatio(max_dpr)
-    desktop_pixmap.fill(Qt.GlobalColor.transparent)
-    painter = QPainter(desktop_pixmap)
-    captured_count = 0
-    for screen in screens:
-        screen_pixmap = screen.grabWindow(0)
-        if screen_pixmap.isNull():
-            continue
-        target_rect = QRect(
-            screen.geometry().topLeft() - virtual_geometry.topLeft(),
-            screen.geometry().size(),
-        )
-        painter.drawPixmap(target_rect, screen_pixmap)
-        captured_count += 1
-    painter.end()
-
-    if captured_count == 0:
+    if not captured:
         raise RuntimeError("屏幕截图为空，可能被系统权限或显示环境阻止。")
-    return desktop_pixmap, virtual_geometry
+    return VirtualDesktopCapture(tuple(captured), virtual_geometry)
+
+
+def capture_virtual_desktop_pixmap() -> tuple[QPixmap, QRect]:
+    """截取并合成虚拟桌面。
+
+    这是兼容旧调用点的接口。混合 DPI 场景应优先使用 capture_virtual_desktop，
+    以免后续裁剪时丢失每块屏幕的 DPR 信息。
+    """
+
+    capture = capture_virtual_desktop()
+    return capture.crop(capture.geometry), QRect(capture.geometry)
+
+
+def draw_virtual_desktop_capture(
+    painter: QPainter,
+    capture: VirtualDesktopCapture,
+    origin: QPoint | None = None,
+) -> None:
+    """在逻辑坐标系中逐屏绘制虚拟桌面截图。"""
+
+    target_origin = origin if origin is not None else QPoint()
+    for screen in capture.screens:
+        target = QRect(
+            screen.geometry.topLeft() - capture.geometry.topLeft() + target_origin,
+            screen.geometry.size(),
+        )
+        painter.drawPixmap(target, screen.pixmap)
+
+
+def _scale_logical_rect(rect: QRect, dpr: float) -> QRect:
+    """缩放矩形边界，避免相邻屏幕因分别舍入宽度产生缝隙。"""
+
+    left = round(rect.x() * dpr)
+    top = round(rect.y() * dpr)
+    right = round((rect.x() + rect.width()) * dpr)
+    bottom = round((rect.y() + rect.height()) * dpr)
+    return QRect(left, top, right - left, bottom - top)
 
 
 def logical_to_device_rect(pixmap: QPixmap, logical_rect: QRect) -> QRect:
-    """把逻辑像素矩形换算成 pixmap 的物理像素矩形。
+    """把逻辑像素矩形换算成 pixmap 的物理像素矩形。"""
 
-    capture_virtual_desktop_pixmap 返回的是「物理像素缓冲 + devicePixelRatio」的 QPixmap：
-    copy()/rect()/width()/height() 及 drawPixmap 源矩形都以物理像素计；而上层（mapToGlobal、
-    screen.geometry()、鼠标事件）给的是逻辑像素。二者相差一个 devicePixelRatio，必须显式换算，
-    否则裁剪区域会缩放并随坐标增大而偏移（屏幕边缘/角落尤其明显）。
-    """
-    dpr = pixmap.devicePixelRatio() or 1.0
-    return QRect(
-        round(logical_rect.x() * dpr),
-        round(logical_rect.y() * dpr),
-        round(logical_rect.width() * dpr),
-        round(logical_rect.height() * dpr),
-    )
+    return _scale_logical_rect(logical_rect, pixmap.devicePixelRatio() or 1.0)
 
 
 def crop_logical_region(
-    desktop_pixmap: QPixmap,
+    desktop_pixmap: QPixmap | VirtualDesktopCapture,
     virtual_geometry: QRect,
     global_logical_rect: QRect,
 ) -> QPixmap:
-    """从虚拟桌面物理像素缓冲里裁出 global_logical_rect（逻辑全局坐标）对应区域。
+    """从虚拟桌面截图裁出全局逻辑区域，并保留请求区域的逻辑尺寸。"""
 
-    返回的子图保留 devicePixelRatio，其逻辑尺寸≈global_logical_rect，可直接按逻辑坐标绘制对齐。
-    若请求区域有一部分超出桌面，会保留原始输出尺寸并把有效截图放在它相对请求区域的真实偏移处；
-    这样贴回同尺寸窗口时不会因边缘裁剪而重新锚定、拉伸错位。与缓冲完全无交集时返回空 QPixmap。
-    """
-    offset = global_logical_rect.translated(
-        -virtual_geometry.x(), -virtual_geometry.y()
-    )
-    requested_device_rect = logical_to_device_rect(desktop_pixmap, offset)
-    if requested_device_rect.width() <= 0 or requested_device_rect.height() <= 0:
-        return QPixmap()
+    if isinstance(desktop_pixmap, VirtualDesktopCapture):
+        return desktop_pixmap.crop(global_logical_rect)
 
-    device_crop = requested_device_rect.intersected(desktop_pixmap.rect())
-    if device_crop.isEmpty():
-        return QPixmap()
-    if device_crop == requested_device_rect:
-        return desktop_pixmap.copy(device_crop)
-
-    dpr = desktop_pixmap.devicePixelRatio() or 1.0
-    result = QPixmap(
-        requested_device_rect.width(),
-        requested_device_rect.height(),
-    )
-    result.fill(Qt.GlobalColor.transparent)
-
-    cropped = desktop_pixmap.copy(device_crop)
-    cropped.setDevicePixelRatio(1.0)
-    painter = QPainter(result)
-    painter.drawPixmap(device_crop.topLeft() - requested_device_rect.topLeft(), cropped)
-    painter.end()
-    result.setDevicePixelRatio(dpr)
-    return result
+    capture = VirtualDesktopCapture.from_pixmap(desktop_pixmap, virtual_geometry)
+    return capture.crop(global_logical_rect)

--- a/app/ui/screen_color_picker.py
+++ b/app/ui/screen_color_picker.py
@@ -7,7 +7,11 @@ from PySide6.QtCore import QEventLoop, QPoint, QRect, QTimer, Qt, Signal
 from PySide6.QtGui import QColor, QCursor, QKeyEvent, QMouseEvent, QPainter, QPen, QPixmap
 from PySide6.QtWidgets import QApplication, QWidget
 
-from app.ui.screen_capture import capture_virtual_desktop_pixmap, logical_to_device_rect
+from app.ui.screen_capture import (
+    VirtualDesktopCapture,
+    capture_virtual_desktop,
+    logical_to_device_rect,
+)
 
 COLOR_PICKER_SAMPLE_SIZE = 17
 COLOR_PICKER_PREVIEW_SIZE = 148
@@ -15,11 +19,15 @@ COLOR_PICKER_REFRESH_INTERVAL_MS = 33
 
 
 def sample_desktop_hex_color(
-    desktop_pixmap: QPixmap,
+    desktop_pixmap: QPixmap | VirtualDesktopCapture,
     virtual_geometry: QRect,
     global_pos: QPoint,
 ) -> str | None:
     """Return #rrggbb for a logical global desktop point."""
+
+    if isinstance(desktop_pixmap, VirtualDesktopCapture):
+        color = desktop_pixmap.color_at(global_pos)
+        return color.name() if color is not None else None
 
     local = QPoint(global_pos) - virtual_geometry.topLeft()
     if not QRect(QPoint(0, 0), virtual_geometry.size()).contains(local):
@@ -77,10 +85,26 @@ class ScreenColorPickerOverlay(QWidget):
     picked = Signal(str)
     cancelled = Signal()
 
-    def __init__(self, desktop_pixmap: QPixmap, virtual_geometry: QRect) -> None:
+    def __init__(
+        self,
+        desktop_pixmap: QPixmap | VirtualDesktopCapture,
+        virtual_geometry: QRect | None = None,
+    ) -> None:
         super().__init__(None)
-        self.desktop_pixmap = desktop_pixmap
-        self.virtual_geometry = QRect(virtual_geometry)
+        if isinstance(desktop_pixmap, VirtualDesktopCapture):
+            self.desktop_capture = desktop_pixmap
+            self.desktop_pixmap = (
+                desktop_pixmap.screens[0].pixmap if len(desktop_pixmap.screens) == 1 else QPixmap()
+            )
+            self.virtual_geometry = QRect(desktop_pixmap.geometry)
+        else:
+            if virtual_geometry is None:
+                raise TypeError("单张桌面截图必须提供 virtual_geometry。")
+            self.desktop_pixmap = desktop_pixmap
+            self.virtual_geometry = QRect(virtual_geometry)
+            self.desktop_capture = VirtualDesktopCapture.from_pixmap(
+                desktop_pixmap, self.virtual_geometry
+            )
         self._sample_cache: tuple[QPixmap, QRect, str | None] | None = None
         self._sample_refresh_timer = QTimer(self)
         self._sample_refresh_timer.setSingleShot(True)
@@ -155,7 +179,7 @@ class ScreenColorPickerOverlay(QWidget):
 
     def _fallback_current_color(self) -> str | None:
         return sample_desktop_hex_color(
-            self.desktop_pixmap,
+            self.desktop_capture,
             self.virtual_geometry,
             self.virtual_geometry.topLeft() + self.cursor_pos,
         )
@@ -187,7 +211,7 @@ class ScreenColorPickerOverlay(QWidget):
 
     def _fallback_sample_source(self, source: QRect) -> tuple[QPixmap, QRect, str | None]:
         global_rect = QRect(source).translated(self.virtual_geometry.topLeft())
-        pixmap = self.desktop_pixmap.copy(logical_to_device_rect(self.desktop_pixmap, source))
+        pixmap = self.desktop_capture.crop(global_rect)
         return pixmap, global_rect, self._fallback_current_color()
 
     def _queue_sample_refresh(self) -> None:
@@ -266,8 +290,8 @@ def pick_screen_color() -> str | None:
     if app is None:
         raise RuntimeError("无法启动取色器：Qt 应用尚未初始化。")
 
-    desktop_pixmap, virtual_geometry = capture_virtual_desktop_pixmap()
-    overlay = ScreenColorPickerOverlay(desktop_pixmap, virtual_geometry)
+    desktop_capture = capture_virtual_desktop()
+    overlay = ScreenColorPickerOverlay(desktop_capture)
     loop = QEventLoop()
     result: dict[str, str] = {}
 

--- a/tests/ui/test_manual_screenshot_overlay.py
+++ b/tests/ui/test_manual_screenshot_overlay.py
@@ -8,6 +8,7 @@ from PySide6.QtCore import QPoint, QRect  # noqa: E402
 from PySide6.QtGui import QColor, QPainter, QPixmap  # noqa: E402
 
 from app.ui.manual_screenshot_overlay import ManualScreenshotOverlay  # noqa: E402
+from app.ui.screen_capture import ScreenCapture, VirtualDesktopCapture  # noqa: E402
 
 
 def _qt_app_or_skip():  # type: ignore[no-untyped-def]
@@ -76,5 +77,30 @@ def test_manual_selection_crops_correct_region_under_high_dpi() -> None:
     assert cropped.height() == round(selection.height() * dpr)
     # 内容应为纯右半（蓝），不混入左半红色。
     assert _dominant_color_name(cropped) == "blue"
+
+    overlay.deleteLater()
+
+
+def test_manual_selection_on_lower_dpi_secondary_screen_is_not_shrunk() -> None:
+    _qt_app_or_skip()
+    primary = _half_split_pixmap(100, 80, 1.5)
+    secondary = QPixmap(100, 80)
+    secondary.setDevicePixelRatio(1.0)
+    secondary.fill(QColor("green"))
+    capture = VirtualDesktopCapture(
+        (
+            ScreenCapture(QRect(0, 0, 100, 80), primary),
+            ScreenCapture(QRect(100, 0, 100, 80), secondary),
+        ),
+        QRect(0, 0, 200, 80),
+    )
+    overlay = ManualScreenshotOverlay(capture)
+
+    cropped = overlay._crop_selection(QRect(120, 10, 50, 40))
+
+    assert cropped.devicePixelRatio() == pytest.approx(1.0)
+    assert cropped.width() == 50
+    assert cropped.height() == 40
+    assert cropped.toImage().pixelColor(25, 20).name() == "#008000"
 
     overlay.deleteLater()

--- a/tests/ui/test_screen_capture_crop.py
+++ b/tests/ui/test_screen_capture_crop.py
@@ -7,7 +7,13 @@ pytest.importorskip("PySide6.QtWidgets")
 from PySide6.QtCore import QRect  # noqa: E402
 from PySide6.QtGui import QColor, QPainter, QPixmap  # noqa: E402
 
-from app.ui.screen_capture import crop_logical_region, logical_to_device_rect  # noqa: E402
+from app.ui.screen_capture import (  # noqa: E402
+    ScreenCapture,
+    VirtualDesktopCapture,
+    crop_logical_region,
+    draw_virtual_desktop_capture,
+    logical_to_device_rect,
+)
 
 
 def _qt_app_or_skip():  # type: ignore[no-untyped-def]
@@ -40,6 +46,13 @@ def _has_white(pixmap: QPixmap) -> bool:
             if image.pixel(x, y) == white:
                 return True
     return False
+
+
+def _solid_screen(logical_w: int, logical_h: int, dpr: float, color: str) -> QPixmap:
+    pixmap = QPixmap(round(logical_w * dpr), round(logical_h * dpr))
+    pixmap.setDevicePixelRatio(dpr)
+    pixmap.fill(QColor(color))
+    return pixmap
 
 
 def test_logical_to_device_rect_scales_by_dpr() -> None:
@@ -90,6 +103,66 @@ def test_crop_logical_region_clamps_out_of_bounds() -> None:
     virtual_geometry = QRect(0, 0, 1600, 1000)
     # 完全在缓冲之外 → 空 QPixmap。
     assert crop_logical_region(desktop, virtual_geometry, QRect(5000, 5000, 100, 100)).isNull()
+
+
+def test_mixed_dpi_capture_crops_each_screen_in_its_own_coordinate_space() -> None:
+    """副屏不能被主屏 DPR 缩小，跨屏选区也必须保持逻辑位置。"""
+
+    _qt_app_or_skip()
+    capture = VirtualDesktopCapture(
+        (
+            ScreenCapture(QRect(0, 0, 100, 80), _solid_screen(100, 80, 1.5, "red")),
+            ScreenCapture(QRect(100, 0, 100, 80), _solid_screen(100, 80, 1.0, "blue")),
+        ),
+        QRect(0, 0, 200, 80),
+    )
+
+    cropped = capture.crop(QRect(75, 10, 75, 40))
+
+    assert cropped.devicePixelRatio() == pytest.approx(1.5)
+    assert cropped.width() == round(75 * 1.5)
+    assert cropped.height() == round(40 * 1.5)
+    image = cropped.toImage()
+    assert image.pixelColor(round(10 * 1.5), round(20 * 1.5)).name() == "#ff0000"
+    assert image.pixelColor(round(50 * 1.5), round(20 * 1.5)).name() == "#0000ff"
+
+
+def test_mixed_dpi_capture_keeps_secondary_screen_native_resolution() -> None:
+    _qt_app_or_skip()
+    capture = VirtualDesktopCapture(
+        (
+            ScreenCapture(QRect(0, 0, 100, 80), _solid_screen(100, 80, 1.5, "red")),
+            ScreenCapture(QRect(100, 0, 100, 80), _solid_screen(100, 80, 1.0, "blue")),
+        ),
+        QRect(0, 0, 200, 80),
+    )
+
+    secondary = capture.crop(QRect(120, 10, 50, 40))
+
+    assert secondary.devicePixelRatio() == pytest.approx(1.0)
+    assert secondary.size() == QRect(0, 0, 50, 40).size()
+    assert secondary.toImage().pixelColor(25, 20).name() == "#0000ff"
+
+
+def test_mixed_dpi_capture_draws_each_screen_at_its_logical_geometry() -> None:
+    _qt_app_or_skip()
+    capture = VirtualDesktopCapture(
+        (
+            ScreenCapture(QRect(0, 0, 100, 80), _solid_screen(100, 80, 1.5, "red")),
+            ScreenCapture(QRect(100, 0, 100, 80), _solid_screen(100, 80, 1.0, "blue")),
+        ),
+        QRect(0, 0, 200, 80),
+    )
+    canvas = QPixmap(200, 80)
+    canvas.fill(QColor("black"))
+
+    painter = QPainter(canvas)
+    draw_virtual_desktop_capture(painter, capture)
+    painter.end()
+
+    image = canvas.toImage()
+    assert image.pixelColor(50, 40).name() == "#ff0000"
+    assert image.pixelColor(150, 40).name() == "#0000ff"
 
 
 @pytest.mark.parametrize(

--- a/tests/ui/test_screen_color_picker.py
+++ b/tests/ui/test_screen_color_picker.py
@@ -13,6 +13,7 @@ from app.ui.screen_color_picker import (  # noqa: E402
     sample_pixmap_hex_color,
     sample_desktop_hex_color,
 )
+from app.ui.screen_capture import ScreenCapture, VirtualDesktopCapture  # noqa: E402
 
 
 def _qt_app_or_skip():  # type: ignore[no-untyped-def]
@@ -51,6 +52,21 @@ def test_screen_color_picker_samples_negative_virtual_geometry() -> None:
         )
         == "#3366cc"
     )
+
+
+def test_screen_color_picker_samples_secondary_screen_with_its_own_dpr() -> None:
+    _qt_app_or_skip()
+    primary = _desktop(100, 80, 1.5, QRect(0, 0, 1, 1), "#000000")
+    secondary = _desktop(100, 80, 1.0, QRect(40, 30, 2, 2), "#55aaee")
+    capture = VirtualDesktopCapture(
+        (
+            ScreenCapture(QRect(0, 0, 100, 80), primary),
+            ScreenCapture(QRect(100, 0, 100, 80), secondary),
+        ),
+        QRect(0, 0, 200, 80),
+    )
+
+    assert sample_desktop_hex_color(capture, capture.geometry, QPoint(140, 30)) == "#55aaee"
 
 
 def test_screen_color_picker_cancel_does_not_pick() -> None:


### PR DESCRIPTION
## 修复内容

- 为虚拟桌面截图保留每块屏幕独立的 geometry、DPR 和 pixmap
- 手动截图覆盖层按屏幕分别绘制，框选区域按各屏交集和 DPR 裁剪后合成
- 同步适配取色器回退采样和输入栏软件模糊背景
- 添加主屏 DPR=1.5、副屏 DPR=1.0 的混合 DPI 回归测试

## 测试

- `python -m pytest -q`
- 1334 passed, 3 skipped

Fixes #119