### PR TITLE
feat: 增强长期记忆精确召回

### DIFF
--- a/app/agent/memory_recall.py
+++ b/app/agent/memory_recall.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
@@ -10,11 +11,96 @@ from app.llm.prompts.types import ContextFragment, ContextRequest
 
 DEFAULT_MEMORY_RECALL_LIMIT = 5
 DEFAULT_MEMORY_RECALL_CANDIDATES = 10
+DEFAULT_LOCAL_RECALL_CANDIDATES = 300
 # all-MiniLM 这类轻量嵌入模型的余弦相似度天然偏低（实测相关命中也常在 0.3~0.45），
 # 0.5 会把所有候选都过滤掉、令自动召回形同虚设。用 0.3 作为去噪下限，配合 top-k=5
 # 与按分排序，既挡住明显无关项，又能让最相关的少量记忆进入上下文。
 DEFAULT_MEMORY_RELEVANCE_THRESHOLD = 0.3
 MAX_MEMORY_QUERY_CHARS = 4000
+_RECALL_INTENT_MARKERS = (
+    "还记得",
+    "记得",
+    "记得我",
+    "之前",
+    "上次",
+    "以前",
+    "回忆",
+    "聊过",
+    "提过",
+    "说过",
+    "去过",
+    "我的名字",
+    "我的偏好",
+    "我是谁",
+    "do you remember",
+    "remember when",
+    "last time",
+    "previously",
+    "we talked about",
+    "i told you",
+    "覚えて",
+    "前回",
+    "以前",
+)
+_RECALL_QUERY_FILLERS = tuple(
+    sorted(
+        (
+            "do you remember",
+            "remember when",
+            "last time",
+            "previously",
+            "we talked about",
+            "i told you",
+            "还记得",
+            "记得",
+            "记得我",
+            "之前",
+            "上次",
+            "以前",
+            "回忆",
+            "聊过",
+            "提过",
+            "说过",
+            "去过",
+            "覚えて",
+            "前回",
+            "你还",
+            "你知道",
+            "你",
+            "我们",
+            "我的",
+            "那个",
+            "那次",
+            "这件事",
+            "事情",
+            "说的",
+            "聊的",
+            "提到的",
+            "是什么",
+            "吗",
+            "呢",
+            "啊",
+            "the",
+            "my",
+            "me",
+            "about",
+        ),
+        key=len,
+        reverse=True,
+    )
+)
+_ENTITY_TOKEN_RE = re.compile(r"[A-Za-z0-9_./:\-]{2,}|[\u3040-\u30ff]{2,}")
+_CHINESE_RUN_RE = re.compile(r"[\u4e00-\u9fff]+")
+_ENTITY_TOKEN_STOP_WORDS = {
+    "知道",
+    "记得",
+    "回忆",
+    "之前",
+    "上次",
+    "以前",
+    "事情",
+    "项目",
+}
 
 
 @dataclass(frozen=True)
@@ -42,6 +128,19 @@ class MemoryRecallService:
         query = _build_memory_query(request)
         if not query:
             return MemoryRecallResult(query="")
+        local_memories = _local_exact_recall_memories(
+            self.memory,
+            request.current_input,
+        )
+        if local_memories:
+            local_result = _build_recall_result(
+                local_memories,
+                threshold=self.threshold,
+                limit=self.limit,
+                query=query,
+            )
+            if local_result.fragments:
+                return local_result
         try:
             response = self.memory.search_memory(
                 {"query": query, "limit": DEFAULT_MEMORY_RECALL_CANDIDATES},
@@ -56,28 +155,21 @@ class MemoryRecallService:
         if not isinstance(memories, list):
             return MemoryRecallResult(status="failed", query=query)
 
-        selected = _select_memories(memories, self.threshold, self.limit)
-        fragments = tuple(
-            ContextFragment(
-                fragment_id=f"memory.{memory['id'] or index}",
-                source="memory",
-                content=f"与本轮相关的长期记忆：{memory['content']}",
-                trust="trusted" if memory["source"] == "explicit" else "untrusted",
-                priority=80 if memory["source"] == "explicit" else 70,
-                freshness=memory["updated_at"],
-                token_budget=512,
-                sensitivity="private",
-                cache_scope="turn",
-            )
-            for index, memory in enumerate(selected)
+        return _build_recall_result(
+            memories,
+            threshold=self.threshold,
+            limit=self.limit,
+            query=query,
         )
-        return MemoryRecallResult(fragments=fragments, status="ready", query=query)
 
 
 def _build_memory_query(request: ContextRequest) -> str:
+    current_input = request.current_input.strip()
+    if _is_explicit_recall_query(current_input):
+        return current_input[:MAX_MEMORY_QUERY_CHARS].rstrip()
     parts: list[str] = []
-    if request.current_input.strip():
-        parts.append(request.current_input.strip())
+    if current_input:
+        parts.append(current_input)
     recent_user = [
         message.content.strip()
         for message in request.recent_messages
@@ -88,6 +180,106 @@ def _build_memory_query(request: ContextRequest) -> str:
     unique = list(dict.fromkeys(parts))
     query = "\n".join(unique).strip()
     return query[:MAX_MEMORY_QUERY_CHARS].rstrip()
+
+
+def _build_recall_result(
+    memories: list[Any],
+    *,
+    threshold: float,
+    limit: int,
+    query: str,
+) -> MemoryRecallResult:
+    selected = _select_memories(memories, threshold, limit)
+    fragments = tuple(
+        ContextFragment(
+            fragment_id=f"memory.{memory['id'] or index}",
+            source="memory",
+            content=f"与本轮相关的长期记忆：{memory['content']}",
+            trust="trusted" if memory["source"] == "explicit" else "untrusted",
+            priority=80 if memory["source"] == "explicit" else 70,
+            freshness=memory["updated_at"],
+            token_budget=512,
+            sensitivity="private",
+            cache_scope="turn",
+        )
+        for index, memory in enumerate(selected)
+    )
+    return MemoryRecallResult(fragments=fragments, status="ready", query=query)
+
+
+def _local_exact_recall_memories(memory: MemoryStore, query: str) -> list[dict[str, Any]]:
+    entity_tokens = _recall_entity_tokens(query)
+    if not entity_tokens:
+        return []
+
+    is_ready = getattr(memory, "is_ready", None)
+    if callable(is_ready):
+        try:
+            if not is_ready():
+                return []
+        except Exception:  # noqa: BLE001 - 状态探测失败时保留语义召回路径
+            return []
+
+    list_memories = getattr(memory, "list_memories", None)
+    if not callable(list_memories):
+        return []
+    try:
+        memories = list_memories(limit=DEFAULT_LOCAL_RECALL_CANDIDATES)
+    except Exception:  # noqa: BLE001 - 本地兜底失败不得阻断语义召回
+        return []
+    if not isinstance(memories, list):
+        return []
+
+    matched: list[tuple[float, int, dict[str, Any]]] = []
+    for index, raw in enumerate(memories):
+        if not isinstance(raw, dict):
+            continue
+        content = str(raw.get("content") or raw.get("memory") or "").strip()
+        if not content:
+            continue
+        lowered = content.casefold()
+        hits = [token for token in entity_tokens if token in lowered]
+        if not hits:
+            continue
+        lexical_score = 1.0 + min(0.75, sum(min(len(token), 8) for token in hits) / 24)
+        existing_score = _optional_score(raw.get("score"))
+        candidate = dict(raw)
+        candidate["score"] = max(existing_score or 0.0, lexical_score)
+        matched.append((candidate["score"], index, candidate))
+
+    matched.sort(key=lambda item: (-item[0], item[1]))
+    return [item[2] for item in matched]
+
+
+def _is_explicit_recall_query(query: str) -> bool:
+    lowered = query.casefold()
+    return bool(lowered) and any(marker in lowered for marker in _RECALL_INTENT_MARKERS)
+
+
+def _recall_entity_tokens(query: str) -> set[str]:
+    if not _is_explicit_recall_query(query):
+        return set()
+    cleaned = query.casefold()
+    for filler in _RECALL_QUERY_FILLERS:
+        cleaned = cleaned.replace(filler, " ")
+
+    tokens = {
+        token.casefold()
+        for token in _ENTITY_TOKEN_RE.findall(cleaned)
+        if token.casefold() not in _ENTITY_TOKEN_STOP_WORDS
+    }
+    for run in _CHINESE_RUN_RE.findall(cleaned):
+        if run in _ENTITY_TOKEN_STOP_WORDS:
+            continue
+        if 2 <= len(run) <= 12:
+            tokens.add(run)
+        if len(run) > 2:
+            tokens.update(
+                run[index : index + 2]
+                for index in range(len(run) - 1)
+                if run[index : index + 2] not in _ENTITY_TOKEN_STOP_WORDS
+            )
+    return {token for token in tokens if len(token) >= 2}
 
 
 def _select_memories(

--- a/tests/unit/test_memory_recall.py
+++ b/tests/unit/test_memory_recall.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.agent.memory_recall import MemoryRecallService, _build_memory_query
+from app.llm.prompts.types import ContextMessage, ContextRequest
+
+
+class FakeMemoryStore:
+    def __init__(
+        self,
+        *,
+        local_memories: list[dict[str, Any]] | None = None,
+        semantic_memories: list[dict[str, Any]] | None = None,
+        ready: bool = True,
+    ) -> None:
+        self.local_memories = list(local_memories or [])
+        self.semantic_memories = list(semantic_memories or [])
+        self.ready = ready
+        self.list_calls: list[int] = []
+        self.search_calls: list[dict[str, Any]] = []
+
+    def is_ready(self) -> bool:
+        return self.ready
+
+    def list_memories(self, *, limit: int) -> list[dict[str, Any]]:
+        self.list_calls.append(limit)
+        return self.local_memories[:limit]
+
+    def search_memory(self, arguments, *, wait=False):  # type: ignore[no-untyped-def]
+        self.search_calls.append({"arguments": dict(arguments), "wait": wait})
+        return {"status": "ready", "memories": list(self.semantic_memories)}
+
+
+def _request(current_input: str, *recent_user_messages: str) -> ContextRequest:
+    return ContextRequest(
+        current_input=current_input,
+        recent_messages=tuple(
+            ContextMessage("user", content)
+            for content in (*recent_user_messages, current_input)
+        ),
+    )
+
+
+def test_explicit_recall_uses_local_chinese_entity_match_before_semantic_search() -> None:
+    store = FakeMemoryStore(
+        local_memories=[
+            {"id": "unrelated", "memory": "用户喜欢听轻音乐"},
+            {"id": "guangzhou", "memory": "用户之前去过广州塔，觉得夜景很好"},
+        ],
+        semantic_memories=[
+            {"id": "semantic", "memory": "语义搜索不应被调用", "score": 0.9}
+        ],
+    )
+
+    result = MemoryRecallService(store).recall(  # type: ignore[arg-type]
+        _request("你记得广州那次吗？", "我们之前聊过别的旅行")
+    )
+
+    assert store.list_calls == [300]
+    assert store.search_calls == []
+    assert len(result.fragments) == 1
+    assert "广州塔" in result.fragments[0].content
+    assert "轻音乐" not in result.fragments[0].content
+
+
+def test_explicit_recall_matches_name_across_chinese_query_boundaries() -> None:
+    store = FakeMemoryStore(
+        local_memories=[
+            {"id": "name", "content": "用户名字是 CIKO", "source": "explicit"}
+        ]
+    )
+
+    result = MemoryRecallService(store).recall(  # type: ignore[arg-type]
+        _request("你还记得我的名字吗？")
+    )
+
+    assert store.search_calls == []
+    assert result.fragments[0].trust == "trusted"
+    assert "CIKO" in result.fragments[0].content
+
+
+def test_explicit_recall_falls_back_to_semantic_search_without_local_hit() -> None:
+    store = FakeMemoryStore(
+        local_memories=[{"id": "other", "memory": "用户喜欢低糖咖啡"}],
+        semantic_memories=[
+            {
+                "id": "semantic",
+                "memory": "用户在广州旅行时参观了博物馆",
+                "score": 0.82,
+            }
+        ],
+    )
+
+    result = MemoryRecallService(store).recall(  # type: ignore[arg-type]
+        _request("你还记得广州那次吗？")
+    )
+
+    assert store.list_calls == [300]
+    assert len(store.search_calls) == 1
+    assert "广州旅行" in result.fragments[0].content
+
+
+def test_expired_local_hit_falls_back_to_semantic_search() -> None:
+    store = FakeMemoryStore(
+        local_memories=[
+            {
+                "id": "expired",
+                "memory": "用户以前去过广州塔",
+                "expires_at": "2000-01-01T00:00:00+08:00",
+            }
+        ],
+        semantic_memories=[
+            {
+                "id": "current",
+                "memory": "用户最近计划再次去广州旅行",
+                "score": 0.85,
+            }
+        ],
+    )
+
+    result = MemoryRecallService(store).recall(  # type: ignore[arg-type]
+        _request("你还记得广州那次吗？")
+    )
+
+    assert len(store.search_calls) == 1
+    assert len(result.fragments) == 1
+    assert "再次去广州" in result.fragments[0].content
+
+
+def test_normal_chat_does_not_scan_local_memory_or_trigger_on_go_character() -> None:
+    store = FakeMemoryStore(
+        local_memories=[{"id": "bath", "memory": "用户以前去过温泉"}],
+        semantic_memories=[
+            {"id": "music", "memory": "用户喜欢安静地听音乐", "score": 0.9}
+        ],
+    )
+
+    result = MemoryRecallService(store).recall(  # type: ignore[arg-type]
+        _request("我去洗澡，等下回来聊")
+    )
+
+    assert store.list_calls == []
+    assert len(store.search_calls) == 1
+    assert "听音乐" in result.fragments[0].content
+
+
+def test_local_recall_skips_blocking_list_when_memory_is_not_ready() -> None:
+    store = FakeMemoryStore(
+        ready=False,
+        local_memories=[{"id": "name", "memory": "用户名字是 CIKO"}],
+        semantic_memories=[],
+    )
+
+    MemoryRecallService(store).recall(  # type: ignore[arg-type]
+        _request("你还记得我的名字吗？")
+    )
+
+    assert store.list_calls == []
+    assert len(store.search_calls) == 1
+    assert store.search_calls[0]["wait"] is False
+
+
+def test_explicit_recall_query_uses_current_input_without_recent_dilution() -> None:
+    request = _request(
+        "你还记得广州那次吗？",
+        "上一轮在讨论完全不同的代码重构和桌面窗口问题",
+    )
+
+    assert _build_memory_query(request) == "你还记得广州那次吗？"


### PR DESCRIPTION
## 改动

- 对“还记得、上次、之前”等显式回忆查询，优先从本地长期记忆中做实体匹配。
- 名字、地点、项目标识等短实体命中后直接进入现有召回结果，减少向量相似度漏召回。
- 本地没有命中、记忆尚未就绪或命中记录已过期时，继续使用原有语义召回路径。
- 不扩大最终召回条数，不修改记忆存储格式，也不启用自动清理。

## 原因

短名称和专有实体在轻量嵌入模型中的相似度可能偏低。用户明确询问过去事实时，即使本地已有准确记录，也可能因为向量阈值而无法召回。

## 验证

- `tests/unit/test_memory_recall.py`：7 passed
- 完整测试：1463 passed, 3 skipped
- `git diff --check` 通过
- 未发现凭据或本地数据

## 兼容性

没有配置格式或存储格式变化。精确匹配只在显式回忆意图下启用，普通聊天仍使用原有语义召回。