### PR TITLE
fix: 修复 Tauri 右键菜单和新建角色弹窗

### DIFF
--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -5518,6 +5518,7 @@ def test_tauri_settings_frontend_has_single_character_editor_button() -> None:
     assert "characterStudioOpenButton" not in source
     assert 'typeof result?.current_character_id === "string"' in source
     assert "if (applyTheme && selectedCharacter()) {" in source
+    assert 'document.addEventListener("contextmenu", (event) => event.preventDefault());' in source
     studio_launch_source = source.split("async function launchCharacterStudio()", 1)[1].split(
         "function resourcesSnapshot()", 1
     )[0]
@@ -5539,6 +5540,9 @@ def test_tauri_studio_frontend_matches_settings_language() -> None:
     assert "保存" in index
     assert 'id="studioCharacterSelect"' in index
     assert 'id="newCharacterButton"' in index
+    assert 'id="createCharacterOverlay"' in index
+    assert 'id="createCharacterForm"' in index
+    assert 'role="dialog"' in index
     assert 'class="studio-character-bar"' in index
     assert index.index('class="studio-character-bar"') < index.index('class="page-head"')
     nav_labels = ["基础信息", "人设卡", "立绘", "语音模型", "参考语音", "配色"]
@@ -5579,7 +5583,9 @@ def test_tauri_studio_frontend_matches_settings_language() -> None:
     assert "function renderReferenceAudios(" in source
     assert "function previewReferenceAudio(" in source
     assert "{ dirty: true }" in source
-    assert "displayName === null" in source
+    assert "openCreateCharacterDialog" in source
+    assert 'window.prompt("角色 ID' not in source
+    assert 'document.addEventListener("contextmenu", (event) => event.preventDefault());' in source
     assert "hostCall(\"studio.list_characters\"" not in source
     assert "hostCall(\"studio.open_character\"" in source
     assert "hostCall(\"studio.create_character\"" in source
@@ -5626,6 +5632,8 @@ def test_tauri_studio_frontend_matches_settings_language() -> None:
     assert "grid-template-columns: 176px minmax(0, 1fr)" in styles
     assert ".custom-select__trigger" in styles
     assert ".studio-character-bar" in styles
+    assert ".modal-overlay" in styles
+    assert ".create-character-dialog" in styles
     assert ".reference-audio-row" in styles
     assert "#saveButton,\n#publishButton,\n.primary-button" in styles
     assert ".custom-select__group" in styles

--- a/tools/settings-tauri/frontend/settings.js
+++ b/tools/settings-tauri/frontend/settings.js
@@ -1,5 +1,7 @@
 const invoke = window.__TAURI__.core.invoke;
 
+document.addEventListener("contextmenu", (event) => event.preventDefault());
+
 const fields = {
   characterSelect: document.getElementById("characterSelect"),
   characterImportButton: document.getElementById("characterImportButton"),

--- a/tools/studio-tauri/frontend/index.html
+++ b/tools/studio-tauri/frontend/index.html
@@ -211,6 +211,52 @@
       </section>
     </main>
 
+    <div id="createCharacterOverlay" class="modal-overlay" hidden>
+      <section
+        class="modal-dialog create-character-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="createCharacterTitle"
+        aria-describedby="createCharacterDescription"
+      >
+        <div class="modal-heading">
+          <span class="modal-heading-mark" aria-hidden="true">+</span>
+          <div>
+            <h2 id="createCharacterTitle">新建角色</h2>
+            <p id="createCharacterDescription">创建一个独立工作区，保存确认后再发布到角色列表。</p>
+          </div>
+        </div>
+        <form id="createCharacterForm" novalidate>
+          <label class="modal-field" for="createCharacterId">
+            <span>角色 ID</span>
+            <input
+              id="createCharacterId"
+              type="text"
+              autocomplete="off"
+              spellcheck="false"
+              placeholder="例如 sakura_friend"
+              aria-describedby="createCharacterIdHint"
+            />
+            <small id="createCharacterIdHint">仅支持字母、数字、下划线、点和连字符。</small>
+          </label>
+          <label class="modal-field" for="createCharacterDisplayName">
+            <span>显示名称</span>
+            <input
+              id="createCharacterDisplayName"
+              type="text"
+              autocomplete="off"
+              placeholder="角色在 Sakura 中显示的名字"
+            />
+          </label>
+          <p id="createCharacterError" class="modal-error" role="alert"></p>
+          <div class="modal-actions">
+            <button id="createCharacterCancelButton" type="button" class="secondary-button">取消</button>
+            <button type="submit" class="primary-button">创建工作区</button>
+          </div>
+        </form>
+      </section>
+    </div>
+
     <div id="toastStack" class="toast-stack" aria-live="polite" aria-atomic="false"></div>
     <script type="module" src="./studio.js"></script>
   </body>

--- a/tools/studio-tauri/frontend/studio.js
+++ b/tools/studio-tauri/frontend/studio.js
@@ -1,5 +1,7 @@
 const invoke = window.__TAURI__.core.invoke;
 
+document.addEventListener("contextmenu", (event) => event.preventDefault());
+
 const fields = {
   pageTitle: document.getElementById("pageTitle"),
   pageSubtitle: document.getElementById("pageSubtitle"),
@@ -44,6 +46,12 @@ const fields = {
   publishButton: document.getElementById("publishButton"),
   saveButton: document.getElementById("saveButton"),
   pageHead: document.querySelector(".page-head"),
+  createCharacterOverlay: document.getElementById("createCharacterOverlay"),
+  createCharacterForm: document.getElementById("createCharacterForm"),
+  createCharacterId: document.getElementById("createCharacterId"),
+  createCharacterDisplayName: document.getElementById("createCharacterDisplayName"),
+  createCharacterError: document.getElementById("createCharacterError"),
+  createCharacterCancelButton: document.getElementById("createCharacterCancelButton"),
 };
 
 const pageMeta = {
@@ -83,6 +91,9 @@ let previewAudio = null;
 let draftAutosaveTimer = null;
 let draftAutosavePromise = null;
 let renderingEditor = false;
+let createCharacterResolve = null;
+let createCharacterPreviousFocus = null;
+let createDisplayNameEdited = false;
 
 function setError(message) {
   fields.errorText.textContent = message || "";
@@ -1263,13 +1274,72 @@ async function selectCharacter(characterId) {
   fields.studioCharacterSelect.__customSelect?.focus();
 }
 
-async function createCharacter() {
-  await flushDraftAutosave();
-  const id = window.prompt("角色 ID：", "");
-  if (!id) {
+function closeCreateCharacterDialog(result = null) {
+  if (fields.createCharacterOverlay.hidden) {
     return;
   }
-  const characterId = id.trim();
+  fields.createCharacterOverlay.hidden = true;
+  document.body.classList.remove("has-modal-open");
+  document.removeEventListener("keydown", handleCreateCharacterDialogKeydown, true);
+  const resolve = createCharacterResolve;
+  createCharacterResolve = null;
+  const previousFocus = createCharacterPreviousFocus;
+  createCharacterPreviousFocus = null;
+  previousFocus?.focus?.();
+  resolve?.(result);
+}
+
+function handleCreateCharacterDialogKeydown(event) {
+  if (event.key === "Escape") {
+    event.preventDefault();
+    closeCreateCharacterDialog();
+    return;
+  }
+  if (event.key !== "Tab") {
+    return;
+  }
+  const focusable = Array.from(
+    fields.createCharacterOverlay.querySelectorAll("input, button:not(:disabled)"),
+  );
+  if (!focusable.length) {
+    return;
+  }
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  if (event.shiftKey && document.activeElement === first) {
+    event.preventDefault();
+    last.focus();
+  } else if (!event.shiftKey && document.activeElement === last) {
+    event.preventDefault();
+    first.focus();
+  }
+}
+
+function openCreateCharacterDialog() {
+  if (createCharacterResolve) {
+    return Promise.resolve(null);
+  }
+  fields.createCharacterForm.reset();
+  fields.createCharacterError.textContent = "";
+  fields.createCharacterId.classList.remove("is-invalid");
+  createDisplayNameEdited = false;
+  createCharacterPreviousFocus = document.activeElement;
+  fields.createCharacterOverlay.hidden = false;
+  document.body.classList.add("has-modal-open");
+  document.addEventListener("keydown", handleCreateCharacterDialogKeydown, true);
+  window.requestAnimationFrame(() => fields.createCharacterId.focus());
+  return new Promise((resolve) => {
+    createCharacterResolve = resolve;
+  });
+}
+
+async function createCharacter() {
+  await flushDraftAutosave();
+  const draft = await openCreateCharacterDialog();
+  if (!draft) {
+    return;
+  }
+  const { characterId, displayName } = draft;
   const existing = (request.characters || []).find((character) => character.id === characterId);
   if (existing) {
     if (!existing.is_installed) {
@@ -1279,13 +1349,9 @@ async function createCharacter() {
     }
     return;
   }
-  const displayName = window.prompt("显示名称：", characterId);
-  if (displayName === null) {
-    return;
-  }
   await runBusy(async () => {
     const payload = await hostCall("studio.create_character", {
-      doc: { id: characterId, display_name: displayName.trim() || characterId },
+      doc: { id: characterId, display_name: displayName },
     });
     setCurrentDoc(payload, {
       id: payload.doc.id,
@@ -1837,6 +1903,42 @@ async function load() {
 fields.navItems.forEach((item) => item.addEventListener("click", () => switchPage(item.dataset.page)));
 fields.studioCharacterSelect.addEventListener("change", (event) => selectCharacter(event.target.value));
 fields.newCharacterButton.addEventListener("click", createCharacter);
+fields.createCharacterOverlay.addEventListener("pointerdown", (event) => {
+  if (event.target === fields.createCharacterOverlay) {
+    closeCreateCharacterDialog();
+  }
+});
+fields.createCharacterCancelButton.addEventListener("click", () => closeCreateCharacterDialog());
+fields.createCharacterId.addEventListener("input", () => {
+  fields.createCharacterError.textContent = "";
+  fields.createCharacterId.classList.remove("is-invalid");
+  if (!createDisplayNameEdited) {
+    fields.createCharacterDisplayName.value = fields.createCharacterId.value.trim();
+  }
+});
+fields.createCharacterDisplayName.addEventListener("input", () => {
+  createDisplayNameEdited = true;
+});
+fields.createCharacterForm.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const characterId = fields.createCharacterId.value.trim();
+  const displayName = fields.createCharacterDisplayName.value.trim() || characterId;
+  let message = "";
+  if (!characterId) {
+    message = "请输入角色 ID。";
+  } else if (!/^[A-Za-z0-9_.-]+$/.test(characterId)) {
+    message = "角色 ID 只能包含字母、数字、下划线、点和连字符。";
+  } else if ((request?.characters || []).some((character) => character.id === characterId)) {
+    message = `角色 ID 已存在：${characterId}。请从上方角色列表中打开。`;
+  }
+  if (message) {
+    fields.createCharacterError.textContent = message;
+    fields.createCharacterId.classList.add("is-invalid");
+    fields.createCharacterId.focus();
+    return;
+  }
+  closeCreateCharacterDialog({ characterId, displayName });
+});
 fields.discardDraftButton.addEventListener("click", discardCurrentDraft);
 fields.addExpressionButton.addEventListener("click", () => importPortrait());
 fields.importPortraitFolderButton.addEventListener("click", importPortraitFolder);

--- a/tools/studio-tauri/frontend/styles.css
+++ b/tools/studio-tauri/frontend/styles.css
@@ -1186,6 +1186,104 @@ input.is-invalid {
   pointer-events: none;
 }
 
+/* ---------- 新建角色弹窗 ---------- */
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 2200;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: color-mix(in srgb, var(--sakura-text) 24%, transparent);
+  backdrop-filter: blur(4px);
+  animation: overlay-in var(--motion-base) var(--ease) both;
+}
+
+.modal-dialog {
+  width: min(440px, 100%);
+  border: 1px solid var(--sakura-border);
+  border-radius: var(--radius-lg);
+  background:
+    linear-gradient(145deg, var(--tint-soft), transparent 42%),
+    var(--surface-raised);
+  box-shadow: 0 28px 70px -30px color-mix(in srgb, var(--sakura-text) 60%, transparent);
+  padding: 22px;
+  animation: modal-in var(--motion-medium) var(--ease) both;
+}
+
+.modal-heading {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.modal-heading-mark {
+  display: grid;
+  flex: 0 0 auto;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 11px;
+  background: var(--sakura-primary);
+  color: var(--sakura-input-bg);
+  font-size: 22px;
+  line-height: 1;
+  box-shadow: var(--shadow-pop);
+}
+
+.modal-heading h2 {
+  margin: 0;
+  color: var(--sakura-text);
+  font-size: 18px;
+}
+
+.modal-heading p {
+  margin: 3px 0 0;
+  color: var(--sakura-muted-text);
+  font-size: 12.5px;
+}
+
+.create-character-dialog form,
+.modal-field {
+  display: grid;
+  gap: 7px;
+}
+
+.create-character-dialog form {
+  gap: 15px;
+}
+
+.modal-field > span {
+  color: var(--sakura-secondary-text);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.modal-field small {
+  color: var(--sakura-muted-text);
+  font-size: 11.5px;
+}
+
+.modal-error {
+  min-height: 20px;
+  margin: -3px 0 0;
+  color: #c63f55;
+  font-size: 12.5px;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  padding-top: 2px;
+}
+
+body.has-modal-open .settings-shell {
+  pointer-events: none;
+}
+
 .toast {
   max-width: min(360px, calc(100vw - 36px));
   padding: 10px 12px;
@@ -1246,6 +1344,19 @@ input.is-invalid {
   from {
     opacity: 0;
     transform: translateY(8px) scale(0.98);
+  }
+}
+
+@keyframes overlay-in {
+  from {
+    opacity: 0;
+  }
+}
+
+@keyframes modal-in {
+  from {
+    opacity: 0;
+    transform: translateY(10px) scale(0.985);
   }
 }
 


### PR DESCRIPTION
## 修复内容

- 在 Tauri 设置页和角色工作室中屏蔽网页右键菜单
- 将“新建角色”的浏览器原生 prompt 替换为 Sakura 风格的内置弹窗
- 增加角色 ID 格式与重复校验
- 支持 Esc、点击遮罩取消、焦点循环和关闭后焦点恢复
- 补充前端契约测试，防止相关行为回退

## 测试

- `python -m pytest`
- 结果：1441 passed, 3 skipped