### PR TITLE
fix: 修复 Tauri RPC 子进程死锁及窗口关闭后 QTimer RuntimeError

### DIFF
--- a/app/ui/tauri_settings.py
+++ b/app/ui/tauri_settings.py
@@ -1151,12 +1151,10 @@ class TauriSettingsProcess(QObject):
         rpc_w = None
         try:
             if sys.platform != "win32":
-                # 绕过 std::io::stdin() 的内部 Mutex/BufReader 冲突（改用独立 pipe）
-                _os = __import__("os")
-                rpc_r, rpc_w = _os.pipe()
-                _os.set_inheritable(rpc_r, True)
-                _os.set_inheritable(rpc_w, False)
-                self._rpc_response_file = _os.fdopen(rpc_w, "wb", buffering=0)
+                rpc_r, rpc_w = os.pipe()
+                os.set_inheritable(rpc_r, True)
+                os.set_inheritable(rpc_w, False)
+                self._rpc_response_file = os.fdopen(rpc_w, "wb", buffering=0)
 
                 env = QProcessEnvironment.systemEnvironment()
                 env.insert("SAKURA_RPC_RESPONSE_FD", str(rpc_r))
@@ -1177,15 +1175,14 @@ class TauriSettingsProcess(QObject):
             self._startup_focus_complete = False
             process.start()
             if sys.platform != "win32" and rpc_r is not None:
-                _os.close(rpc_r)  # 父进程不再需要读端，子进程已继承
+                os.close(rpc_r)
                 rpc_r = None
             return True
         except Exception as exc:
             if sys.platform != "win32":
-                _os = __import__("os")
                 if rpc_r is not None:
                     try:
-                        _os.close(rpc_r)
+                        os.close(rpc_r)
                     except OSError:
                         pass
                 if rpc_w is not None:
@@ -1194,7 +1191,7 @@ class TauriSettingsProcess(QObject):
                             self._rpc_response_file.close()
                             self._rpc_response_file = None
                         else:
-                            _os.close(rpc_w)
+                            os.close(rpc_w)
                     except OSError:
                         pass
             raise exc

--- a/app/ui/tauri_settings.py
+++ b/app/ui/tauri_settings.py
@@ -1121,6 +1121,7 @@ class TauriSettingsProcess(QObject):
         self.model = model
         self.parent_widget = parent_widget
         self._process: QProcess | None = None
+        self._rpc_response_file = None
         self._nonce = ""
         self._done = False
         self._cleaned = False
@@ -1145,18 +1146,58 @@ class TauriSettingsProcess(QObject):
         process.setProgram(str(binary))
         process.setArguments([])
         process.setWorkingDirectory(str(self.base_dir))
-        process.setProcessEnvironment(QProcessEnvironment.systemEnvironment())
-        process.started.connect(self._handle_started)
-        process.finished.connect(self._handle_finished)
-        process.errorOccurred.connect(self._handle_error)
-        process.readyReadStandardOutput.connect(self._handle_stdout)
 
-        self._process = process
-        self._nonce = str(request["nonce"])
-        self._request_payload = json.dumps(request, ensure_ascii=False).encode("utf-8")
-        self._startup_focus_complete = False
-        process.start()
-        return True
+        rpc_r = None
+        rpc_w = None
+        try:
+            if sys.platform != "win32":
+                # 绕过 std::io::stdin() 的内部 Mutex/BufReader 冲突（改用独立 pipe）
+                _os = __import__("os")
+                rpc_r, rpc_w = _os.pipe()
+                _os.set_inheritable(rpc_r, True)
+                _os.set_inheritable(rpc_w, False)
+                self._rpc_response_file = _os.fdopen(rpc_w, "wb", buffering=0)
+
+                env = QProcessEnvironment.systemEnvironment()
+                env.insert("SAKURA_RPC_RESPONSE_FD", str(rpc_r))
+                process.setProcessEnvironment(env)
+                process.setProcessChannelMode(QProcess.ForwardedErrorChannel)
+            else:
+                self._rpc_response_file = None
+                process.setProcessEnvironment(QProcessEnvironment.systemEnvironment())
+
+            process.started.connect(self._handle_started)
+            process.finished.connect(self._handle_finished)
+            process.errorOccurred.connect(self._handle_error)
+            process.readyReadStandardOutput.connect(self._handle_stdout)
+
+            self._process = process
+            self._nonce = str(request["nonce"])
+            self._request_payload = json.dumps(request, ensure_ascii=False).encode("utf-8")
+            self._startup_focus_complete = False
+            process.start()
+            if sys.platform != "win32" and rpc_r is not None:
+                _os.close(rpc_r)  # 父进程不再需要读端，子进程已继承
+                rpc_r = None
+            return True
+        except Exception as exc:
+            if sys.platform != "win32":
+                _os = __import__("os")
+                if rpc_r is not None:
+                    try:
+                        _os.close(rpc_r)
+                    except OSError:
+                        pass
+                if rpc_w is not None:
+                    try:
+                        if self._rpc_response_file is not None:
+                            self._rpc_response_file.close()
+                            self._rpc_response_file = None
+                        else:
+                            _os.close(rpc_w)
+                    except OSError:
+                        pass
+            raise exc
 
     def focus_window(self) -> bool:
         """把已打开的 Tauri 设置窗口还原并前置（用于重复唤起时找回最小化的窗口）。"""
@@ -1626,9 +1667,17 @@ class TauriSettingsProcess(QObject):
             + "\n"
         )
         try:
-            process.write(line.encode("utf-8"))
-        except RuntimeError:
-            return
+            rpc_file = self._rpc_response_file
+            if rpc_file is not None:
+                rpc_file.write(line.encode("utf-8"))
+                rpc_file.flush()
+            else:
+                process.write(line.encode("utf-8"))
+        except (OSError, RuntimeError) as exc:
+            if not self._done:
+                self._done = True
+                self.failed.emit(f"RPC 响应通道写入失败：{exc}")
+                self._cleanup()
 
     def _queue_rpc_response(
         self,

--- a/app/ui/tauri_settings.py
+++ b/app/ui/tauri_settings.py
@@ -1235,6 +1235,7 @@ class TauriSettingsProcess(QObject):
         for delay_ms in SETTINGS_FOCUS_RETRY_DELAYS_MS:
             QTimer.singleShot(
                 delay_ms,
+                self,
                 lambda active_process=process: self._try_startup_focus(active_process),
             )
 

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sys
 import ctypes
 import faulthandler
@@ -402,8 +403,22 @@ def _format_data_migration_failure(report: MigrationReport) -> str:
     )
 
 
+def _normalize_proxy_env() -> None:
+    """将环境变量中 ``socks://`` scheme 规范化为 ``socks5://``。
+
+    httpx 只识别 ``http://``、``https://`` 和 ``socks5://`` 三种 proxy scheme，
+    不识别 ``socks://``。部分工具（如 clash）设的 ``ALL_PROXY=socks://…`` 会
+    导致 httpx 初始化时抛出 ``ValueError: Unknown scheme for proxy URL``。
+    """
+    for key in ("ALL_PROXY", "all_proxy"):
+        value = os.environ.get(key)
+        if value and value.startswith("socks://"):
+            os.environ[key] = "socks5://" + value[len("socks://"):]
+
+
 def main() -> int:
     _enable_crash_diagnostics(BASE_DIR)
+    _normalize_proxy_env()
     qInstallMessageHandler(_qt_message_handler)
     _configure_windows_high_dpi()
     app = QApplication(sys.argv)

--- a/main.py
+++ b/main.py
@@ -404,12 +404,7 @@ def _format_data_migration_failure(report: MigrationReport) -> str:
 
 
 def _normalize_proxy_env() -> None:
-    """将环境变量中 ``socks://`` scheme 规范化为 ``socks5://``。
-
-    httpx 只识别 ``http://``、``https://`` 和 ``socks5://`` 三种 proxy scheme，
-    不识别 ``socks://``。部分工具（如 clash）设的 ``ALL_PROXY=socks://…`` 会
-    导致 httpx 初始化时抛出 ``ValueError: Unknown scheme for proxy URL``。
-    """
+    """将 ``socks://`` 规范化为 ``socks5://``，兼容 httpx 仅识别 socks5:// 的限制。"""
     for key in ("ALL_PROXY", "all_proxy"):
         value = os.environ.get(key)
         if value and value.startswith("socks://"):

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -6004,7 +6004,7 @@ def test_tauri_settings_process_schedules_bounded_focus_retries_after_start(
     monkeypatch.setattr(
         tauri_settings.QTimer,
         "singleShot",
-        lambda delay, callback: scheduled.append((delay, callback)),
+        lambda delay, _receiver, callback: scheduled.append((delay, callback)),
     )
     process = tauri_settings.TauriSettingsProcess(
         base_dir=Path("."),

--- a/tools/settings-tauri/src-tauri/src/lib.rs
+++ b/tools/settings-tauri/src-tauri/src/lib.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, Write};
+#[cfg(unix)]
+use std::os::unix::io::FromRawFd;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -252,7 +254,18 @@ fn close_settings_window(window: Window) -> Result<(), String> {
 }
 
 pub fn run() {
-    let (request, rpc, window_control) = match read_request_and_spawn_rpc_reader() {
+    #[cfg(unix)]
+    let rpc_response_fd = std::env::var("SAKURA_RPC_RESPONSE_FD")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+
+    let (request, rpc, window_control) = match {
+        #[cfg(unix)]
+        { read_request_and_spawn_rpc_reader(rpc_response_fd) }
+        #[cfg(not(unix))]
+        { read_request_and_spawn_rpc_reader() }
+    } {
         Ok(state) => state,
         Err(error) => {
             eprintln!("{error}");
@@ -292,8 +305,64 @@ pub fn run() {
         .expect("failed to run Sakura settings window");
 }
 
+#[cfg(unix)]
+fn read_request_and_spawn_rpc_reader(rpc_response_fd: std::os::unix::io::RawFd) -> Result<(Value, HostRpc, WindowControl), String> {
+    if rpc_response_fd < 3 {
+        return Err("SAKURA_RPC_RESPONSE_FD must refer to a non-standard fd".to_string());
+    }
+    let mut initial_line = String::new();
+    {
+        let stdin_guard = std::io::stdin().lock();
+        let mut reader = std::io::BufReader::new(stdin_guard);
+        let bytes = reader
+            .read_line(&mut initial_line)
+            .map_err(|error| error.to_string())?;
+        if bytes == 0 {
+            return Err("request payload is empty".to_string());
+        }
+    }
+    let value: Value = serde_json::from_str(initial_line.trim_end()).map_err(|error| error.to_string())?;
+    if !matches!(value, Value::Object(_)) {
+        return Err("request payload must be a JSON object".to_string());
+    }
+    let rpc = HostRpc::new();
+    let pending = rpc.pending.clone();
+    let window_control = WindowControl::default();
+    let reader_window_control = window_control.clone();
+    std::thread::spawn(move || {
+        // 从独立 pipe fd 读取 RPC 响应，绕过 std::io::stdin() 的全局内部 Mutex。
+        let file = unsafe { std::fs::File::from_raw_fd(rpc_response_fd) };
+        let mut reader = std::io::BufReader::new(file);
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match reader.read_line(&mut line) {
+                Ok(0) => break,
+                Ok(_) => {
+                    let trimmed = line.trim_end();
+                    if let Some(command) = parse_window_control_line(trimmed) {
+                        reader_window_control.execute(command);
+                        continue;
+                    }
+                    if let Some(response) = parse_rpc_response_line(trimmed) {
+                        if let Ok(mut pending) = pending.lock() {
+                            if let Some(sender) = pending.remove(&response.id) {
+                                let _ = sender.send(response);
+                            }
+                        }
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+        clear_pending_rpcs(&pending);
+    });
+    Ok((value, rpc, window_control))
+}
+
+#[cfg(not(unix))]
 fn read_request_and_spawn_rpc_reader() -> Result<(Value, HostRpc, WindowControl), String> {
-    let mut reader = BufReader::new(std::io::stdin());
+    let mut reader = std::io::BufReader::new(std::io::stdin());
     let mut data = String::new();
     let bytes = reader
         .read_line(&mut data)
@@ -310,6 +379,7 @@ fn read_request_and_spawn_rpc_reader() -> Result<(Value, HostRpc, WindowControl)
     let window_control = WindowControl::default();
     let reader_window_control = window_control.clone();
     std::thread::spawn(move || {
+        let mut reader = std::io::BufReader::new(std::io::stdin());
         let mut line = String::new();
         loop {
             line.clear();

--- a/tools/settings-tauri/src-tauri/src/lib.rs
+++ b/tools/settings-tauri/src-tauri/src/lib.rs
@@ -330,7 +330,6 @@ fn read_request_and_spawn_rpc_reader(rpc_response_fd: std::os::unix::io::RawFd) 
     let window_control = WindowControl::default();
     let reader_window_control = window_control.clone();
     std::thread::spawn(move || {
-        // 从独立 pipe fd 读取 RPC 响应，绕过 std::io::stdin() 的全局内部 Mutex。
         let file = unsafe { std::fs::File::from_raw_fd(rpc_response_fd) };
         let mut reader = std::io::BufReader::new(file);
         let mut line = String::new();
@@ -379,7 +378,6 @@ fn read_request_and_spawn_rpc_reader() -> Result<(Value, HostRpc, WindowControl)
     let window_control = WindowControl::default();
     let reader_window_control = window_control.clone();
     std::thread::spawn(move || {
-        let mut reader = std::io::BufReader::new(std::io::stdin());
         let mut line = String::new();
         loop {
             line.clear();


### PR DESCRIPTION
# fix: 修复 Tauri RPC 子进程死锁及窗口关闭后 QTimer RuntimeError

## 改动内容

包含 3 个 commit，解决两个问题：

### 1. Tauri RPC 子线程 stdin 死锁（f9022bd）

Rust 子线程通过 `std::io::stdin()` 读取 RPC 响应时，与主线程 `BufReader` 共用同一 fd 0，
触发全局内部 Mutex 死锁。

**修复：** Python 侧创建独立 pipe 作为 RPC 响应通道，通过 `SAKURA_RPC_RESPONSE_FD` 环境变量
传递给子进程；Rust 侧从该 fd 读取响应，绕过 stdin 的全局锁。

涉及文件：
- `app/ui/tauri_settings.py` — 新增 pipe 创建、异常安全清理、写入通道切换
- `tools/settings-tauri/src-tauri/src/lib.rs` — 新增 `#[cfg(unix)]` 分叉读取逻辑，
  移除 `#[cfg(not(unix))]` 中的内部重复 BufReader
- `main.py` — 新增 `socks://` → `socks5://` 代理 scheme 规范化

### 2. QTimer.singleShot 窗口关闭后触发 RuntimeError（57af702）

`QTimer.singleShot(delay, callback)` 在窗口销毁后仍会触发回调，此时访问已销毁的
QObject 会抛出 RuntimeError。

**修复：** 改为三参数形式 `QTimer.singleShot(delay, self, callback)`，将 QTimer
的生命周期绑定到 receiver 对象，窗口关闭后自动取消未触发的定时器。

涉及文件：
- `app/ui/tauri_settings.py`

## 兼容性

- 无配置格式或公开接口变更
- `SAKURA_RPC_RESPONSE_FD` 环境变量仅内部使用，不影响用户配置
- 非 Unix 平台（Windows）行为与原逻辑一致