### PR TITLE
fix: marshal Tauri settings RPC responses to the UI thread

### DIFF
--- a/app/ui/tauri_settings.py
+++ b/app/ui/tauri_settings.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
-from PySide6.QtCore import QObject, QProcess, QProcessEnvironment, QThread, QTimer, Signal
+from PySide6.QtCore import QObject, QProcess, QProcessEnvironment, QThread, QTimer, Signal, Slot
 from PySide6.QtWidgets import QApplication, QWidget
 
 from app.agent.memory_curator import MemoryCurationSettings
@@ -1036,6 +1036,7 @@ class TauriSettingsProcess(QObject):
     cancelled = Signal()
     failed = Signal(str)
     layout_preview = Signal(object)
+    rpc_response_requested = Signal(str, bool, object, str)
 
     def __init__(
         self,
@@ -1132,6 +1133,7 @@ class TauriSettingsProcess(QObject):
         self._character_rpcs: dict[str, tuple[QThread, QObject]] = {}
         self._theme_ai_rpcs: dict[str, tuple[QThread, QObject]] = {}
         self._tts_test_rpcs: dict[str, tuple[QThread, QObject]] = {}
+        self.rpc_response_requested.connect(self._deliver_queued_rpc_response)
 
     def start(self) -> bool:
         binary = resolve_tauri_settings_binary(self.base_dir)
@@ -1404,7 +1406,7 @@ class TauriSettingsProcess(QObject):
         thread.started.connect(worker.run)
 
         def _default_failure(message: str) -> None:
-            self._send_rpc_response(request_id, ok=False, error=str(message) or "请求失败。")
+            self._queue_rpc_response(request_id, ok=False, error=str(message) or "请求失败。")
 
         worker.succeeded.connect(on_success)
         worker.failed.connect(on_failure or _default_failure)
@@ -1429,10 +1431,10 @@ class TauriSettingsProcess(QObject):
 
         def _on_success(payload: Any) -> None:
             if method == "api.test_connection":
-                self._send_rpc_response(request_id, ok=True, result={"message": str(payload)})
+                self._queue_rpc_response(request_id, ok=True, result={"message": str(payload)})
             else:
                 models = [str(item) for item in payload if str(item).strip()]
-                self._send_rpc_response(request_id, ok=True, result={"models": models})
+                self._queue_rpc_response(request_id, ok=True, result={"models": models})
 
         self._start_rpc_worker(request_id, worker, self._api_probes, _on_success)
 
@@ -1446,7 +1448,7 @@ class TauriSettingsProcess(QObject):
 
         def _on_success(payload: object) -> None:
             result = payload if isinstance(payload, dict) else {"result": payload}
-            self._send_rpc_response(request_id, ok=True, result=result)
+            self._queue_rpc_response(request_id, ok=True, result=result)
 
         self._start_rpc_worker(request_id, worker, self._memory_rpcs, _on_success)
 
@@ -1465,7 +1467,7 @@ class TauriSettingsProcess(QObject):
                 self.current_character = self.character_registry.get(selected_id) if selected_id else None
             except Exception:  # noqa: BLE001 - RPC result is already computed; keep response intact.
                 pass
-            self._send_rpc_response(request_id, ok=True, result=result)
+            self._queue_rpc_response(request_id, ok=True, result=result)
 
         self._start_rpc_worker(request_id, worker, self._character_rpcs, _on_success)
 
@@ -1487,9 +1489,9 @@ class TauriSettingsProcess(QObject):
 
         def _on_success(payload: object) -> None:
             if not isinstance(payload, ThemeSettings):
-                self._send_rpc_response(request_id, ok=False, error="AI 返回的主题格式无效。")
+                self._queue_rpc_response(request_id, ok=False, error="AI 返回的主题格式无效。")
                 return
-            self._send_rpc_response(request_id, ok=True, result={"theme": theme_to_mapping(payload)})
+            self._queue_rpc_response(request_id, ok=True, result={"theme": theme_to_mapping(payload)})
 
         self._start_rpc_worker(request_id, worker, self._theme_ai_rpcs, _on_success)
 
@@ -1514,7 +1516,7 @@ class TauriSettingsProcess(QObject):
         worker: QObject = TTSTestWorker(settings, base_dir=self.base_dir)
 
         def _on_success(_settings: object, message: str) -> None:
-            self._send_rpc_response(
+            self._queue_rpc_response(
                 request_id,
                 ok=True,
                 result={"message": str(message) or "TTS 服务检测成功。"},
@@ -1627,6 +1629,32 @@ class TauriSettingsProcess(QObject):
             process.write(line.encode("utf-8"))
         except RuntimeError:
             return
+
+    def _queue_rpc_response(
+        self,
+        request_id: str,
+        *,
+        ok: bool,
+        result: dict[str, Any] | None = None,
+        error: str = "",
+    ) -> None:
+        """把后台 worker 的 RPC 回包切回拥有 QProcess 的宿主线程。"""
+        self.rpc_response_requested.emit(request_id, bool(ok), result, str(error))
+
+    @Slot(str, bool, object, str)
+    def _deliver_queued_rpc_response(
+        self,
+        request_id: str,
+        ok: bool,
+        result: object,
+        error: str,
+    ) -> None:
+        self._send_rpc_response(
+            request_id,
+            ok=bool(ok),
+            result=result if isinstance(result, dict) else None,
+            error=str(error),
+        )
 
     def _handle_error(self, error: QProcess.ProcessError) -> None:
         if self._done:

--- a/app/ui/tauri_studio.py
+++ b/app/ui/tauri_studio.py
@@ -8,7 +8,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
-from PySide6.QtCore import QObject, QProcess, QProcessEnvironment, QThread, QTimer, Signal
+from PySide6.QtCore import QObject, QProcess, QProcessEnvironment, QThread, QTimer, Signal, Slot
 
 from app.config.character_studio import CharacterStudioService
 from app.ui.screen_color_picker import pick_screen_color
@@ -165,6 +165,7 @@ def _workspace_reference(params: dict[str, Any]) -> str | Path:
 class TauriStudioProcess(QObject):
     closed = Signal()
     failed = Signal(str)
+    rpc_response_requested = Signal(str, bool, object, str)
 
     def __init__(self, base_dir: Path, *, initial_character_id: str = "", parent: QObject | None = None) -> None:
         super().__init__(parent)
@@ -176,6 +177,7 @@ class TauriStudioProcess(QObject):
         self._done = False
         self._startup_focus_complete = False
         self._rpcs: dict[str, tuple[QThread, QObject]] = {}
+        self.rpc_response_requested.connect(self._deliver_queued_rpc_response)
 
     def start(self) -> bool:
         binary = resolve_tauri_studio_binary(self.base_dir)
@@ -341,14 +343,14 @@ class TauriStudioProcess(QObject):
         self._rpcs[request_id] = (thread, worker)
         thread.started.connect(worker.run)
         worker.succeeded.connect(
-            lambda result, rid=request_id: self._send_rpc_response(
+            lambda result, rid=request_id: self._queue_rpc_response(
                 rid,
                 ok=True,
                 result=result if isinstance(result, dict) else {"value": result},
             )
         )
         worker.failed.connect(
-            lambda message, rid=request_id: self._send_rpc_response(
+            lambda message, rid=request_id: self._queue_rpc_response(
                 rid,
                 ok=False,
                 error=str(message),
@@ -379,6 +381,32 @@ class TauriStudioProcess(QObject):
         }
         line = TAURI_STUDIO_RPC_RESULT_MARKER + json.dumps(payload, ensure_ascii=False) + "\n"
         process.write(line.encode("utf-8"))
+
+    def _queue_rpc_response(
+        self,
+        request_id: str,
+        *,
+        ok: bool,
+        result: dict[str, Any] | None = None,
+        error: str = "",
+    ) -> None:
+        """把后台 worker 的 RPC 回包切回拥有 QProcess 的宿主线程。"""
+        self.rpc_response_requested.emit(request_id, bool(ok), result, str(error))
+
+    @Slot(str, bool, object, str)
+    def _deliver_queued_rpc_response(
+        self,
+        request_id: str,
+        ok: bool,
+        result: object,
+        error: str,
+    ) -> None:
+        self._send_rpc_response(
+            request_id,
+            ok=bool(ok),
+            result=result if isinstance(result, dict) else None,
+            error=str(error),
+        )
 
     def _handle_finished(self, exit_code: int, exit_status: QProcess.ExitStatus) -> None:
         self._handle_stdout(flush=True)

--- a/tests/unit/test_tauri_studio.py
+++ b/tests/unit/test_tauri_studio.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import threading
 import time
 import stat
 from pathlib import Path
@@ -81,6 +82,104 @@ def test_tauri_binary_resolvers_reject_non_executable_posix_files(
         tmp_path,
         environ={tauri_studio.TAURI_STUDIO_BIN_ENV: str(studio)},
     ) is None
+
+
+def test_tauri_worker_rpc_responses_write_on_process_owner_thread(tmp_path: Path) -> None:
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    if not hasattr(qtwidgets, "QApplication"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+    app = qtwidgets.QApplication.instance() or qtwidgets.QApplication([])
+
+    from app.agent.screen_awareness import ScreenAwarenessSettings
+    from app.ui.tauri_settings import TauriSettingsProcess
+    from app.ui.tauri_studio import TauriStudioProcess
+
+    class FakeQProcess:
+        def __init__(self) -> None:
+            self.write_threads: list[int] = []
+            self.writes: list[bytes] = []
+
+        def write(self, payload: bytes) -> int:
+            self.write_threads.append(threading.get_ident())
+            self.writes.append(bytes(payload))
+            return len(payload)
+
+    owner_thread_id = threading.get_ident()
+    processes = (
+        TauriSettingsProcess(base_dir=tmp_path, settings=ScreenAwarenessSettings()),
+        TauriStudioProcess(tmp_path),
+    )
+    for process in processes:
+        fake = FakeQProcess()
+        process._process = fake
+        worker = threading.Thread(
+            target=lambda target=process: target._queue_rpc_response(
+                "request-1",
+                ok=True,
+                result={"ok": True},
+            ),
+        )
+        worker.start()
+        worker.join(timeout=1)
+        assert not worker.is_alive()
+
+        deadline = time.monotonic() + 1
+        while not fake.writes and time.monotonic() < deadline:
+            app.processEvents()
+            time.sleep(0.01)
+
+        assert fake.write_threads == [owner_thread_id]
+        assert b'"id": "request-1"' in fake.writes[0]
+
+
+def test_tauri_memory_search_worker_returns_on_process_owner_thread(tmp_path: Path) -> None:
+    qtwidgets = pytest.importorskip("PySide6.QtWidgets")
+    if not hasattr(qtwidgets, "QApplication"):
+        pytest.skip("当前测试环境只提供了 PySide6 stub。")
+    app = qtwidgets.QApplication.instance() or qtwidgets.QApplication([])
+
+    from app.agent.screen_awareness import ScreenAwarenessSettings
+    from app.ui.tauri_settings import TauriSettingsProcess
+
+    class FakeQProcess:
+        def __init__(self) -> None:
+            self.write_threads: list[int] = []
+            self.writes: list[bytes] = []
+
+        def write(self, payload: bytes) -> int:
+            self.write_threads.append(threading.get_ident())
+            self.writes.append(bytes(payload))
+            return len(payload)
+
+    class FakeMemoryStore:
+        def __init__(self) -> None:
+            self.search_threads: list[int] = []
+
+        def search_memory(self, _arguments, *, wait: bool):  # type: ignore[no-untyped-def]
+            assert wait is False
+            self.search_threads.append(threading.get_ident())
+            return {"status": "ready", "memories": []}
+
+    owner_thread_id = threading.get_ident()
+    memory_store = FakeMemoryStore()
+    process = TauriSettingsProcess(
+        base_dir=tmp_path,
+        settings=ScreenAwarenessSettings(),
+        memory_store=memory_store,
+    )
+    fake = FakeQProcess()
+    process._process = fake
+    process._dispatch_memory_rpc("memory-1", "memory.search", {})
+
+    deadline = time.monotonic() + 2
+    while (not fake.writes or process._memory_rpcs) and time.monotonic() < deadline:
+        app.processEvents()
+        time.sleep(0.01)
+
+    assert memory_store.search_threads and memory_store.search_threads[0] != owner_thread_id
+    assert fake.write_threads == [owner_thread_id]
+    assert b'"id": "memory-1"' in fake.writes[0]
+    assert process._memory_rpcs == {}
 
 
 def test_build_tauri_studio_request_contains_characters_and_nonce(tmp_path: Path) -> None:


### PR DESCRIPTION
## 问题

设置窗口的异步 RPC 回调可能在工作线程中直接调用 Qt `QProcess.write()`。这违反 QObject 线程归属，macOS 上可表现为 `QSocketNotifier` 警告和设置页（包括记忆页面）卡死；其它平台也会出现不稳定行为。

## 修复

- 将 Settings 与 Studio 的异步 RPC 响应通过 Qt signal 排队回 UI 线程后再写入子进程。
- 保持原有 RPC 协议和调用方接口不变。
- 增加通用跨线程回归测试及真实 `memory.search` 工作线程覆盖。

## 验证

- `python -m py_compile app/ui/tauri_settings.py app/ui/tauri_studio.py`
- `python -m pytest tests/unit/test_tauri_studio.py -q`（27 passed）

该 PR 仅包含 Tauri/Qt 线程修复，不含接话层、感知或用户运行数据。