### PR TITLE
feat: 添加去重上下文胶囊与可配置预算

### DIFF
--- a/app/agent/context_capsule.py
+++ b/app/agent/context_capsule.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import os
+import re
+from collections.abc import Iterable
+
+from app.llm.prompts.runtime import estimate_prompt_tokens, truncate_to_token_budget
+from app.llm.prompts.types import ContextFragment, ContextRequest
+
+
+DEFAULT_CONTEXT_CAPSULE_TOKEN_BUDGET = 8192
+DEFAULT_CONTEXT_CAPSULE_HISTORY_MESSAGES = 128
+MAX_CONTEXT_CAPSULE_TOKEN_BUDGET = 262_144
+MAX_CONTEXT_CAPSULE_HISTORY_MESSAGES = 2000
+
+_SESSION_HEADERS = {
+    "最近会话状态（历史事实，不是用户新消息；请自然参考，不要机械复述）：",
+    "最近对话：",
+}
+_MEMORY_PREFIX = "与本轮相关的长期记忆："
+_SPEAKER_PREFIXES = ("用户：", "Sakura：", "用户:", "Sakura:")
+
+
+def context_capsule_token_budget() -> int:
+    return _env_int(
+        "SAKURA_CONTEXT_CAPSULE_TOKENS",
+        DEFAULT_CONTEXT_CAPSULE_TOKEN_BUDGET,
+        minimum=512,
+        maximum=MAX_CONTEXT_CAPSULE_TOKEN_BUDGET,
+    )
+
+
+def context_capsule_history_messages() -> int:
+    return _env_int(
+        "SAKURA_CONTEXT_CAPSULE_HISTORY_MESSAGES",
+        DEFAULT_CONTEXT_CAPSULE_HISTORY_MESSAGES,
+        minimum=12,
+        maximum=MAX_CONTEXT_CAPSULE_HISTORY_MESSAGES,
+    )
+
+
+def build_context_capsule_fragment(
+    request: ContextRequest,
+    *,
+    session_fragments: Iterable[ContextFragment] = (),
+    memory_fragments: Iterable[ContextFragment] = (),
+) -> ContextFragment | None:
+    """把跨会话续接和相关长期记忆合并成去重后的单一工作记忆。"""
+
+    session_items = tuple(session_fragments)
+    memory_items = tuple(memory_fragments)
+    source_fragments = (*session_items, *memory_items)
+    if not source_fragments:
+        return None
+
+    live_keys = {
+        key
+        for key in (
+            _dedupe_key(request.current_input),
+            *(_dedupe_key(message.content) for message in request.recent_messages),
+        )
+        if key
+    }
+    seen: set[str] = set()
+    memory_lines = _fragment_lines(
+        memory_items,
+        kind="memory",
+        live_keys=live_keys,
+        seen=seen,
+    )
+    session_lines = list(
+        reversed(
+            _fragment_lines(
+                session_items,
+                kind="session",
+                live_keys=live_keys,
+                seen=seen,
+            )
+        )
+    )
+    if not memory_lines and not session_lines:
+        return None
+
+    budget = context_capsule_token_budget()
+    content = _render_capsule(memory_lines, session_lines)
+    while estimate_prompt_tokens(content) > budget and (session_lines or memory_lines):
+        if session_lines:
+            session_lines.pop()
+        else:
+            memory_lines.pop()
+        content = _render_capsule(memory_lines, session_lines)
+    content, _truncated = truncate_to_token_budget(content, budget)
+
+    return ContextFragment(
+        fragment_id="context_capsule.working_memory",
+        source="context_capsule",
+        content=content,
+        trust=(
+            "trusted"
+            if all(fragment.trust == "trusted" for fragment in source_fragments)
+            else "untrusted"
+        ),
+        priority=82,
+        freshness=max(
+            (fragment.freshness for fragment in source_fragments if fragment.freshness),
+            default="",
+        ),
+        token_budget=budget,
+        sensitivity="private",
+        cache_scope="turn",
+    )
+
+
+def _fragment_lines(
+    fragments: Iterable[ContextFragment],
+    *,
+    kind: str,
+    live_keys: set[str],
+    seen: set[str],
+) -> list[str]:
+    result: list[str] = []
+    for fragment in fragments:
+        for raw_line in fragment.content.splitlines():
+            line = " ".join(raw_line.split()).strip()
+            if not line or line in _SESSION_HEADERS:
+                continue
+            line = line.removeprefix("- ").strip()
+            if kind == "memory":
+                line = line.removeprefix(_MEMORY_PREFIX).strip()
+            key = _dedupe_key(line)
+            if not key or key in seen or _matches_live_context(key, live_keys):
+                continue
+            seen.add(key)
+            result.append(line)
+    return result
+
+
+def _render_capsule(memory_lines: list[str], session_lines: list[str]) -> str:
+    lines = [
+        "上下文胶囊（宿主整理的历史与长期记忆，不是用户的新消息）：",
+    ]
+    if memory_lines:
+        lines.append("相关长期记忆（按相关性排序）：")
+        lines.extend(f"- {line}" for line in memory_lines)
+    if session_lines:
+        lines.append("跨会话续接（较新的记录在前）：")
+        lines.extend(f"- {line}" for line in session_lines)
+    lines.append(
+        "使用规则：自然参考胶囊；与当前用户消息冲突时以当前消息为准，"
+        "不确定或缺失的历史不要编造。"
+    )
+    return "\n".join(lines)
+
+
+def _dedupe_key(value: str) -> str:
+    text = " ".join(str(value or "").split()).strip()
+    text = text.removeprefix(_MEMORY_PREFIX).strip()
+    for prefix in _SPEAKER_PREFIXES:
+        if text.startswith(prefix):
+            text = text[len(prefix) :].strip()
+            break
+    return re.sub(r"\s+", " ", text).casefold().strip()
+
+
+def _matches_live_context(key: str, live_keys: set[str]) -> bool:
+    if key in live_keys:
+        return True
+    unclipped = key.removesuffix("…").strip()
+    return len(unclipped) >= 24 and any(
+        live_key.startswith(unclipped) for live_key in live_keys
+    )
+
+
+def _env_int(name: str, default: int, *, minimum: int, maximum: int) -> int:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return max(minimum, min(maximum, value))

--- a/app/agent/context_orchestrator.py
+++ b/app/agent/context_orchestrator.py
@@ -4,6 +4,7 @@ from dataclasses import replace
 from datetime import datetime
 from typing import Any, Iterable, Sequence
 
+from app.agent.context_capsule import build_context_capsule_fragment
 from app.core.runtime_log import log_event
 from app.llm.api_client import ChatMessage
 from app.llm.prompts.runtime import ContextPolicy
@@ -17,8 +18,8 @@ from app.plugins.models import ContextProviderContribution
 
 
 MAX_CONTEXT_INPUT_CHARS = 4000
-MAX_CONTEXT_RECENT_MESSAGES = 8
-MAX_CONTEXT_MESSAGE_CHARS = 1000
+MAX_CONTEXT_RECENT_MESSAGES = 32
+MAX_CONTEXT_MESSAGE_CHARS = 2000
 MAX_VISUAL_SUMMARIES = 6
 MAX_VISUAL_SUMMARY_CHARS = 500
 
@@ -37,7 +38,16 @@ class ContextOrchestrator:
         session_fragments: Iterable[ContextFragment] = (),
         memory_fragments: Iterable[ContextFragment] = (),
     ) -> ContextSnapshot:
-        fragments = [*_builtin_fragments(request), *session_fragments, *memory_fragments]
+        session_items = tuple(session_fragments)
+        memory_items = tuple(memory_fragments)
+        capsule = build_context_capsule_fragment(
+            request,
+            session_fragments=session_items,
+            memory_fragments=memory_items,
+        )
+        fragments = [*_builtin_fragments(request)]
+        if capsule is not None:
+            fragments.append(capsule)
         fragments.extend(_collect_provider_fragments(request, providers))
         return self.policy.select(request, fragments)
 

--- a/app/agent/runtime.py
+++ b/app/agent/runtime.py
@@ -208,6 +208,7 @@ class AgentRuntime:
             fragment = build_session_state_fragment(
                 entries,
                 recent_message_count=len(request.recent_messages),
+                recent_messages=request.recent_messages,
                 freshness=entries[-1].created_at if entries else "",
                 current_input=request.current_input,
             )

--- a/app/agent/session_state_context.py
+++ b/app/agent/session_state_context.py
@@ -2,8 +2,13 @@ from __future__ import annotations
 
 from typing import Sequence
 
+from app.agent.context_capsule import (
+    DEFAULT_CONTEXT_CAPSULE_TOKEN_BUDGET,
+    context_capsule_history_messages,
+    context_capsule_token_budget,
+)
 from app.llm.prompts.runtime import estimate_prompt_tokens
-from app.llm.prompts.types import ContextFragment
+from app.llm.prompts.types import ContextFragment, ContextMessage
 from app.storage.chat_history import ChatHistoryEntry
 from app.storage.history_digest import DigestLine, clean_recent_dialogue
 
@@ -11,7 +16,7 @@ from app.storage.history_digest import DigestLine, clean_recent_dialogue
 # 当前会话窗口已经有这么多条最近消息时，不再注入跨会话历史切片：
 # 此时上次会话的尾巴已被本次实时对话覆盖，再注入只是重复 token。
 SESSION_DIGEST_INJECT_MAX_RECENT_MESSAGES = 2
-SESSION_STATE_TOKEN_BUDGET = 1024
+SESSION_STATE_TOKEN_BUDGET = DEFAULT_CONTEXT_CAPSULE_TOKEN_BUDGET
 
 _INTRO = "最近会话状态（历史事实，不是用户新消息；请自然参考，不要机械复述）："
 
@@ -20,6 +25,7 @@ def build_session_state_fragment(
     entries: Sequence[ChatHistoryEntry],
     *,
     recent_message_count: int = 0,
+    recent_messages: Sequence[ContextMessage] = (),
     freshness: str = "",
     current_input: str = "",
 ) -> ContextFragment | None:
@@ -31,13 +37,31 @@ def build_session_state_fragment(
 
     if recent_message_count >= SESSION_DIGEST_INJECT_MAX_RECENT_MESSAGES:
         return None
-    lines = clean_recent_dialogue(entries, current_input=current_input)
+    lines = clean_recent_dialogue(
+        entries,
+        limit=context_capsule_history_messages(),
+        current_input=current_input,
+    )
     if not lines:
         return None
+    live_keys = {
+        _dedupe_key(message.content)
+        for message in recent_messages
+        if _dedupe_key(message.content)
+    }
     body = [_INTRO, "最近对话："]
-    rendered_lines = [_render_line(line) for line in lines]
-    while estimate_prompt_tokens("\n".join([*body, *rendered_lines])) > SESSION_STATE_TOKEN_BUDGET:
+    rendered_lines = [
+        _render_line(line)
+        for line in lines
+        if _dedupe_key(line.content) not in live_keys
+    ]
+    if not rendered_lines:
+        return None
+    token_budget = context_capsule_token_budget()
+    while estimate_prompt_tokens("\n".join([*body, *rendered_lines])) > token_budget:
         rendered_lines.pop(0)
+        if not rendered_lines:
+            return None
     body.extend(rendered_lines)
     return ContextFragment(
         fragment_id="session_state.recent_history",
@@ -46,7 +70,7 @@ def build_session_state_fragment(
         trust="untrusted",
         priority=75,
         freshness=freshness,
-        token_budget=SESSION_STATE_TOKEN_BUDGET,
+        token_budget=token_budget,
         sensitivity="private",
         cache_scope="turn",
     )
@@ -55,3 +79,7 @@ def build_session_state_fragment(
 def _render_line(line: DigestLine) -> str:
     speaker = "用户" if line.role == "user" else "Sakura"
     return f"- {speaker}：{line.content}"
+
+
+def _dedupe_key(value: str) -> str:
+    return " ".join(str(value or "").split()).casefold().strip()

--- a/app/llm/context_trimming.py
+++ b/app/llm/context_trimming.py
@@ -1,19 +1,58 @@
 from __future__ import annotations
 
+import os
 from typing import Any
 
 
-MAX_MODEL_CONTEXT_MESSAGES = 24
-MAX_MODEL_CONTEXT_CHARS = 40_000
+MAX_MODEL_CONTEXT_MESSAGES = 64
+MAX_MODEL_CONTEXT_CHARS = 120_000
+MAX_CONFIGURED_CONTEXT_MESSAGES = 2000
+MAX_CONFIGURED_CONTEXT_CHARS = 2_000_000
 
 
-def trim_messages_for_model(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def trim_messages_for_model(
+    messages: list[dict[str, Any]],
+    *,
+    max_messages: int | None = None,
+    max_chars: int | None = None,
+) -> list[dict[str, Any]]:
     """保留最近上下文，并用字符预算兜底限制入模历史体积。"""
-    recent = list(messages[-MAX_MODEL_CONTEXT_MESSAGES:])
-    while len(recent) > 1 and _estimate_messages_chars(recent) > MAX_MODEL_CONTEXT_CHARS:
+    message_limit = (
+        max_messages
+        if max_messages is not None
+        else _env_int(
+            "SAKURA_MODEL_CONTEXT_MESSAGES",
+            MAX_MODEL_CONTEXT_MESSAGES,
+            minimum=1,
+            maximum=MAX_CONFIGURED_CONTEXT_MESSAGES,
+        )
+    )
+    char_limit = (
+        max_chars
+        if max_chars is not None
+        else _env_int(
+            "SAKURA_MODEL_CONTEXT_CHARS",
+            MAX_MODEL_CONTEXT_CHARS,
+            minimum=1000,
+            maximum=MAX_CONFIGURED_CONTEXT_CHARS,
+        )
+    )
+    recent = list(messages[-max(1, message_limit) :])
+    while len(recent) > 1 and _estimate_messages_chars(recent) > max(1, char_limit):
         recent.pop(0)
     return recent
 
 
 def _estimate_messages_chars(messages: list[dict[str, Any]]) -> int:
     return sum(len(str(message.get("content", ""))) for message in messages)
+
+
+def _env_int(name: str, default: int, *, minimum: int, maximum: int) -> int:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return max(minimum, min(maximum, value))

--- a/app/llm/prompts/runtime.py
+++ b/app/llm/prompts/runtime.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import math
+import os
 import re
 from dataclasses import replace
 from datetime import datetime
@@ -20,9 +21,9 @@ from app.llm.prompts.types import (
 )
 
 
-DEFAULT_DYNAMIC_CONTEXT_TOKEN_BUDGET = 4096
-DEFAULT_PLUGIN_CONTEXT_TOKEN_BUDGET = 2048
-DEFAULT_MEMORY_CONTEXT_TOKEN_BUDGET = 1024
+DEFAULT_DYNAMIC_CONTEXT_TOKEN_BUDGET = 16_384
+DEFAULT_PLUGIN_CONTEXT_TOKEN_BUDGET = 4096
+DEFAULT_MEMORY_CONTEXT_TOKEN_BUDGET = 8192
 DEFAULT_PLUGIN_FRAGMENT_TOKEN_BUDGET = 512
 
 RUNTIME_FACTS_HEADER = (
@@ -108,13 +109,25 @@ class ContextPolicy:
     def __init__(
         self,
         *,
-        total_budget: int = DEFAULT_DYNAMIC_CONTEXT_TOKEN_BUDGET,
-        plugin_budget: int = DEFAULT_PLUGIN_CONTEXT_TOKEN_BUDGET,
-        memory_budget: int = DEFAULT_MEMORY_CONTEXT_TOKEN_BUDGET,
+        total_budget: int | None = None,
+        plugin_budget: int | None = None,
+        memory_budget: int | None = None,
     ) -> None:
-        self.total_budget = total_budget
-        self.plugin_budget = plugin_budget
-        self.memory_budget = memory_budget
+        self.total_budget = _resolved_budget(
+            total_budget,
+            "SAKURA_DYNAMIC_CONTEXT_TOKENS",
+            DEFAULT_DYNAMIC_CONTEXT_TOKEN_BUDGET,
+        )
+        self.plugin_budget = _resolved_budget(
+            plugin_budget,
+            "SAKURA_PLUGIN_CONTEXT_TOKENS",
+            DEFAULT_PLUGIN_CONTEXT_TOKEN_BUDGET,
+        )
+        self.memory_budget = _resolved_budget(
+            memory_budget,
+            "SAKURA_MEMORY_CONTEXT_TOKENS",
+            DEFAULT_MEMORY_CONTEXT_TOKEN_BUDGET,
+        )
 
     def select(
         self,
@@ -145,7 +158,7 @@ class ContextPolicy:
             own_budget = max(1, fragment.token_budget)
             if fragment.source.startswith("plugin:"):
                 own_budget = min(own_budget, DEFAULT_PLUGIN_FRAGMENT_TOKEN_BUDGET, remaining_plugin)
-            elif fragment.source == "memory":
+            elif fragment.source in {"memory", "context_capsule"}:
                 own_budget = min(own_budget, remaining_memory)
             allowed = min(own_budget, remaining_total)
             if allowed <= 0:
@@ -177,7 +190,7 @@ class ContextPolicy:
             remaining_total -= used
             if fragment.source.startswith("plugin:"):
                 remaining_plugin -= used
-            elif fragment.source == "memory":
+            elif fragment.source in {"memory", "context_capsule"}:
                 remaining_memory -= used
 
         return ContextSnapshot(
@@ -311,3 +324,16 @@ def _freshness_sort_key(value: str) -> float:
         return -datetime.fromisoformat(value).timestamp()
     except (TypeError, ValueError):
         return 0.0
+
+
+def _resolved_budget(value: int | None, env_name: str, default: int) -> int:
+    if value is not None:
+        return max(0, int(value))
+    raw = os.environ.get(env_name, "").strip()
+    if not raw:
+        return default
+    try:
+        configured = int(raw)
+    except ValueError:
+        return default
+    return max(0, min(262_144, configured))

--- a/docs/context-token-budget.md
+++ b/docs/context-token-budget.md
@@ -3,7 +3,8 @@
 > 目的：盘清「一轮请求里到底有哪些东西、各占多少」，并给出按 token（而非字符）统一预算的设计，
 > 作为后续「显示预计 token」功能的参考底稿。
 >
-> 状态：设计/参考文档，非已落地实现。日期：2026-06-20。
+> 状态：部分落地。2026-07-14 已加入去重上下文胶囊、扩大默认预算和环境变量覆盖；
+> 模型窗口自动识别、完整请求 token 对账和 UI 展示仍属于后续设计。
 
 ---
 
@@ -62,8 +63,8 @@ self.messages（内存,append-only,只存"干净文本"）
 当前裁剪在 `app/llm/context_trimming.py:10`：
 
 ```python
-MAX_MODEL_CONTEXT_MESSAGES = 24
-MAX_MODEL_CONTEXT_CHARS = 40_000
+MAX_MODEL_CONTEXT_MESSAGES = 64
+MAX_MODEL_CONTEXT_CHARS = 120_000
 
 def trim_messages_for_model(messages):
     recent = messages[-MAX_MODEL_CONTEXT_MESSAGES:]
@@ -74,12 +75,23 @@ def trim_messages_for_model(messages):
 
 三个局限：
 1. **按字符不按 token**：CJK ≈ 1 token/字，ASCII ≈ 4 字/token，字符数与真实 token 偏差大且不稳定。
-2. **只统计了对话消息**：system 人格(~4k)、工具定义(~23KB)、runtime_context(~1.8k) 都没算进这 40k 闸门，
-   真实占用远大于"40k 字符"给人的印象。
+2. **只统计了对话消息**：system 人格(~4k)、工具定义(~23KB)、runtime_context 都没算进这 120k 闸门，
+   真实占用仍大于"120k 字符"给人的印象。
 3. **没有总窗口概念、没有 headroom、没有溢出兜底**：单条超大消息（大段 OCR/粘贴）仍可能把请求冲到模型上限 → API 报错。
 
 > 注：会话内的"硬遗忘"（FIFO 砍掉的旧消息）一部分被 `memory_curation`（每 3 轮全量读历史并固化要点）
 > 通过记忆召回补回，所以**不建议**为会话内溢出再上一套 LLM 摘要——长期记忆系统已覆盖大半。
+
+### 2.1 已落地的上下文胶囊
+
+`app/agent/context_capsule.py` 会把两类动态事实合并成一个胶囊：
+
+- 新会话开头读取的跨会话续接历史；
+- 本轮召回的相关长期记忆。
+
+胶囊不会再次复制实时消息窗口中已有的内容，也不会调用额外模型。默认最多回看 128 条经过清洗的
+持久化聊天记录，最终受 8192-token 胶囊预算和 `ContextPolicy` 总预算共同约束。历史仍保持 append-only，
+胶囊不会自动删除、压缩或改写聊天记录和长期记忆。
 
 ---
 
@@ -89,12 +101,29 @@ def trim_messages_for_model(messages):
 |---|---|---|
 | `estimate_prompt_tokens(text)` | `app/llm/prompts/runtime.py:71` | 保守估 token：非 ASCII 每字符 1，连续 ASCII 约 4 字符 1 token |
 | `truncate_to_token_budget(text, budget)` | `app/llm/prompts/runtime.py:89` | 按 token 预算截断文本，返回 (文本, 是否被截断) |
-| `ContextPolicy` 预算 | `app/llm/prompts/runtime.py:23-26,119` | runtime_context 已按 token 预算选择片段（total 4096 / plugin 2048 / memory 1024） |
+| `ContextPolicy` 预算 | `app/llm/prompts/runtime.py` | runtime_context 已按 token 预算选择片段（total 16384 / plugin 4096 / capsule+memory 8192） |
+| 上下文胶囊 | `app/agent/context_capsule.py` | 合并并去重跨会话历史与相关长期记忆，不额外调用模型 |
 | `PromptInspection.estimated_tokens` | `app/llm/prompts/types.py:129-142` | **已逐段 + 汇总**了 system_prompt 与 runtime_context 的估算 token（日志里被 redacted，但值已算出） |
 | `get_last_prompt_inspection()` | `app/agent/runtime.py:151` | 取最近一次 prompt 构建的脱敏检查（含 estimated_tokens） |
 
 **缺口**：`PromptInspection` 只覆盖 system_prompt + runtime_context，**没算**对话消息和工具定义；
 `api_client` **没有解析响应里的 `usage`**（无真实 token 对账，目前只能估）。
+
+### 3.1 大上下文模型覆盖
+
+默认值兼顾常见 128k 模型。使用 Gemini 等大上下文模型时，可以通过环境变量提高限制：
+
+| 环境变量 | 默认值 | 上限 |
+|---|---:|---:|
+| `SAKURA_MODEL_CONTEXT_MESSAGES` | 64 | 2000 |
+| `SAKURA_MODEL_CONTEXT_CHARS` | 120000 | 2000000 |
+| `SAKURA_CONTEXT_CAPSULE_HISTORY_MESSAGES` | 128 | 2000 |
+| `SAKURA_CONTEXT_CAPSULE_TOKENS` | 8192 | 262144 |
+| `SAKURA_DYNAMIC_CONTEXT_TOKENS` | 16384 | 262144 |
+| `SAKURA_MEMORY_CONTEXT_TOKENS` | 8192 | 262144 |
+| `SAKURA_PLUGIN_CONTEXT_TOKENS` | 4096 | 262144 |
+
+提高限制前需要确认模型上下文窗口和中转站请求体限制。
 
 ---
 
@@ -208,6 +237,7 @@ request_messages、runtime_context）。在这里算一份 `PromptTokenEstimate`
 
 ## 7. 关键文件索引
 - 裁剪：`app/llm/context_trimming.py:10`
+- 上下文胶囊：`app/agent/context_capsule.py`
 - token 估算/截断：`app/llm/prompts/runtime.py:71`（estimate）、`:89`（truncate）
 - runtime_context 预算与选择：`app/llm/prompts/runtime.py:23-26,119`（ContextPolicy）
 - prompt 构建（静态/动态分层 + inspection）：`app/llm/prompts/runtime.py:196`

--- a/tests/integration/test_agent_core.py
+++ b/tests/integration/test_agent_core.py
@@ -2891,6 +2891,19 @@ def test_trim_messages_for_model_keeps_recent_messages_without_mutating_history(
     assert len(messages) == MAX_MODEL_CONTEXT_MESSAGES + 5
 
 
+def test_trim_messages_for_model_allows_large_context_override(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setenv("SAKURA_MODEL_CONTEXT_MESSAGES", "200")
+    monkeypatch.setenv("SAKURA_MODEL_CONTEXT_CHARS", "500000")
+    messages = [
+        {"role": "user", "content": f"message {index}"}
+        for index in range(150)
+    ]
+
+    trimmed = trim_messages_for_model(messages)
+
+    assert len(trimmed) == 150
+
+
 def test_autonomous_screen_observation_can_request_screen_without_explicit_user_command() -> None:
     class ScreenRequestClient:
         def __init__(self) -> None:

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -217,7 +217,8 @@ class TestRuntimeLimits:
         call = client.complete_with_tools.call_args
         runtime_context = call.kwargs["runtime_context"]
         request_messages = call.args[1]
-        assert "最近会话状态" in runtime_context
+        assert "上下文胶囊" in runtime_context
+        assert "跨会话续接" in runtime_context
         assert "继续执行计划" in runtime_context
         assert "用户：本轮问题" not in runtime_context
         assert all("最近会话状态" not in str(message.get("content", "")) for message in request_messages)
@@ -248,7 +249,7 @@ class TestRuntimeLimits:
         )
 
         runtime_context = client.complete_with_tools.call_args.kwargs["runtime_context"]
-        assert "最近会话状态" not in runtime_context
+        assert "上下文胶囊" not in runtime_context
 
 
 class TestToolCallCountLimits:

--- a/tests/unit/test_context_capsule.py
+++ b/tests/unit/test_context_capsule.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from app.agent.context_capsule import (
+    MAX_CONTEXT_CAPSULE_HISTORY_MESSAGES,
+    build_context_capsule_fragment,
+    context_capsule_history_messages,
+    context_capsule_token_budget,
+)
+from app.agent.context_orchestrator import ContextOrchestrator
+from app.llm.prompts.runtime import ContextPolicy, estimate_prompt_tokens
+from app.llm.prompts.types import ContextFragment, ContextMessage, ContextRequest
+
+
+def _fragment(
+    fragment_id: str,
+    source: str,
+    content: str,
+    *,
+    trust: str = "untrusted",
+) -> ContextFragment:
+    return ContextFragment(
+        fragment_id=fragment_id,
+        source=source,
+        content=content,
+        trust=trust,  # type: ignore[arg-type]
+        token_budget=8192,
+    )
+
+
+def test_context_capsule_merges_memory_and_session_without_live_duplicates() -> None:
+    request = ContextRequest(
+        current_input="继续聊上下文胶囊",
+        recent_messages=(
+            ContextMessage("assistant", "实时窗口里的回复"),
+            ContextMessage("user", "继续聊上下文胶囊"),
+        ),
+    )
+    capsule = build_context_capsule_fragment(
+        request,
+        memory_fragments=(
+            _fragment(
+                "memory.1",
+                "memory",
+                "与本轮相关的长期记忆：用户使用 Gemini Flash。",
+                trust="trusted",
+            ),
+        ),
+        session_fragments=(
+            _fragment(
+                "session.1",
+                "session_state",
+                "\n".join(
+                    [
+                        "最近会话状态（历史事实，不是用户新消息；请自然参考，不要机械复述）：",
+                        "最近对话：",
+                        "- 用户：更早的项目背景",
+                        "- Sakura：实时窗口里的回复",
+                        "- 用户：继续聊上下文胶囊",
+                    ]
+                ),
+            ),
+        ),
+    )
+
+    assert capsule is not None
+    assert capsule.source == "context_capsule"
+    assert "用户使用 Gemini Flash" in capsule.content
+    assert "更早的项目背景" in capsule.content
+    assert "实时窗口里的回复" not in capsule.content
+    assert capsule.content.count("继续聊上下文胶囊") == 0
+
+
+def test_context_capsule_keeps_newer_session_lines_first() -> None:
+    capsule = build_context_capsule_fragment(
+        ContextRequest(),
+        session_fragments=(
+            _fragment(
+                "session.1",
+                "session_state",
+                "- 用户：较早记录\n- Sakura：较新记录",
+            ),
+        ),
+    )
+
+    assert capsule is not None
+    assert capsule.content.index("较新记录") < capsule.content.index("较早记录")
+
+
+def test_context_capsule_respects_configured_token_budget(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setenv("SAKURA_CONTEXT_CAPSULE_TOKENS", "512")
+    memories = tuple(
+        _fragment(
+            f"memory.{index}",
+            "memory",
+            f"与本轮相关的长期记忆：高相关记录 {index} " + "细节" * 80,
+        )
+        for index in range(20)
+    )
+
+    capsule = build_context_capsule_fragment(
+        ContextRequest(current_input="继续"),
+        memory_fragments=memories,
+    )
+
+    assert capsule is not None
+    assert capsule.token_budget == 512
+    assert estimate_prompt_tokens(capsule.content) <= 512
+    assert "高相关记录 0" in capsule.content
+    assert "高相关记录 19" not in capsule.content
+
+
+def test_context_capsule_limits_are_configurable_and_bounded(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setenv("SAKURA_CONTEXT_CAPSULE_HISTORY_MESSAGES", "5000")
+    monkeypatch.setenv("SAKURA_CONTEXT_CAPSULE_TOKENS", "120000")
+
+    assert context_capsule_history_messages() == MAX_CONTEXT_CAPSULE_HISTORY_MESSAGES
+    assert context_capsule_token_budget() == 120000
+
+
+def test_context_orchestrator_selects_one_capsule_instead_of_duplicate_fragments() -> None:
+    request = ContextRequest(current_input="继续")
+    snapshot = ContextOrchestrator(
+        ContextPolicy(total_budget=20_000, memory_budget=10_000)
+    ).build_snapshot(
+        request,
+        session_fragments=(
+            _fragment("session.1", "session_state", "- 用户：跨会话记录"),
+        ),
+        memory_fragments=(
+            _fragment("memory.1", "memory", "与本轮相关的长期记忆：长期偏好"),
+        ),
+    )
+
+    selected_sources = [decision.fragment.source for decision in snapshot.selected]
+    assert selected_sources.count("context_capsule") == 1
+    assert "session_state" not in selected_sources
+    assert "memory" not in selected_sources
+
+
+def test_context_policy_reads_expanded_environment_budgets(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setenv("SAKURA_DYNAMIC_CONTEXT_TOKENS", "24000")
+    monkeypatch.setenv("SAKURA_PLUGIN_CONTEXT_TOKENS", "6000")
+    monkeypatch.setenv("SAKURA_MEMORY_CONTEXT_TOKENS", "12000")
+
+    policy = ContextPolicy()
+
+    assert policy.total_budget == 24000
+    assert policy.plugin_budget == 6000
+    assert policy.memory_budget == 12000

--- a/tests/unit/test_history_digest.py
+++ b/tests/unit/test_history_digest.py
@@ -5,6 +5,7 @@ from app.agent.session_state_context import (
     SESSION_STATE_TOKEN_BUDGET,
     build_session_state_fragment,
 )
+from app.llm.prompts.types import ContextMessage
 from app.storage.chat_history import ChatHistoryEntry
 from app.storage.history_digest import (
     MAX_DIGEST_MESSAGES,
@@ -103,10 +104,25 @@ class TestBuildSessionStateFragment:
         assert "上次任务" in fragment.content
         assert "本轮问题" not in fragment.content
 
+    def test_excludes_messages_already_present_in_live_context(self) -> None:
+        entries = [
+            _entry("user", "更早的项目背景"),
+            _entry("assistant", "实时窗口已经包含这句"),
+        ]
+        fragment = build_session_state_fragment(
+            entries,
+            recent_messages=(ContextMessage("assistant", "实时窗口已经包含这句"),),
+        )
+
+        assert fragment is not None
+        assert "更早的项目背景" in fragment.content
+        assert "实时窗口已经包含这句" not in fragment.content
+
     def test_token_budget_keeps_newest_messages(self) -> None:
-        entries = [_entry("user", f"消息{i}：" + "中" * 220) for i in range(MAX_DIGEST_MESSAGES)]
+        entry_count = 80
+        entries = [_entry("user", f"消息{i}：" + "中" * 220) for i in range(entry_count)]
         fragment = build_session_state_fragment(entries)
         assert fragment is not None
         assert fragment.token_budget == SESSION_STATE_TOKEN_BUDGET
         assert "消息0：" not in fragment.content
-        assert f"消息{MAX_DIGEST_MESSAGES - 1}：" in fragment.content
+        assert f"消息{entry_count - 1}：" in fragment.content


### PR DESCRIPTION
## 改动

- 新增去重上下文胶囊，合并跨会话续接记录与本轮相关长期记忆。
- 排除实时消息窗口中已经存在的内容，避免同一事实重复注入。
- 胶囊不调用额外模型，不删除、不压缩、不自动清理聊天记录或长期记忆。
- 对话窗口默认提高到 64 条 / 120000 字符，胶囊默认回看 128 条历史并使用 8192-token 预算。
- 动态上下文默认预算提高到 16384 tokens，并提供有界环境变量覆盖，兼容大上下文模型。

## 原因

现有跨会话历史和长期记忆会作为独立片段注入，容易与实时消息重复，并受到较小固定预算限制。胶囊统一去重和预算后，可以在不增加额外请求的前提下提高历史连续性。

## 验证

- 胶囊相关测试：189 passed
- 完整测试：1464 passed, 3 skipped
- `git diff --check` 通过
- 未发现凭据或本地数据

## 兼容性与风险

默认值兼顾常见 128k 模型，没有修改持久化配置格式。更大的窗口需要通过环境变量显式开启；当前直接对话历史仍以字符数作为兜底，尚未自动识别模型上下文窗口。