### PR TITLE
feat: 添加主动截图分辨率选择器

### DIFF
--- a/app/agent/screen_awareness.py
+++ b/app/agent/screen_awareness.py
@@ -6,6 +6,18 @@ from math import ceil, floor, sqrt
 SCREEN_AWARENESS_DEFAULT_CHECK_INTERVAL_MINUTES = 2
 SCREEN_AWARENESS_DEFAULT_COOLDOWN_MINUTES = 10
 SCREEN_AWARENESS_DEFAULT_SCREEN_CONTEXT_BATCH_LIMIT = 6
+SCREEN_AWARENESS_DEFAULT_SCREEN_CONTEXT_RESOLUTION = "fullscreen"
+SCREEN_AWARENESS_SCREEN_CONTEXT_RESOLUTIONS = (
+    "fullscreen",
+    "720p",
+    "1080p",
+    "2160p",
+)
+SCREEN_AWARENESS_SCREEN_CONTEXT_RESOLUTION_BOUNDS = {
+    "720p": (1280, 720),
+    "1080p": (1920, 1080),
+    "2160p": (3840, 2160),
+}
 SCREEN_AWARENESS_IMAGE_DETAIL = "high"
 SCREEN_AWARENESS_TOKEN_PATCH_SIZE = 32
 SCREEN_AWARENESS_HIGH_DETAIL_MAX_EDGE = 2048
@@ -33,6 +45,7 @@ class ScreenAwarenessSettings:
     check_interval_minutes: int = SCREEN_AWARENESS_DEFAULT_CHECK_INTERVAL_MINUTES
     cooldown_minutes: int = SCREEN_AWARENESS_DEFAULT_COOLDOWN_MINUTES
     screen_context_batch_limit: int = SCREEN_AWARENESS_DEFAULT_SCREEN_CONTEXT_BATCH_LIMIT
+    screen_context_resolution: str = SCREEN_AWARENESS_DEFAULT_SCREEN_CONTEXT_RESOLUTION
 
     def normalized(self) -> "ScreenAwarenessSettings":
         enabled = bool(self.enabled)
@@ -55,6 +68,9 @@ class ScreenAwarenessSettings:
                 min_value=SCREEN_AWARENESS_MIN_SCREEN_CONTEXT_BATCH_LIMIT,
                 max_value=SCREEN_AWARENESS_MAX_SCREEN_CONTEXT_BATCH_LIMIT,
             ),
+            screen_context_resolution=normalize_screen_context_resolution(
+                self.screen_context_resolution
+            ),
         )
 
     def allows_screen_context(self) -> bool:
@@ -71,6 +87,36 @@ def _clamp_bounded_int(value: int, *, min_value: int, max_value: int) -> int:
     return max(
         min_value,
         min(max_value, value),
+    )
+
+
+def normalize_screen_context_resolution(value: object) -> str:
+    normalized = str(value or "").strip().lower()
+    if normalized in SCREEN_AWARENESS_SCREEN_CONTEXT_RESOLUTIONS:
+        return normalized
+    return SCREEN_AWARENESS_DEFAULT_SCREEN_CONTEXT_RESOLUTION
+
+
+def screen_context_resolution_size(
+    width: int,
+    height: int,
+    resolution: object,
+) -> tuple[int, int]:
+    """返回所选档位下的等比截图尺寸；固定档位不会放大较小的屏幕。"""
+    image_width = max(1, int(width))
+    image_height = max(1, int(height))
+    normalized = normalize_screen_context_resolution(resolution)
+    bounds = SCREEN_AWARENESS_SCREEN_CONTEXT_RESOLUTION_BOUNDS.get(normalized)
+    if bounds is None:
+        return image_width, image_height
+
+    max_width, max_height = bounds
+    if image_height > image_width:
+        max_width, max_height = max_height, max_width
+    scale = min(1.0, max_width / image_width, max_height / image_height)
+    return (
+        max(1, int(round(image_width * scale))),
+        max(1, int(round(image_height * scale))),
     )
 
 

--- a/app/agent/screen_observation.py
+++ b/app/agent/screen_observation.py
@@ -134,12 +134,19 @@ def build_screen_observation_from_image(
     captured: CapturedScreenImage,
     *,
     max_edge: int = SCREEN_OBSERVATION_MAX_EDGE,
+    max_width: int | None = None,
+    max_height: int | None = None,
 ) -> ScreenObservation:
     """从已复制的 QImage 构造观察结果，可在后台线程执行。"""
     if captured.image.isNull():
         raise RuntimeError("屏幕截图为空。")
 
-    encoded_image = _scaled_image(captured.image, max_edge=max_edge)
+    encoded_image = _scaled_image(
+        captured.image,
+        max_edge=max_edge,
+        max_width=max_width,
+        max_height=max_height,
+    )
     return ScreenObservation(
         data_url=_encode_image_to_data_url(encoded_image),
         width=encoded_image.width(),
@@ -166,8 +173,26 @@ def build_screen_observation_from_pixmap(
     )
 
 
-def _scaled_image(image: QImage, *, max_edge: int = SCREEN_OBSERVATION_MAX_EDGE) -> QImage:
+def _scaled_image(
+    image: QImage,
+    *,
+    max_edge: int = SCREEN_OBSERVATION_MAX_EDGE,
+    max_width: int | None = None,
+    max_height: int | None = None,
+) -> QImage:
     from PySide6.QtCore import Qt
+
+    if max_width is not None and max_height is not None:
+        target_width = max(1, int(max_width))
+        target_height = max(1, int(max_height))
+        if image.width() <= target_width and image.height() <= target_height:
+            return image
+        return image.scaled(
+            target_width,
+            target_height,
+            Qt.AspectRatioMode.KeepAspectRatio,
+            Qt.TransformationMode.SmoothTransformation,
+        )
 
     max_edge = max(1, int(max_edge or SCREEN_OBSERVATION_MAX_EDGE))
     longest_edge = max(image.width(), image.height())

--- a/app/config/settings_service.py
+++ b/app/config/settings_service.py
@@ -37,6 +37,7 @@ from app.agent.screen_awareness import (
     SCREEN_AWARENESS_DEFAULT_CHECK_INTERVAL_MINUTES,
     SCREEN_AWARENESS_DEFAULT_COOLDOWN_MINUTES,
     SCREEN_AWARENESS_DEFAULT_SCREEN_CONTEXT_BATCH_LIMIT,
+    SCREEN_AWARENESS_DEFAULT_SCREEN_CONTEXT_RESOLUTION,
     ScreenAwarenessSettings,
 )
 from app.voice.tts_settings import (
@@ -673,6 +674,12 @@ class AppSettingsService:
                 screen_awareness.get("screen_context_batch_limit"),
                 SCREEN_AWARENESS_DEFAULT_SCREEN_CONTEXT_BATCH_LIMIT,
             ),
+            screen_context_resolution=str(
+                screen_awareness.get(
+                    "screen_context_resolution",
+                    SCREEN_AWARENESS_DEFAULT_SCREEN_CONTEXT_RESOLUTION,
+                )
+            ),
         )
 
     def save_screen_awareness_settings(self, settings: ScreenAwarenessSettings) -> None:
@@ -684,6 +691,7 @@ class AppSettingsService:
             "check_interval_minutes": int(normalized.check_interval_minutes),
             "cooldown_minutes": int(normalized.cooldown_minutes),
             "screen_context_batch_limit": int(normalized.screen_context_batch_limit),
+            "screen_context_resolution": normalized.screen_context_resolution,
         }
         save_yaml_mapping(self.system_config_path, data)
 

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -159,6 +159,7 @@ from app.agent.screen_awareness import (
     SCREEN_AWARENESS_TIMER_DUE_GRACE_SECONDS,
     SCREEN_AWARENESS_TIMER_POLL_INTERVAL_MS,
     ScreenAwarenessSettings,
+    screen_context_resolution_size,
 )
 from app.agent.screen_observation import (
     CapturedScreenImage,
@@ -541,11 +542,22 @@ class ScreenObservationEncodeWorker(QObject):
         try:
             self._cancel_token.throw_if_cancelled()
             max_edge = _screen_observation_max_edge_from_context(self.context)
-            if self.context.get("preserve_original_resolution") is True:
+            max_width: int | None = None
+            max_height: int | None = None
+            resolution = self.context.get("screen_context_resolution")
+            if resolution is not None:
+                max_width, max_height = screen_context_resolution_size(
+                    self.captured.image.width(),
+                    self.captured.image.height(),
+                    resolution,
+                )
+            elif self.context.get("preserve_original_resolution") is True:
                 max_edge = max(1, self.captured.image.width(), self.captured.image.height())
             observation = build_screen_observation_from_image(
                 self.captured,
                 max_edge=max_edge,
+                max_width=max_width,
+                max_height=max_height,
             )
             self._cancel_token.throw_if_cancelled()
         except OperationCancelled:
@@ -3886,8 +3898,12 @@ class PetWindow(QWidget):
         return self._current_screen_awareness_settings().allows_screen_context()
 
     def _screen_awareness_encode_options(self) -> dict[str, Any]:
+        resolution = (
+            self._current_screen_awareness_settings().normalized().screen_context_resolution
+        )
         return {
-            "preserve_original_resolution": True,
+            "screen_context_resolution": resolution,
+            "preserve_original_resolution": resolution == "fullscreen",
             "detail": SCREEN_AWARENESS_IMAGE_DETAIL,
         }
 

--- a/app/ui/tauri_settings.py
+++ b/app/ui/tauri_settings.py
@@ -40,14 +40,17 @@ from app.agent.runtime_limits import (
     normalize_runtime_loop_settings,
 )
 from app.agent.screen_awareness import (
+    SCREEN_AWARENESS_DEFAULT_SCREEN_CONTEXT_RESOLUTION,
     SCREEN_AWARENESS_MAX_CHECK_INTERVAL_MINUTES,
     SCREEN_AWARENESS_MAX_COOLDOWN_MINUTES,
     SCREEN_AWARENESS_MAX_SCREEN_CONTEXT_BATCH_LIMIT,
     SCREEN_AWARENESS_MIN_CHECK_INTERVAL_MINUTES,
     SCREEN_AWARENESS_MIN_COOLDOWN_MINUTES,
     SCREEN_AWARENESS_MIN_SCREEN_CONTEXT_BATCH_LIMIT,
+    SCREEN_AWARENESS_SCREEN_CONTEXT_RESOLUTIONS,
     ScreenAwarenessSettings,
     estimate_screen_context_image_tokens_for_size,
+    screen_context_resolution_size,
 )
 from app.config.character_archive import (
     CharacterArchiveError,
@@ -530,6 +533,22 @@ def build_tauri_settings_request(
     )
     normalized_bubble = (bubble_settings or BubbleSettings()).normalized()
     width, height = _screen_estimate_size(parent_widget)
+    screen_resolution_estimates = {}
+    for resolution in SCREEN_AWARENESS_SCREEN_CONTEXT_RESOLUTIONS:
+        estimate_width, estimate_height = screen_context_resolution_size(
+            width,
+            height,
+            resolution,
+        )
+        screen_resolution_estimates[resolution] = {
+            "width": estimate_width,
+            "height": estimate_height,
+            "tokens": estimate_screen_context_image_tokens_for_size(
+                estimate_width,
+                estimate_height,
+                model=model,
+            ),
+        }
     return {
         "version": TAURI_SETTINGS_PROTOCOL_VERSION,
         "nonce": nonce or secrets.token_urlsafe(16),
@@ -678,6 +697,7 @@ def build_tauri_settings_request(
             height,
             model=model,
         ),
+        "screen_resolution_estimates": screen_resolution_estimates,
     }
 
 
@@ -770,6 +790,12 @@ def parse_tauri_settings_payload(
             check_interval_minutes=_required_int(settings, "check_interval_minutes"),
             cooldown_minutes=_required_int(settings, "cooldown_minutes"),
             screen_context_batch_limit=_required_int(settings, "screen_context_batch_limit"),
+            screen_context_resolution=str(
+                settings.get(
+                    "screen_context_resolution",
+                    SCREEN_AWARENESS_DEFAULT_SCREEN_CONTEXT_RESOLUTION,
+                )
+            ),
         ).normalized(),
         mcp=normalize_mcp_runtime_settings(
             MCPRuntimeSettings(windows_enabled=_required_bool(mcp, "windows_enabled"))
@@ -1710,6 +1736,7 @@ def _screen_awareness_to_mapping(settings: ScreenAwarenessSettings) -> dict[str,
         "check_interval_minutes": int(settings.check_interval_minutes),
         "cooldown_minutes": int(settings.cooldown_minutes),
         "screen_context_batch_limit": int(settings.screen_context_batch_limit),
+        "screen_context_resolution": settings.screen_context_resolution,
     }
 
 

--- a/tests/integration/test_agent_core.py
+++ b/tests/integration/test_agent_core.py
@@ -52,6 +52,7 @@ from app.agent.screen_awareness import (
     ScreenAwarenessSettings,
     estimate_screen_context_batch_tokens_for_size,
     estimate_screen_context_image_tokens_for_size,
+    screen_context_resolution_size,
 )
 from app.agent.screen_observation import (
     SCREEN_OBSERVATION_HISTORY_MARKER,
@@ -217,6 +218,14 @@ def test_screen_awareness_settings_default_to_enabled() -> None:
     assert settings.check_interval_minutes == 2
     assert settings.cooldown_minutes == 10
     assert settings.screen_context_batch_limit == 6
+    assert settings.screen_context_resolution == "fullscreen"
+
+
+def test_screen_awareness_resolution_presets_keep_aspect_ratio_without_upscaling() -> None:
+    assert screen_context_resolution_size(3200, 2000, "1080p") == (1728, 1080)
+    assert screen_context_resolution_size(2000, 3200, "1080p") == (1080, 1728)
+    assert screen_context_resolution_size(1280, 720, "2160p") == (1280, 720)
+    assert screen_context_resolution_size(2560, 1440, "invalid") == (2560, 1440)
 
 
 def test_screen_awareness_token_estimate_uses_high_detail_rules() -> None:
@@ -306,6 +315,7 @@ def test_screen_awareness_settings_save_writes_yaml() -> None:
             check_interval_minutes=3,
             cooldown_minutes=7,
             screen_context_batch_limit=4,
+            screen_context_resolution="1080p",
         )
     )
 
@@ -315,6 +325,7 @@ def test_screen_awareness_settings_save_writes_yaml() -> None:
     assert config["screen_awareness"]["check_interval_minutes"] == 3
     assert config["screen_awareness"]["cooldown_minutes"] == 7
     assert config["screen_awareness"]["screen_context_batch_limit"] == 4
+    assert config["screen_awareness"]["screen_context_resolution"] == "1080p"
 
 
 def test_screen_awareness_settings_save_normalizes_enabled_flag() -> None:

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -4236,6 +4236,7 @@ def _tauri_settings_result_payload(theme_payload: dict[str, object]) -> dict[str
                     "check_interval_minutes": 5,
                     "cooldown_minutes": 8,
                     "screen_context_batch_limit": 4,
+                    "screen_context_resolution": "1080p",
                 },
                 "mcp": {
                     "windows_enabled": True,
@@ -4346,6 +4347,7 @@ def test_tauri_settings_result_parser_normalizes_runtime_loop() -> None:
     result = parse_tauri_settings_payload(payload, expected_nonce="nonce")
 
     assert result.mcp == MCPRuntimeSettings(windows_enabled=True)
+    assert result.screen_awareness.screen_context_resolution == "1080p"
     assert result.runtime_loop == RuntimeLoopSettings(
         max_agent_steps_per_turn=12,
         max_tool_calls_per_step=8,
@@ -4522,6 +4524,22 @@ def test_tauri_settings_request_includes_theme_colors() -> None:
     assert request["theme_defaults"]["primary_color"] == DEFAULT_THEME_SETTINGS.primary_color
     assert {"id": "primary_color", "label": "主题色"} in request["theme_fields"]
     assert {"id": "solid", "label": "纯色块"} in request["visual_effect_modes"]
+
+
+def test_tauri_settings_request_includes_screen_resolution_estimates(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    import app.ui.tauri_settings as tauri_settings
+
+    monkeypatch.setattr(tauri_settings, "_screen_estimate_size", lambda _widget: (3200, 2000))
+
+    request = tauri_settings.build_tauri_settings_request(
+        ScreenAwarenessSettings(screen_context_resolution="1080p"),
+        nonce="nonce",
+    )
+
+    assert request["screen_awareness"]["screen_context_resolution"] == "1080p"
+    assert request["screen_resolution_estimates"]["fullscreen"]["width"] == 3200
+    assert request["screen_resolution_estimates"]["1080p"]["width"] == 1728
+    assert request["screen_resolution_estimates"]["1080p"]["height"] == 1080
 
 
 def test_tauri_settings_request_includes_font_sizes_and_layout_limits() -> None:
@@ -6904,7 +6922,7 @@ def test_screen_context_cache_log_uses_summary_without_image_payload(monkeypatch
         assert "data:image" not in str(payload)
 
 
-def test_screen_awareness_capture_uses_selected_resolution(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_screen_awareness_capture_defaults_to_fullscreen_resolution(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     import app.ui.pet_window as pet_window_module
 
     contexts: list[dict[str, object]] = []
@@ -6920,8 +6938,59 @@ def test_screen_awareness_capture_uses_selected_resolution(monkeypatch) -> None:
 
     window._capture_screen_awareness_context(60)
 
+    assert contexts[0]["screen_context_resolution"] == "fullscreen"
     assert contexts[0]["preserve_original_resolution"] is True
     assert contexts[0]["detail"] == "high"
+
+
+def test_screen_awareness_capture_uses_selected_resolution(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    import app.ui.pet_window as pet_window_module
+
+    contexts: list[dict[str, object]] = []
+    window = _build_minimal_screen_awareness_window(
+        screen_context_enabled=True,
+        check_interval_minutes=1,
+        cooldown_minutes=2,
+        screen_context_resolution="720p",
+    )
+    monkeypatch.setattr(pet_window_module, "capture_screen_image", lambda _window: object())
+    window._start_screen_observation_encode = lambda _captured, context: (
+        contexts.append(context) or True
+    )
+
+    window._capture_screen_awareness_context(60)
+
+    assert contexts[0]["screen_context_resolution"] == "720p"
+    assert contexts[0]["preserve_original_resolution"] is False
+    assert contexts[0]["detail"] == "high"
+
+
+def test_screen_observation_encode_worker_resizes_to_selected_resolution() -> None:
+    qtgui = pytest.importorskip("PySide6.QtGui")
+    if not hasattr(qtgui, "QImage"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+
+    from app.agent.screen_observation import CapturedScreenImage
+    from app.ui.pet_window import ScreenObservationEncodeWorker
+
+    image = qtgui.QImage(1600, 1000, qtgui.QImage.Format.Format_RGB32)
+    image.fill(0xFFFFFFFF)
+    captured = CapturedScreenImage(
+        image=image,
+        captured_at="2026-07-12T12:00:00+08:00",
+        screen_name="DISPLAY1",
+    )
+    worker = ScreenObservationEncodeWorker(
+        captured,
+        {"screen_context_resolution": "720p"},
+    )
+    observations: list[ScreenObservation] = []
+    worker.finished.connect(lambda _context, observation: observations.append(observation))
+
+    worker.run()
+
+    assert len(observations) == 1
+    assert (observations[0].width, observations[0].height) == (1152, 720)
 
 
 def test_proactive_care_event_includes_recent_conversation() -> None:
@@ -8572,6 +8641,7 @@ def _build_minimal_screen_awareness_window(
     check_interval_minutes: int,
     cooldown_minutes: int,
     screen_context_batch_limit: int = 6,
+    screen_context_resolution: str = "fullscreen",
     events=None,  # type: ignore[no-untyped-def]
     history=None,  # type: ignore[no-untyped-def]
 ):
@@ -8599,6 +8669,7 @@ def _build_minimal_screen_awareness_window(
         check_interval_minutes=check_interval_minutes,
         cooldown_minutes=cooldown_minutes,
         screen_context_batch_limit=screen_context_batch_limit,
+        screen_context_resolution=screen_context_resolution,
     )
     window.worker_thread = None
     window.active_reminder_id = None

--- a/tests/unit/test_settings_service.py
+++ b/tests/unit/test_settings_service.py
@@ -221,6 +221,7 @@ def test_settings_service_saves_runtime_config_to_yaml() -> None:
             check_interval_minutes=5,
             cooldown_minutes=7,
             screen_context_batch_limit=3,
+            screen_context_resolution="720p",
         )
     )
 
@@ -241,6 +242,7 @@ def test_settings_service_saves_runtime_config_to_yaml() -> None:
     assert "raw_tts_service_enabled" not in system["debug"]
     assert system["startup"]["launch_at_login"] is True
     assert system["screen_awareness"]["check_interval_minutes"] == 5
+    assert system["screen_awareness"]["screen_context_resolution"] == "720p"
 
 
 def test_settings_service_loads_and_saves_startup_settings() -> None:

--- a/tools/settings-tauri/frontend/index.html
+++ b/tools/settings-tauri/frontend/index.html
@@ -236,9 +236,21 @@
               <span class="field-unit"><input id="batchLimit" type="number" step="1" /><span class="unit">张</span></span>
             </div>
             <div class="setting-row">
+              <label class="setting-row-text" for="screenResolution">
+                <span class="setting-title">截图分辨率</span>
+                <span class="setting-desc">发送前等比缩小截图；固定档位不会放大小于目标尺寸的屏幕。</span>
+              </label>
+              <select id="screenResolution">
+                <option value="fullscreen">全屏分辨率</option>
+                <option value="720p">720p</option>
+                <option value="1080p">1080p</option>
+                <option value="2160p">2160p</option>
+              </select>
+            </div>
+            <div class="setting-row">
               <div class="setting-row-text">
                 <span class="setting-title">预计图像 token</span>
-                <span class="setting-desc">按当前屏幕估算每张截图消耗的 token。</span>
+                <span class="setting-desc">按当前屏幕和所选分辨率估算每张截图消耗的 token。</span>
               </div>
               <p id="tokenEstimate" class="hint"></p>
             </div>

--- a/tools/settings-tauri/frontend/settings.js
+++ b/tools/settings-tauri/frontend/settings.js
@@ -16,6 +16,7 @@ const fields = {
   checkInterval: document.getElementById("checkInterval"),
   cooldown: document.getElementById("cooldown"),
   batchLimit: document.getElementById("batchLimit"),
+  screenResolution: document.getElementById("screenResolution"),
   windowsMcp: document.getElementById("windowsMcp"),
   agentSteps: document.getElementById("agentSteps"),
   toolCallsPerStep: document.getElementById("toolCallsPerStep"),
@@ -737,6 +738,22 @@ function syncEnabledState() {
   setControlDisabled(fields.checkInterval, !enabled);
   setControlDisabled(fields.cooldown, !enabled);
   setControlDisabled(fields.batchLimit, !enabled);
+  setControlDisabled(fields.screenResolution, !enabled);
+}
+
+function updateScreenResolutionEstimate() {
+  if (!request) {
+    return;
+  }
+  const resolution = fields.screenResolution.value || "fullscreen";
+  const estimate = request.screen_resolution_estimates?.[resolution];
+  if (estimate) {
+    fields.tokenEstimate.textContent =
+      `预计发送 ${estimate.width}×${estimate.height}：约 ${estimate.tokens.toLocaleString("zh-CN")} token/张。`;
+    return;
+  }
+  fields.tokenEstimate.textContent =
+    `按当前屏幕估算：约 ${request.estimated_tokens_per_image.toLocaleString("zh-CN")} token/张。`;
 }
 
 function syncRuntimeLoopState() {
@@ -3860,6 +3877,7 @@ function collectScreenAwarenessSettings() {
     check_interval_minutes: clampInt(fields.checkInterval.value, limits.check_interval_minutes),
     cooldown_minutes: clampInt(fields.cooldown.value, limits.cooldown_minutes),
     screen_context_batch_limit: clampInt(fields.batchLimit.value, limits.screen_context_batch_limit),
+    screen_context_resolution: fields.screenResolution.value || "fullscreen",
   };
 }
 
@@ -4131,6 +4149,7 @@ async function load() {
   enhanceSelect(fields.visualEffectMode);
   enhanceSelect(fields.ttsProvider);
   enhanceSelect(fields.backchannelMode);
+  enhanceSelect(fields.screenResolution);
   enhanceSelect(fields.memoryLayerFilter);
   enhanceSelect(fields.memorySort);
   enhanceSelect(fields.memoryLayer);
@@ -4174,6 +4193,7 @@ async function load() {
   fields.checkInterval.value = settings.check_interval_minutes;
   fields.cooldown.value = settings.cooldown_minutes;
   fields.batchLimit.value = settings.screen_context_batch_limit;
+  fields.screenResolution.value = settings.screen_context_resolution || "fullscreen";
   syncDesktopMcpControl(request.mcp);
   fields.windowsMcp.checked = request.mcp.windows_enabled;
   fields.agentSteps.value = request.runtime_loop.max_agent_steps_per_turn;
@@ -4226,8 +4246,7 @@ async function load() {
 
   setThemeValues(request.theme);
   themeChanged = false;
-  fields.tokenEstimate.textContent =
-    `按当前屏幕估算：约 ${request.estimated_tokens_per_image.toLocaleString("zh-CN")} token/张。`;
+  updateScreenResolutionEstimate();
   syncEnabledState();
   syncRuntimeLoopState();
   syncDebugLogState();
@@ -4239,6 +4258,7 @@ async function load() {
   refreshSelect(fields.characterSelect);
   refreshSelect(fields.ttsProvider);
   refreshSelect(fields.backchannelMode);
+  refreshSelect(fields.screenResolution);
   renderMemoryPage();
   renderPluginPage();
   renderResourceCards();
@@ -4281,6 +4301,7 @@ fields.ttsVoiceImportButton.addEventListener("click", importCharacterVoiceArchiv
 fields.characterExportButton.addEventListener("click", exportCharacterArchive);
 fields.characterEditorButton.addEventListener("click", launchCharacterStudio);
 fields.enabled.addEventListener("change", syncEnabledState);
+fields.screenResolution.addEventListener("change", updateScreenResolutionEstimate);
 fields.toolCallsPerStep.addEventListener("input", syncRuntimeLoopState);
 fields.addProviderButton.addEventListener("click", openAddProviderChooser);
 fields.providerSearch.addEventListener("input", () => {


### PR DESCRIPTION
## 修改内容

- 在主动屏幕感知设置中新增截图分辨率选择器，默认使用全屏分辨率
- 提供 720p、1080p、2160p 固定档位，发送前保持宽高比缩小且不放大小尺寸截图
- 支持横屏、竖屏和超宽屏，并同步显示所选档位的预计发送尺寸与图像 token
- 持久化分辨率配置，并兼容缺少新字段的旧配置和旧设置结果

## 验证

- `runtime/python.exe -m pytest`（1333 passed, 3 skipped）
- `cargo check`（`tools/settings-tauri/src-tauri`）
- `node --check tools/settings-tauri/frontend/settings.js`
- `runtime/python.exe -m compileall -q app tests`

Closes #115