### PR TITLE
feat: 增强首次启动角色与供应商引导

### DIFF
--- a/app/config/defaults.py
+++ b/app/config/defaults.py
@@ -9,15 +9,15 @@
 from __future__ import annotations
 
 # ---- API 默认值 ----
-DEFAULT_BASE_URL = "https://api.openai.com/v1"
-DEFAULT_MODEL = "gpt-4.1-mini"
+DEFAULT_BASE_URL = ""
+DEFAULT_MODEL = ""
 DEFAULT_API_TIMEOUT_SECONDS = 60
 
 # ---- API 配置文件默认值 ----
 DEFAULT_PROFILE_ID = "default"
 DEFAULT_PROFILE_ALIAS = "默认"
-DEFAULT_VISION_MODEL = "gpt-4o"
-DEFAULT_TEXT_MODEL = "gpt-4.1-mini"
+DEFAULT_VISION_MODEL = ""
+DEFAULT_TEXT_MODEL = ""
 
 # ---- TTS 默认值 ----
 DEFAULT_TTS_ENABLED = False

--- a/app/config/models.py
+++ b/app/config/models.py
@@ -51,9 +51,9 @@ MODEL_SLOT_FALLBACKS = {
 class ApiSettings:
     """LLM API 连接配置。"""
 
-    base_url: str = "https://api.openai.com/v1"
+    base_url: str = ""
     api_key: str = ""
-    model: str = "gpt-4.1-mini"
+    model: str = ""
     timeout_seconds: int = 60
     # 角色对话生成参数；None 表示沿用内置默认/不发送该参数，保持历史行为。
     temperature: float | None = None

--- a/app/config/settings_service.py
+++ b/app/config/settings_service.py
@@ -180,9 +180,9 @@ class AppSettingsService:
             60,
         )
         return ApiSettings(
-            base_url=str(data.get("base_url", "https://api.openai.com/v1")).strip().rstrip("/"),
+            base_url=str(data.get("base_url", DEFAULT_BASE_URL)).strip().rstrip("/"),
             api_key=str(data.get("api_key", "")).strip(),
-            model=str(data.get("model", "gpt-4.1-mini")).strip(),
+            model=str(data.get("model", DEFAULT_TEXT_MODEL)).strip(),
             timeout_seconds=timeout_seconds,
             temperature=_optional_float(data.get("temperature"), minimum=0.0, maximum=2.0),
             top_p=_optional_float(data.get("top_p"), minimum=0.0, maximum=1.0),

--- a/app/config/settings_service.py
+++ b/app/config/settings_service.py
@@ -54,6 +54,8 @@ from app.voice.tts_settings import (
 API_CONFIG_FILE = "api.yaml"
 CHARACTERS_CONFIG_FILE = "characters.yaml"
 SYSTEM_CONFIG_FILE = "system_config.yaml"
+_LEGACY_DEFAULT_TEXT_MODEL = "gpt-4.1-mini"
+_LEGACY_DEFAULT_VISION_MODEL = "gpt-4o"
 
 
 @dataclass(frozen=True)
@@ -242,7 +244,7 @@ class AppSettingsService:
                 alias=DEFAULT_PROFILE_ALIAS,
                 base_url=str(llm.get("base_url", DEFAULT_BASE_URL)).strip().rstrip("/"),
                 api_key=str(llm.get("api_key", "")).strip(),
-                models=tuple(_dedupe([old_model or DEFAULT_TEXT_MODEL])),
+                models=tuple(_dedupe([old_model or _LEGACY_DEFAULT_TEXT_MODEL])),
             )
             # 写入新格式
             self.save_api_profiles([profile])
@@ -251,7 +253,7 @@ class AppSettingsService:
                 ModelSelectionSettings(
                     chat=ModelSlotSelection(
                         profile_id=DEFAULT_PROFILE_ID,
-                        model=old_model or DEFAULT_TEXT_MODEL,
+                        model=old_model or _LEGACY_DEFAULT_TEXT_MODEL,
                     ),
                 )
             )
@@ -318,18 +320,18 @@ class AppSettingsService:
                 settings = ModelSelectionSettings(
                     chat=ModelSlotSelection(
                         profile_id=str(data.get("text_profile_id", "")).strip(),
-                        model=str(data.get("text_model", DEFAULT_TEXT_MODEL)).strip(),
+                        model=str(data.get("text_model", _LEGACY_DEFAULT_TEXT_MODEL)).strip(),
                     ),
                     vision_chat=ModelSlotSelection(
                         profile_id=str(data.get("vision_profile_id", "")).strip(),
-                        model=str(data.get("vision_model", DEFAULT_VISION_MODEL)).strip(),
+                        model=str(data.get("vision_model", _LEGACY_DEFAULT_VISION_MODEL)).strip(),
                     ),
                 )
             else:
                 settings = ModelSelectionSettings(
                     chat=ModelSlotSelection(
                         profile_id=str(data.get("vision_profile_id", "")).strip(),
-                        model=str(data.get("vision_model", DEFAULT_VISION_MODEL)).strip(),
+                        model=str(data.get("vision_model", _LEGACY_DEFAULT_VISION_MODEL)).strip(),
                     ),
                 )
             self.save_model_selection(settings)
@@ -340,7 +342,7 @@ class AppSettingsService:
         return ModelSelectionSettings(
             chat=ModelSlotSelection(
                 profile_id=DEFAULT_PROFILE_ID if llm.get("base_url") else "",
-                model=old_model or DEFAULT_TEXT_MODEL,
+                model=old_model or (_LEGACY_DEFAULT_TEXT_MODEL if llm.get("base_url") else ""),
             ),
         )
 
@@ -821,6 +823,13 @@ def _legacy_model_names(data: dict[str, Any]) -> list[str]:
         names.append(str(data.get(key, "")).strip())
     llm = _mapping(data.get("llm"))
     names.append(str(llm.get("model", "")).strip())
+    if any(key in data for key in ("text_enabled", "text_profile_id", "vision_profile_id")):
+        if _bool_value(data.get("text_enabled"), True) and not str(data.get("text_model", "")).strip():
+            names.append(_LEGACY_DEFAULT_TEXT_MODEL)
+        if not str(data.get("vision_model", "")).strip():
+            names.append(_LEGACY_DEFAULT_VISION_MODEL)
+    elif llm.get("base_url") and not str(llm.get("model", "")).strip():
+        names.append(_LEGACY_DEFAULT_TEXT_MODEL)
     return _dedupe(names)
 
 

--- a/app/ui/tauri_settings.py
+++ b/app/ui/tauri_settings.py
@@ -531,6 +531,7 @@ def build_tauri_settings_request(
     name_font_size: int = DEFAULT_NAME_FONT_SIZE,
     input_font_size: int = DEFAULT_INPUT_FONT_SIZE,
     button_font_size: int = DEFAULT_BUTTON_FONT_SIZE,
+    onboarding: bool = False,
 ) -> dict[str, Any]:
     normalized_screen_awareness = screen_awareness_settings.normalized()
     normalized_mcp = normalize_mcp_runtime_settings(mcp_settings or MCPRuntimeSettings())
@@ -560,6 +561,7 @@ def build_tauri_settings_request(
     return {
         "version": TAURI_SETTINGS_PROTOCOL_VERSION,
         "nonce": nonce or secrets.token_urlsafe(16),
+        "onboarding": bool(onboarding),
         "screen_awareness": _screen_awareness_to_mapping(normalized_screen_awareness),
         "mcp": _mcp_to_mapping(normalized_mcp),
         "runtime_loop": _runtime_loop_to_mapping(normalized_runtime_loop),
@@ -1074,6 +1076,7 @@ class TauriSettingsProcess(QObject):
         name_font_size: int = DEFAULT_NAME_FONT_SIZE,
         input_font_size: int = DEFAULT_INPUT_FONT_SIZE,
         button_font_size: int = DEFAULT_BUTTON_FONT_SIZE,
+        onboarding: bool = False,
     ) -> None:
         super().__init__(parent)
         self.base_dir = Path(base_dir)
@@ -1098,6 +1101,7 @@ class TauriSettingsProcess(QObject):
         self.name_font_size = name_font_size
         self.input_font_size = input_font_size
         self.button_font_size = button_font_size
+        self.onboarding = bool(onboarding)
         self.api_settings = api_settings or _default_api_settings()
         self.api_profiles = api_profiles
         self.model_selection = model_selection
@@ -1239,6 +1243,7 @@ class TauriSettingsProcess(QObject):
             name_font_size=self.name_font_size,
             input_font_size=self.input_font_size,
             button_font_size=self.button_font_size,
+            onboarding=self.onboarding,
             api_settings=self.api_settings,
             api_profiles=self.api_profiles,
             model_selection=self.model_selection,
@@ -2674,6 +2679,8 @@ def _normalized_request_api_profiles(
         )
     if normalized:
         return normalized
+    if not any((settings.base_url.strip(), settings.api_key.strip(), settings.model.strip())):
+        return []
     defaults = _default_api_settings()
     model = str(settings.model or defaults.model).strip()
     return [
@@ -2693,6 +2700,8 @@ def _normalized_request_model_selection(
     model_selection: ModelSelectionSettings | None,
 ) -> ModelSelectionSettings:
     selection = model_selection or ModelSelectionSettings()
+    if not profiles:
+        return selection
     if resolve_model_slot(profiles, selection, MODEL_SLOT_CHAT, settings) is not None:
         return selection
     profile = profiles[0]

--- a/main.py
+++ b/main.py
@@ -32,6 +32,8 @@ from app.core.instance import SingleInstanceGuard
 from app.core.selfcheck import run_startup_self_check
 from app.storage.paths import StoragePaths
 from app.config.character_loader import CharacterConfigError, CharacterRegistry
+from app.config.model_slots import resolve_model_slot
+from app.config.models import MODEL_SLOT_CHAT
 from app.config.settings_service import AppSettingsService, StartupSettings
 from app.platforms.launch_at_login import (
     LaunchAtLoginError,
@@ -434,31 +436,28 @@ def main() -> int:
             _format_data_migration_failure(migration_report),
         )
 
+    initial_setup = False
     try:
-        context = build_initial_app_context(BASE_DIR)
-    except CharacterConfigError as exc:
-        if not _character_packages_missing(BASE_DIR):
-            _write_startup_error("Character", f"配置无效：{exc}")
-            return 1
-        try:
+        initial_setup = _initial_setup_required(BASE_DIR)
+        if initial_setup:
             context = _open_first_run_settings(BASE_DIR)
-        except (CharacterConfigError, OSError, TTSConfigError, ValueError) as first_run_exc:
+        else:
+            context = build_initial_app_context(BASE_DIR)
+    except (CharacterConfigError, OSError, TTSConfigError, ValueError) as exc:
+        if initial_setup:
             QMessageBox.critical(
                 None,
                 "启动失败",
                 format_failure_message(
                     "首次启动配置没有完成，Sakura 无法继续启动。",
                     "请检查角色包、TTS 配置和 data 目录权限后重试。",
-                    first_run_exc,
+                    exc,
                 ),
             )
-            _write_startup_error("Character", f"配置无效：{first_run_exc}")
-            return 1
-        if context is None:
-            return 0
-    except (OSError, ValueError) as exc:
         _write_startup_error("Character", f"配置无效：{exc}")
         return 1
+    if context is None:
+        return 0
 
     character_issues = getattr(context.character_registry, "load_errors", ())
     if character_issues:
@@ -495,6 +494,22 @@ def _character_packages_missing(base_dir: Path) -> bool:
         return not any(characters_dir.glob("*/character.json"))
     except OSError:
         return False
+
+
+def _initial_setup_required(base_dir: Path) -> bool:
+    if _character_packages_missing(base_dir):
+        return True
+    settings_service = AppSettingsService(base_dir=base_dir)
+    settings = settings_service.load_api_settings()
+    chat = resolve_model_slot(
+        settings_service.load_api_profiles(),
+        settings_service.load_model_selection(),
+        MODEL_SLOT_CHAT,
+        settings,
+    )
+    return chat is None or not all(
+        (chat.settings.base_url, chat.settings.api_key, chat.settings.model)
+    )
 
 
 def _ensure_launch_at_login_state(
@@ -572,6 +587,13 @@ def _open_first_run_settings(base_dir: Path) -> AppContext | None:
         character_profile=None,
     )
     startup_settings = settings_service.load_startup_settings()
+    character_registry = None
+    current_character = None
+    if not _character_packages_missing(base_dir):
+        character_registry = CharacterRegistry(base_dir)
+        current_character = character_registry.get(
+            settings_service.load_current_character_id(character_registry)
+        )
 
     process = TauriSettingsProcess(
         base_dir=base_dir,
@@ -580,8 +602,8 @@ def _open_first_run_settings(base_dir: Path) -> AppContext | None:
         runtime_loop_settings=settings_service.load_runtime_loop_settings(),
         debug_log_settings=settings_service.load_debug_log_settings(),
         theme_settings=settings_service.load_theme_settings(),
-        character_registry=None,
-        current_character=None,
+        character_registry=character_registry,
+        current_character=current_character,
         portrait_scale_percent=PORTRAIT_SCALE_DEFAULT_PERCENT,
         api_settings=api_settings,
         api_profiles=settings_service.load_api_profiles(),
@@ -591,6 +613,7 @@ def _open_first_run_settings(base_dir: Path) -> AppContext | None:
         launch_at_login_supported=is_launch_at_login_supported(),
         studio_launcher=lambda character_id: _open_first_run_studio(base_dir, character_id),
         model=getattr(api_settings, "model", None),
+        onboarding=True,
     )
 
     loop = QEventLoop()

--- a/main.py
+++ b/main.py
@@ -42,6 +42,16 @@ from app.platforms.launch_at_login import (
     set_launch_at_login_enabled,
 )
 from app.ui.pet_window import PetWindow
+from app.ui.control_panel_layout import (
+    DEFAULT_BUBBLE_HEIGHT,
+    DEFAULT_CONTROL_PANEL_VERTICAL_OFFSET,
+    DEFAULT_CONTROL_PANEL_WIDTH,
+    DEFAULT_INPUT_BAR_OFFSET,
+    normalize_bubble_height,
+    normalize_control_panel_vertical_offset,
+    normalize_control_panel_width,
+    normalize_input_bar_offset,
+)
 from app.ui.error_messages import format_failure_message
 from app.ui.tauri_settings import (
     TauriSettingsProcess,
@@ -50,8 +60,15 @@ from app.ui.tauri_settings import (
     tts_settings_from_tauri_result,
 )
 from app.ui.tauri_studio import TauriStudioProcess, resolve_tauri_studio_binary
-from app.ui.portrait_controller import PORTRAIT_SCALE_DEFAULT_PERCENT
-from app.ui.subtitle_controller import normalize_subtitle_display_speed
+from app.ui.portrait_controller import (
+    PORTRAIT_SCALE_DEFAULT_PERCENT,
+    normalize_portrait_scale_percent,
+)
+from app.ui.subtitle_controller import (
+    REPLY_SEGMENT_PAUSE_MS,
+    SPEECH_TYPING_INTERVAL_MS,
+    normalize_subtitle_display_speed,
+)
 from app.voice.tts_settings import TTSConfigError
 from app.voice.tts_bundle import (
     TTSBundleMigration,
@@ -443,7 +460,7 @@ def main() -> int:
             context = _open_first_run_settings(BASE_DIR)
         else:
             context = build_initial_app_context(BASE_DIR)
-    except (CharacterConfigError, OSError, TTSConfigError, ValueError) as exc:
+    except (CharacterConfigError, OSError, RuntimeError, TTSConfigError, ValueError) as exc:
         if initial_setup:
             QMessageBox.critical(
                 None,
@@ -587,6 +604,11 @@ def _open_first_run_settings(base_dir: Path) -> AppContext | None:
         character_profile=None,
     )
     startup_settings = settings_service.load_startup_settings()
+    ui_settings = settings_service.load_system_values("ui")
+    subtitle_typing_interval_ms, reply_segment_pause_ms = normalize_subtitle_display_speed(
+        ui_settings.get("subtitle_typing_interval_ms", SPEECH_TYPING_INTERVAL_MS),
+        ui_settings.get("reply_segment_pause_ms", REPLY_SEGMENT_PAUSE_MS),
+    )
     character_registry = None
     current_character = None
     if not _character_packages_missing(base_dir):
@@ -604,7 +626,26 @@ def _open_first_run_settings(base_dir: Path) -> AppContext | None:
         theme_settings=settings_service.load_theme_settings(),
         character_registry=character_registry,
         current_character=current_character,
-        portrait_scale_percent=PORTRAIT_SCALE_DEFAULT_PERCENT,
+        portrait_scale_percent=normalize_portrait_scale_percent(
+            ui_settings.get("portrait_scale_percent", PORTRAIT_SCALE_DEFAULT_PERCENT)
+        ),
+        control_panel_width=normalize_control_panel_width(
+            ui_settings.get("control_panel_width", DEFAULT_CONTROL_PANEL_WIDTH)
+        ),
+        bubble_height=normalize_bubble_height(
+            ui_settings.get("bubble_height", DEFAULT_BUBBLE_HEIGHT)
+        ),
+        control_panel_vertical_offset=normalize_control_panel_vertical_offset(
+            ui_settings.get(
+                "control_panel_vertical_offset",
+                DEFAULT_CONTROL_PANEL_VERTICAL_OFFSET,
+            )
+        ),
+        input_bar_offset=normalize_input_bar_offset(
+            ui_settings.get("input_bar_offset", DEFAULT_INPUT_BAR_OFFSET)
+        ),
+        subtitle_typing_interval_ms=subtitle_typing_interval_ms,
+        reply_segment_pause_ms=reply_segment_pause_ms,
         api_settings=api_settings,
         api_profiles=settings_service.load_api_profiles(),
         model_selection=settings_service.load_model_selection(),

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -4917,6 +4917,45 @@ def test_tauri_settings_request_includes_theme_colors() -> None:
     assert {"id": "solid", "label": "纯色块"} in request["visual_effect_modes"]
 
 
+def test_tauri_settings_request_preserves_empty_api_for_onboarding() -> None:
+    from app.config.models import ModelSelectionSettings
+    from app.llm.api_client import ApiSettings
+    from app.ui.tauri_settings import build_tauri_settings_request
+
+    request = build_tauri_settings_request(
+        ScreenAwarenessSettings(),
+        api_settings=ApiSettings("", "", ""),
+        api_profiles=[],
+        model_selection=ModelSelectionSettings(),
+        onboarding=True,
+        nonce="nonce",
+    )
+
+    assert request["onboarding"] is True
+    assert request["api"]["profiles"] == []
+    assert request["api"]["model_selection"]["slots"]["chat"] == {
+        "profile_id": "",
+        "model": "",
+    }
+
+
+def test_tauri_settings_frontend_has_two_step_onboarding() -> None:
+    root = Path(__file__).resolve().parents[2] / "tools" / "settings-tauri" / "frontend"
+    html = (root / "index.html").read_text(encoding="utf-8")
+    script = (root / "settings.js").read_text(encoding="utf-8")
+    styles = (root / "styles.css").read_text(encoding="utf-8")
+
+    assert 'id="onboardingHead"' in html
+    assert 'id="onboardingCharacterStep"' in html
+    assert 'id="onboardingProviderStep"' in html
+    assert 'id="onboardingBackButton"' in html
+    assert 'body.classList.toggle("is-onboarding"' in script
+    assert 'fields.saveButton.textContent = "完成并启动 Sakura"' in script
+    assert 'showOnboardingStep("providers")' in script
+    assert "通常应以 /v1 结尾" in script
+    assert "body.is-onboarding .nav-card" in styles
+
+
 def test_tauri_settings_request_includes_screen_resolution_estimates(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     import app.ui.tauri_settings as tauri_settings
 
@@ -6693,6 +6732,53 @@ def test_main_detects_missing_character_packages() -> None:
     assert not sakura_main._character_packages_missing(root)
 
 
+def test_main_requires_initial_setup_until_character_and_chat_provider_exist() -> None:
+    import main as sakura_main
+
+    root = _ui_runtime_root("initial_setup_required")
+    assert sakura_main._initial_setup_required(root)
+
+    character_dir = root / "characters" / "demo"
+    character_dir.mkdir(parents=True)
+    (character_dir / "character.json").write_text("{}", encoding="utf-8")
+    assert sakura_main._initial_setup_required(root)
+
+    api_config = root / "data" / "config" / "api.yaml"
+    api_config.parent.mkdir(parents=True)
+    api_config.write_text(
+        """
+llm:
+  base_url: https://api.example.com/v1
+  api_key: key
+  model: model
+api_profiles:
+  - id: default
+    alias: 默认
+    base_url: https://api.example.com/v1
+    api_key: key
+    models:
+      - name: model
+model_slots:
+  chat:
+    profile_id: default
+    model: model
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    assert not sakura_main._initial_setup_required(root)
+
+
+def test_main_checks_initial_setup_before_building_app_context() -> None:
+    source = (Path(__file__).resolve().parents[2] / "main.py").read_text(encoding="utf-8")
+    startup = source[source.index("migration_report =") : source.index("character_issues =")]
+
+    assert "initial_setup = _initial_setup_required(BASE_DIR)" in startup
+    assert startup.index("initial_setup = _initial_setup_required(BASE_DIR)") < startup.index(
+        "build_initial_app_context(BASE_DIR)"
+    )
+
+
 def test_main_first_run_studio_waits_for_close_and_requests_refresh(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     import main as sakura_main
 
@@ -6758,6 +6844,7 @@ def test_main_first_run_tauri_save_persists_full_layout(monkeypatch) -> None:  #
     root = _ui_runtime_root("first_run_tauri_layout")
     saved_system_values: dict[str, dict[str, object]] = {}
     studio_launchers: list[object] = []
+    process_kwargs: list[dict[str, object]] = []
     app_context = object()
     tts_settings = _minimal_tts_settings()
     result = _build_tauri_settings_result(
@@ -6793,6 +6880,9 @@ def test_main_first_run_tauri_save_persists_full_layout(monkeypatch) -> None:  #
 
         def load_startup_settings(self):  # type: ignore[no-untyped-def]
             return StartupSettings()
+
+        def load_current_character_id(self, _registry):  # type: ignore[no-untyped-def]
+            return "sakura"
 
         def load_screen_awareness_settings(self):  # type: ignore[no-untyped-def]
             return result.screen_awareness
@@ -6858,6 +6948,7 @@ def test_main_first_run_tauri_save_persists_full_layout(monkeypatch) -> None:  #
             self.failed = _SignalStub()
             self.shutdown_called = False
             studio_launchers.append(kwargs.get("studio_launcher"))
+            process_kwargs.append(kwargs)
 
         def start(self) -> bool:
             self.completed.emit(result)
@@ -6873,6 +6964,7 @@ def test_main_first_run_tauri_save_persists_full_layout(monkeypatch) -> None:  #
     monkeypatch.setattr(sakura_main, "QEventLoop", EventLoopStub)
     monkeypatch.setattr(sakura_main, "AppSettingsService", SettingsServiceStub)
     monkeypatch.setattr(sakura_main, "CharacterRegistry", CharacterRegistryStub)
+    monkeypatch.setattr(sakura_main, "_character_packages_missing", lambda _base_dir: False)
     monkeypatch.setattr(sakura_main, "TauriSettingsProcess", TauriSettingsProcessStub)
     monkeypatch.setattr(
         sakura_main,
@@ -6889,6 +6981,9 @@ def test_main_first_run_tauri_save_persists_full_layout(monkeypatch) -> None:  #
     assert sakura_main._open_first_run_settings(root) is app_context
     assert len(studio_launchers) == 1
     assert callable(studio_launchers[0])
+    assert process_kwargs[0]["onboarding"] is True
+    assert isinstance(process_kwargs[0]["character_registry"], CharacterRegistryStub)
+    assert process_kwargs[0]["current_character"].id == "sakura"
     assert saved_system_values["ui"] == {
         "portrait_scale_percent": 155,
         "control_panel_width": 730,

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -6777,6 +6777,7 @@ def test_main_checks_initial_setup_before_building_app_context() -> None:
     assert startup.index("initial_setup = _initial_setup_required(BASE_DIR)") < startup.index(
         "build_initial_app_context(BASE_DIR)"
     )
+    assert "RuntimeError" in startup
 
 
 def test_main_first_run_studio_waits_for_close_and_requests_refresh(monkeypatch) -> None:  # type: ignore[no-untyped-def]
@@ -6899,6 +6900,18 @@ def test_main_first_run_tauri_save_persists_full_layout(monkeypatch) -> None:  #
         def load_theme_settings(self):  # type: ignore[no-untyped-def]
             return DEFAULT_THEME_SETTINGS
 
+        def load_system_values(self, section: str) -> dict[str, int]:
+            assert section == "ui"
+            return {
+                "portrait_scale_percent": 125,
+                "control_panel_width": 620,
+                "bubble_height": 180,
+                "control_panel_vertical_offset": 20,
+                "input_bar_offset": 12,
+                "subtitle_typing_interval_ms": 48,
+                "reply_segment_pause_ms": 260,
+            }
+
         def save_api_settings(self, _settings) -> None:  # type: ignore[no-untyped-def]
             pass
 
@@ -6984,6 +6997,13 @@ def test_main_first_run_tauri_save_persists_full_layout(monkeypatch) -> None:  #
     assert process_kwargs[0]["onboarding"] is True
     assert isinstance(process_kwargs[0]["character_registry"], CharacterRegistryStub)
     assert process_kwargs[0]["current_character"].id == "sakura"
+    assert process_kwargs[0]["portrait_scale_percent"] == 125
+    assert process_kwargs[0]["control_panel_width"] == 620
+    assert process_kwargs[0]["bubble_height"] == 180
+    assert process_kwargs[0]["control_panel_vertical_offset"] == 20
+    assert process_kwargs[0]["input_bar_offset"] == 12
+    assert process_kwargs[0]["subtitle_typing_interval_ms"] == 48
+    assert process_kwargs[0]["reply_segment_pause_ms"] == 260
     assert saved_system_values["ui"] == {
         "portrait_scale_percent": 155,
         "control_panel_width": 730,

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -4952,7 +4952,10 @@ def test_tauri_settings_frontend_has_two_step_onboarding() -> None:
     assert 'body.classList.toggle("is-onboarding"' in script
     assert 'fields.saveButton.textContent = "完成并启动 Sakura"' in script
     assert 'showOnboardingStep("providers")' in script
-    assert "通常应以 /v1 结尾" in script
+    assert 'base_url: "通常以 /v1 结尾"' in script
+    assert 'api_key: "通常以 sk- 开头"' in script
+    assert "provider-url-hint" not in script
+    assert "provider-url-hint" not in styles
     assert "body.is-onboarding .nav-card" in styles
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -20,6 +20,8 @@ from app.config.defaults import (
     DEFAULT_BASE_URL,
     DEFAULT_MODEL,
     DEFAULT_SUBTITLE_LANGUAGE,
+    DEFAULT_TEXT_MODEL,
+    DEFAULT_VISION_MODEL,
 )
 from app.config.migrations import _parse_dotenv, _coerce_type, migrate_env_to_yaml
 from app.config.models import ApiSettings, DebugLogSettings
@@ -98,6 +100,10 @@ class TestApiSettings:
 
     def test_defaults(self) -> None:
         s = ApiSettings()
+        assert DEFAULT_BASE_URL == ""
+        assert DEFAULT_MODEL == ""
+        assert DEFAULT_TEXT_MODEL == ""
+        assert DEFAULT_VISION_MODEL == ""
         assert s.base_url == DEFAULT_BASE_URL
         assert s.model == DEFAULT_MODEL
         assert s.timeout_seconds == 60

--- a/tests/unit/test_sakura_mobile.py
+++ b/tests/unit/test_sakura_mobile.py
@@ -14,6 +14,7 @@ from app.agent.actions import AgentResult
 from app.agent.runtime_limits import RuntimeLoopSettings
 from app.agent.tools import Tool, ToolRegistry
 from app.config.character_loader import CharacterProfile
+from app.core.http_client import urlopen_direct_for_loopback
 from app.core.mobile_chat_bridge import MobileChatBridge, MobileChatBusyError
 from app.llm.chat_reply import ChatReply, ChatSegment
 from app.plugins.capabilities import PluginCapabilityRegistry
@@ -212,7 +213,7 @@ def test_mobile_chat_busy_returns_409() -> None:
             method="POST",
         )
         with pytest.raises(urllib.error.HTTPError) as exc_info:
-            urllib.request.urlopen(request, timeout=5)
+            urlopen_direct_for_loopback(request, timeout=5)
         payload = json.loads(exc_info.value.read().decode("utf-8"))
         assert exc_info.value.code == 409
         assert payload == {"ok": False, "busy": True, "error": "Sakura 正忙，请稍后再试。"}

--- a/tests/unit/test_settings_service.py
+++ b/tests/unit/test_settings_service.py
@@ -44,6 +44,15 @@ class CharacterRegistryStub:
         return self.profiles[character_id]
 
 
+def test_settings_service_keeps_missing_api_config_empty() -> None:
+    root = _runtime_root("empty_api")
+    service = AppSettingsService(root)
+
+    assert service.load_api_settings() == ApiSettings("", "", "")
+    assert service.load_api_profiles() == []
+    assert service.load_model_selection() == ModelSelectionSettings()
+
+
 def test_settings_service_loads_yaml_api_config() -> None:
     root = _runtime_root("yaml_api")
     service = AppSettingsService(root)

--- a/tests/unit/test_settings_service.py
+++ b/tests/unit/test_settings_service.py
@@ -103,6 +103,26 @@ llm:
     assert load_yaml_mapping(service.api_config_path)["model_slots"]["chat"]["model"] == "legacy-chat"
 
 
+def test_api_model_slots_keep_historical_model_for_legacy_llm_without_model() -> None:
+    root = _runtime_root("model_slots_legacy_llm_without_model")
+    service = AppSettingsService(root)
+    service.api_config_path.parent.mkdir(parents=True)
+    service.api_config_path.write_text(
+        """
+llm:
+  base_url: https://legacy.example/v1
+  api_key: legacy-key
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    profiles = service.load_api_profiles()
+    selection = service.load_model_selection()
+
+    assert profiles[0].models == ("gpt-4.1-mini",)
+    assert selection.chat == ModelSlotSelection("default", "gpt-4.1-mini")
+
+
 def test_api_model_slots_migrate_pr110_selection() -> None:
     root = _runtime_root("model_slots_pr110")
     service = AppSettingsService(root)
@@ -133,6 +153,32 @@ vision_model: vision-model
     assert selection.chat.model == "text-model"
     assert selection.vision_chat is not None
     assert selection.vision_chat.model == "vision-model"
+
+
+def test_api_model_slots_keep_historical_models_for_pr110_without_model_names() -> None:
+    root = _runtime_root("model_slots_pr110_without_models")
+    service = AppSettingsService(root)
+    service.api_config_path.parent.mkdir(parents=True)
+    service.api_config_path.write_text(
+        """
+api_profiles:
+  - id: p1
+    alias: 旧供应商
+    base_url: https://api.example/v1
+    api_key: key
+text_enabled: true
+text_profile_id: p1
+vision_profile_id: p1
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    profiles = service.load_api_profiles()
+    selection = service.load_model_selection()
+
+    assert profiles[0].models == ("gpt-4.1-mini", "gpt-4o")
+    assert selection.chat == ModelSlotSelection("p1", "gpt-4.1-mini")
+    assert selection.vision_chat == ModelSlotSelection("p1", "gpt-4o")
 
 
 def test_model_slot_resolver_uses_configured_fallbacks() -> None:

--- a/tools/settings-tauri/frontend/index.html
+++ b/tools/settings-tauri/frontend/index.html
@@ -74,6 +74,26 @@
       </aside>
 
       <section class="detail-card">
+        <header id="onboardingHead" class="onboarding-head" hidden>
+          <div>
+            <p class="onboarding-kicker">首次启动</p>
+            <h1>让 Sakura 准备好陪你</h1>
+            <p>完成两个必要步骤，其他选项可以稍后再调整。</p>
+          </div>
+          <div class="onboarding-steps" role="list" aria-label="初始化进度">
+            <button id="onboardingCharacterStep" class="onboarding-step" type="button" role="listitem">
+              <span>1</span> 添加角色
+            </button>
+            <span class="onboarding-step-line" aria-hidden="true"></span>
+            <button id="onboardingProviderStep" class="onboarding-step" type="button" role="listitem">
+              <span>2</span> 配置供应商
+            </button>
+            <span class="onboarding-step-line" aria-hidden="true"></span>
+            <span id="onboardingCompleteStep" class="onboarding-step is-static" role="listitem">
+              <span>3</span> 完成
+            </span>
+          </div>
+        </header>
         <header class="page-head">
           <h1 id="pageTitle" class="page-title">角色与布局</h1>
           <p id="pageSubtitle" class="page-subtitle">选择陪伴角色与桌宠布局</p>
@@ -677,6 +697,7 @@
             <span class="dirty-flag">● 有未保存的改动</span>
             <p id="errorText" class="error" role="alert"></p>
           </div>
+          <button id="onboardingBackButton" class="secondary-button" type="button" hidden>返回角色</button>
           <button id="cancelButton" class="secondary-button" type="button">取消</button>
           <button id="applyButton" class="secondary-button" type="button">应用</button>
           <button id="saveButton" type="button">保存并关闭</button>

--- a/tools/settings-tauri/frontend/settings.js
+++ b/tools/settings-tauri/frontend/settings.js
@@ -95,6 +95,11 @@ const fields = {
   pluginDetail: document.getElementById("pluginDetail"),
   tokenEstimate: document.getElementById("tokenEstimate"),
   errorText: document.getElementById("errorText"),
+  onboardingHead: document.getElementById("onboardingHead"),
+  onboardingCharacterStep: document.getElementById("onboardingCharacterStep"),
+  onboardingProviderStep: document.getElementById("onboardingProviderStep"),
+  onboardingCompleteStep: document.getElementById("onboardingCompleteStep"),
+  onboardingBackButton: document.getElementById("onboardingBackButton"),
   saveButton: document.getElementById("saveButton"),
   applyButton: document.getElementById("applyButton"),
   cancelButton: document.getElementById("cancelButton"),
@@ -126,6 +131,7 @@ let settingsBaseline = null;
 let bypassCloseGuard = false;
 let memoryRetryTimer = null;
 let characterArchiveBusy = false;
+let onboardingStep = "character";
 const characterExportOptions = [
   {
     kind: "full",
@@ -754,6 +760,65 @@ function showPage(page) {
   }
 }
 
+function isOnboarding() {
+  return Boolean(request?.onboarding);
+}
+
+function onboardingChatProfile() {
+  const profiles = normalizedProviderProfiles();
+  const chat = collectModelSelection().slots.chat || {};
+  return profiles.find((profile) => profile.id === chat.profile_id) || null;
+}
+
+function onboardingApiReady() {
+  const profile = onboardingChatProfile();
+  const chat = collectModelSelection().slots.chat || {};
+  return Boolean(
+    profile
+    && profile.base_url
+    && profile.api_key
+    && chat.model
+    && profile.models.includes(chat.model)
+  );
+}
+
+function updateOnboardingUi() {
+  if (!isOnboarding()) {
+    return;
+  }
+  const characterReady = Boolean(selectedCharacter());
+  const apiReady = onboardingApiReady();
+  const providerActive = onboardingStep === "providers";
+  fields.onboardingCharacterStep.classList.toggle("is-active", !providerActive);
+  fields.onboardingCharacterStep.classList.toggle("is-complete", characterReady);
+  fields.onboardingProviderStep.classList.toggle("is-active", providerActive);
+  fields.onboardingProviderStep.classList.toggle("is-complete", apiReady);
+  fields.onboardingProviderStep.disabled = !characterReady;
+  fields.onboardingCompleteStep.classList.toggle("is-complete", characterReady && apiReady);
+  fields.onboardingBackButton.hidden = !providerActive;
+  fields.saveButton.disabled = characterArchiveBusy || !(characterReady && apiReady);
+}
+
+function showOnboardingStep(page) {
+  if (!isOnboarding() || (page === "providers" && !selectedCharacter())) {
+    return;
+  }
+  onboardingStep = page;
+  showPage(page);
+  updateOnboardingUi();
+}
+
+function initializeOnboarding() {
+  const active = isOnboarding();
+  document.body.classList.toggle("is-onboarding", active);
+  fields.onboardingHead.hidden = !active;
+  if (!active) {
+    return;
+  }
+  fields.saveButton.textContent = "完成并启动 Sakura";
+  showOnboardingStep(selectedCharacter() ? "providers" : "character");
+}
+
 function syncEnabledState() {
   const enabled = fields.enabled.checked;
   setControlDisabled(fields.checkInterval, !enabled);
@@ -979,6 +1044,7 @@ function syncCharacterArchiveState() {
     ? "角色包处理中..."
     : (hasCharacter ? "管理 Sakura .char 与 .voice 文件。" : "先导入一个 Sakura .char 角色包。");
   refreshSelect(fields.characterSelect);
+  updateOnboardingUi();
 }
 
 function setCharacterArchiveBusy(busy) {
@@ -1581,8 +1647,15 @@ function providerField(profile, key, label, type) {
     } else if (key === "api_key") {
       renderProviderStatus();
     }
+    updateOnboardingUi();
   });
   row.append(labelEl, input);
+  if (key === "base_url") {
+    const hint = document.createElement("span");
+    hint.className = "provider-url-hint";
+    hint.textContent = "通常应以 /v1 结尾；特殊兼容地址请按供应商文档填写。";
+    row.append(hint);
+  }
   return row;
 }
 
@@ -1623,6 +1696,7 @@ function renderProviderModels(profile) {
         profile.models = profile.models.filter((item) => item !== model);
         renderProviderPage();
         refreshModelSlots();
+        updateOnboardingUi();
       });
       chip.append(name, remove);
       list.append(chip);
@@ -1678,6 +1752,7 @@ function addModelsToProfile(profile, models) {
   if (added) {
     renderProviderPage();
     refreshModelSlots();
+    updateOnboardingUi();
   }
   return added;
 }
@@ -1764,6 +1839,7 @@ function removeProvider(profile) {
   }
   renderProviderPage();
   refreshModelSlots();
+  updateOnboardingUi();
 }
 
 function addProvider(preset) {
@@ -1782,6 +1858,7 @@ function addProvider(preset) {
   }
   renderProviderPage();
   refreshModelSlots();
+  updateOnboardingUi();
 }
 
 function makeModalButton(text, className, handler) {
@@ -2255,6 +2332,9 @@ function applyCharacterRpcResult(result, { dirty = true, applyTheme = false } = 
   }
   if (result?.message) {
     notify(result.message, "success");
+  }
+  if (isOnboarding() && selectedCharacter()) {
+    showOnboardingStep("providers");
   }
 }
 
@@ -3938,6 +4018,26 @@ function focusProviderValidation(profile, field) {
   markInvalid(providerDetailInput(field), true);
 }
 
+function validateOnboardingBeforeSubmit() {
+  if (!isOnboarding()) {
+    return true;
+  }
+  if (!selectedCharacter()) {
+    showOnboardingStep("character");
+    setError("请先导入并选择一个角色包。");
+    return false;
+  }
+  const profile = onboardingChatProfile();
+  if (profile && !profile.api_key) {
+    focusProviderValidation(profile, "api_key");
+    onboardingStep = "providers";
+    updateOnboardingUi();
+    setError(`供应商「${providerDisplayName(profile)}」缺少 API Key。`);
+    return false;
+  }
+  return true;
+}
+
 function validateApiSettingsBeforeSubmit() {
   const profiles = normalizedProviderProfiles();
   if (!profiles.length) {
@@ -4283,6 +4383,7 @@ async function load() {
   renderMemoryPage();
   renderPluginPage();
   renderResourceCards();
+  initializeOnboarding();
   if (hasRunningResourceTask()) {
     startResourcePolling();
   }
@@ -4317,6 +4418,7 @@ layoutSliders.forEach((fieldKey) => {
 fields.characterSelect.addEventListener("change", syncTtsState);
 fields.characterSelect.addEventListener("change", applySelectedCharacterTheme);
 fields.characterSelect.addEventListener("change", syncCharacterArchiveState);
+fields.characterSelect.addEventListener("change", updateOnboardingUi);
 fields.characterImportButton.addEventListener("click", importCharacterArchive);
 fields.ttsVoiceImportButton.addEventListener("click", importCharacterVoiceArchive);
 fields.characterExportButton.addEventListener("click", exportCharacterArchive);
@@ -4325,6 +4427,9 @@ fields.enabled.addEventListener("change", syncEnabledState);
 fields.screenResolution.addEventListener("change", updateScreenResolutionEstimate);
 fields.toolCallsPerStep.addEventListener("input", syncRuntimeLoopState);
 fields.addProviderButton.addEventListener("click", openAddProviderChooser);
+fields.onboardingCharacterStep.addEventListener("click", () => showOnboardingStep("character"));
+fields.onboardingProviderStep.addEventListener("click", () => showOnboardingStep("providers"));
+fields.onboardingBackButton.addEventListener("click", () => showOnboardingStep("character"));
 fields.providerSearch.addEventListener("input", () => {
   providerState.search = fields.providerSearch.value;
   renderProviderList();
@@ -4366,7 +4471,7 @@ fields.saveButton.addEventListener("click", async () => {
     return;
   }
   setError("");
-  if (!validateApiSettingsBeforeSubmit()) {
+  if (!validateOnboardingBeforeSubmit() || !validateApiSettingsBeforeSubmit()) {
     return;
   }
   const original = fields.saveButton.textContent;
@@ -4405,7 +4510,7 @@ fields.applyButton.addEventListener("click", async () => {
     return;
   }
   setError("");
-  if (!validateApiSettingsBeforeSubmit()) {
+  if (!validateOnboardingBeforeSubmit() || !validateApiSettingsBeforeSubmit()) {
     return;
   }
   let settings;

--- a/tools/settings-tauri/frontend/settings.js
+++ b/tools/settings-tauri/frontend/settings.js
@@ -1431,6 +1431,10 @@ function makeProfileId() {
 // 「供应商」页与「模型」页的槽位都从它派生（参照 pluginState/memoryState）。
 const providerState = { profiles: [], selectedId: "", search: "" };
 const inheritedSlotManualSelections = {};
+const PROVIDER_FIELD_PLACEHOLDERS = {
+  base_url: "通常以 /v1 结尾",
+  api_key: "通常以 sk- 开头",
+};
 
 // 内置预设：选中即预填 Base URL 与图标，其余走「自定义」。
 const PROVIDER_PRESETS = [
@@ -1629,6 +1633,7 @@ function providerField(profile, key, label, type) {
   input.className = "wide-input";
   input.dataset.providerField = key;
   input.value = profile[key] || "";
+  input.placeholder = PROVIDER_FIELD_PLACEHOLDERS[key] || "";
   input.addEventListener("input", () => {
     profile[key] = input.value;
     if (input.value.trim()) {
@@ -1650,12 +1655,6 @@ function providerField(profile, key, label, type) {
     updateOnboardingUi();
   });
   row.append(labelEl, input);
-  if (key === "base_url") {
-    const hint = document.createElement("span");
-    hint.className = "provider-url-hint";
-    hint.textContent = "通常应以 /v1 结尾；特殊兼容地址请按供应商文档填写。";
-    row.append(hint);
-  }
   return row;
 }
 

--- a/tools/settings-tauri/frontend/styles.css
+++ b/tools/settings-tauri/frontend/styles.css
@@ -378,13 +378,6 @@ body.is-onboarding #page-character {
   margin: 0 auto;
 }
 
-.provider-url-hint {
-  grid-column: 2;
-  margin-top: -12px;
-  color: var(--sakura-muted-text);
-  font-size: 11.5px;
-}
-
 .page-title {
   margin: 0;
   font-size: 19px;

--- a/tools/settings-tauri/frontend/styles.css
+++ b/tools/settings-tauri/frontend/styles.css
@@ -270,6 +270,121 @@ html.is-theme-view-transition::view-transition-new(root) {
   border-bottom: 1px solid var(--hairline);
 }
 
+.onboarding-head {
+  display: grid;
+  gap: 18px;
+  padding: 22px 26px 18px;
+  border-bottom: 1px solid var(--hairline);
+  background: linear-gradient(120deg, var(--tint-soft), transparent 62%);
+}
+
+.onboarding-head h1,
+.onboarding-head p {
+  margin: 0;
+}
+
+.onboarding-head h1 {
+  color: var(--sakura-text);
+  font-size: 22px;
+}
+
+.onboarding-head p:not(.onboarding-kicker) {
+  margin-top: 4px;
+  color: var(--sakura-muted-text);
+  font-size: 12.5px;
+}
+
+.onboarding-kicker {
+  color: var(--sakura-primary);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+}
+
+.onboarding-steps {
+  display: grid;
+  grid-template-columns: auto minmax(28px, 1fr) auto minmax(28px, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+}
+
+.onboarding-step {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+  min-height: 32px;
+  border: 0;
+  background: transparent;
+  color: var(--sakura-muted-text);
+  padding: 0;
+  white-space: nowrap;
+}
+
+.onboarding-step span:first-child {
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  border: 1px solid var(--sakura-border);
+  border-radius: 50%;
+  background: var(--surface-raised);
+  font-size: 11px;
+}
+
+.onboarding-step.is-active,
+.onboarding-step.is-complete {
+  color: var(--sakura-primary);
+}
+
+.onboarding-step.is-active span:first-child,
+.onboarding-step.is-complete span:first-child {
+  border-color: var(--sakura-primary);
+  background: var(--sakura-primary);
+  color: white;
+}
+
+.onboarding-step-line {
+  height: 1px;
+  background: var(--hairline);
+}
+
+.onboarding-step.is-static {
+  font-weight: 700;
+}
+
+body.is-onboarding .settings-shell {
+  grid-template-columns: minmax(0, 1fr);
+  width: min(100%, 1040px);
+  margin: 0 auto;
+}
+
+body.is-onboarding .nav-card,
+body.is-onboarding .page-head,
+body.is-onboarding #cancelButton,
+body.is-onboarding #applyButton,
+body.is-onboarding #page-character .settings-group:not(:last-child),
+body.is-onboarding #ttsVoiceImportButton,
+body.is-onboarding #characterExportButton {
+  display: none;
+}
+
+body.is-onboarding .onboarding-head {
+  display: grid;
+}
+
+body.is-onboarding #page-character {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.provider-url-hint {
+  grid-column: 2;
+  margin-top: -12px;
+  color: var(--sakura-muted-text);
+  font-size: 11.5px;
+}
+
 .page-title {
   margin: 0;
   font-size: 19px;


### PR DESCRIPTION
## 变更内容

- 首次启动改为两步引导：添加角色包、配置 API 供应商
- 新安装不再预填 OpenAI Base URL 或模型，空配置会保持为空
- 缺少角色或可用聊天供应商时自动进入引导
- 仅缺 API 配置时复用已有角色、布局和字幕速度
- Base URL 仅提示通常以 `/v1` 结尾，不强制修改
- 保留旧版 `llm` 与 PR #110 配置的历史模型迁移兼容
- 修复移动端本地 HTTP 测试受系统代理影响而返回空响应的问题

## 原因与影响

现有首次启动只在缺少角色包时打开完整设置页，并会自动生成 OpenAI 默认配置，用户不容易理解必须完成的步骤。现在新用户只需完成角色和聊天供应商配置，已有用户配置不会被清空或被隐藏字段的默认值覆盖。

移动端 409 用例失败的根因是测试请求经过系统代理；改为复用现有 loopback 直连 helper，服务器实现不变。

## 验证

- `node --check tools/settings-tauri/frontend/settings.js`
- `.\runtime\python.exe -m pytest`（1441 passed, 3 skipped）
- 两轮只读代码审查，Critical/Important 均为 0
