### PR TITLE
feat: 支持桌面与手机网页流式回复

### DIFF
--- a/app/agent/runtime.py
+++ b/app/agent/runtime.py
@@ -42,7 +42,21 @@ from app.llm.api_client import (
     is_vision_unsupported_error,
     messages_contain_image,
 )
-from app.llm.chat_reply import ChatReply, parse_chat_reply, parse_chat_reply_result, sanitize_reply_tones
+from app.llm.chat_reply import (
+    ChatReply,
+    ChatSegment,
+    parse_chat_reply,
+    parse_chat_reply_result,
+    sanitize_reply_tones,
+)
+from app.llm.streaming_reply import (
+    STREAMING_REPLY_STAGE,
+    StreamedReplyParser,
+    StreamingReplyUnavailable,
+    build_streaming_reply_instruction,
+    is_streaming_candidate,
+    needs_streaming_translation_repair,
+)
 from app.core.cancellation import CancelChecker, OperationCancelled, check_cancelled
 from app.core.runtime_log import log_body_enabled, log_event, summarize_messages
 from app.agent.runtime_limits import (
@@ -298,6 +312,165 @@ class AgentRuntime:
         if callable(resolver):
             return resolver()
         return 0.8, {}
+
+    def should_stream_user_message(self, messages: list[ChatMessage]) -> bool:
+        """仅对无需工具或媒体处理的普通聊天启用低延迟流式回复。"""
+        if not is_streaming_candidate(messages):
+            return False
+        if tool_routing._should_prefer_browser_page_tools(messages):
+            return False
+        if tool_routing._latest_user_requests_visible_browser(messages):
+            return False
+        if tool_routing._latest_user_explicitly_requests_windows_control(messages):
+            return False
+        return True
+
+    def handle_streaming_user_message(
+        self,
+        messages: list[ChatMessage],
+        *,
+        progress_callback: ProgressCallback,
+        cancel_checker: CancelChecker | None = None,
+    ) -> AgentResult:
+        """流式生成普通聊天句段，并通过进度回调送入字幕/TTS 队列。"""
+        check_cancelled(cancel_checker)
+        if not self.should_stream_user_message(messages):
+            raise StreamingReplyUnavailable("当前消息需要完整 Agent 链路。")
+
+        snapshot = self._build_single_context_snapshot(messages, source="chat")
+        prompt_build = self._build_streaming_reply_result(snapshot)
+        dialogue_temperature, dialogue_extra_params = self._resolve_dialogue_params()
+        parser = StreamedReplyParser(self.reply_tones)
+        segments: list[ChatSegment] = []
+        raw_chars = 0
+        stream_error = ""
+        started_at = time.perf_counter()
+        log_event(
+            "AgentRuntime",
+            "开始普通聊天流式回复",
+            {"message_count": len(messages), "messages": summarize_messages(messages)},
+        )
+        try:
+            chunks = self._client_for_messages(messages).stream_raw_text(
+                prompt_build.system_prompt,
+                messages,
+                temperature=dialogue_temperature,
+                runtime_context=prompt_build.runtime_context,
+                cancel_checker=cancel_checker,
+                **dialogue_extra_params,
+            )
+            for chunk in chunks:
+                check_cancelled(cancel_checker)
+                raw_chars += len(chunk)
+                for segment in parser.feed(chunk):
+                    repaired = self._repair_streaming_segment_translation(
+                        segment,
+                        cancel_checker=cancel_checker,
+                    )
+                    segments.append(repaired)
+                    progress_callback(
+                        AgentProgress(
+                            reply=ChatReply([repaired]),
+                            stage=STREAMING_REPLY_STAGE,
+                            metadata={"segment_index": len(segments) - 1},
+                        )
+                    )
+            for segment in parser.finish():
+                repaired = self._repair_streaming_segment_translation(
+                    segment,
+                    cancel_checker=cancel_checker,
+                )
+                segments.append(repaired)
+                progress_callback(
+                    AgentProgress(
+                        reply=ChatReply([repaired]),
+                        stage=STREAMING_REPLY_STAGE,
+                        metadata={"segment_index": len(segments) - 1},
+                    )
+                )
+        except OperationCancelled:
+            raise
+        except ApiRequestError as exc:
+            if not segments:
+                raise StreamingReplyUnavailable(str(exc)) from exc
+            stream_error = str(exc)
+            log_event(
+                "AgentRuntime",
+                "流式连接中断，保留已完成句段",
+                {"segments": len(segments), "error": stream_error},
+            )
+
+        if not segments:
+            raise StreamingReplyUnavailable("流式端点没有返回可展示句段。")
+        self._record_runtime_role(prompt_build.inspection)
+        reply = ChatReply(segments)
+        log_event(
+            "AgentRuntime",
+            "普通聊天流式回复完成",
+            {
+                "segments": len(segments),
+                "reply_chars": len(reply.text),
+                "raw_chars": raw_chars,
+                "elapsed_ms": int((time.perf_counter() - started_at) * 1000),
+                "incomplete": bool(stream_error),
+            },
+        )
+        return AgentResult(
+            reply=reply,
+            _debug={
+                "source": "streaming_chat",
+                "streamed": True,
+                "incomplete": bool(stream_error),
+                **({"stream_error": stream_error} if stream_error else {}),
+            },
+        )
+
+    def _repair_streaming_segment_translation(
+        self,
+        segment: ChatSegment,
+        *,
+        cancel_checker: CancelChecker | None = None,
+    ) -> ChatSegment:
+        if not needs_streaming_translation_repair(segment):
+            return segment
+        check_cancelled(cancel_checker)
+        try:
+            turn = self.api_client.complete_with_tools(
+                (
+                    "你是 Sakura 的中文字幕修复器。"
+                    "把输入的 ja 日语台词翻译成自然、简洁的简体中文。"
+                    "只返回 JSON：{\"zh\":\"中文译文\"}。"
+                ),
+                [
+                    {
+                        "role": "user",
+                        "content": json.dumps({"ja": segment.text}, ensure_ascii=False),
+                    }
+                ],
+                tools=[],
+                tool_choice="none",
+                temperature=0,
+                structured_response=True,
+                cancel_checker=cancel_checker,
+            )
+            data = json.loads(turn.content)
+            translation = data.get("zh") if isinstance(data, dict) else None
+        except (ApiRequestError, json.JSONDecodeError, TypeError, ValueError) as exc:
+            log_event(
+                "AgentRuntime",
+                "流式句段中文字幕修复失败，保留原句段",
+                {"error": str(exc)},
+            )
+            return segment
+        if not isinstance(translation, str) or not translation.strip():
+            return segment
+        return ChatSegment(
+            segment.text,
+            segment.tone,
+            translation.strip(),
+            segment.portrait,
+            suppress_tts=segment.suppress_tts,
+        )
 
     def _parse_final_reply_with_retry(
         self,
@@ -1452,6 +1625,23 @@ class AgentRuntime:
         return self._build_screen_awareness_tool_prompt_result(
             None, extra_instructions=extra_instructions
         ).system_prompt
+
+    def _build_streaming_reply_result(self, snapshot: ContextSnapshot | None = None):
+        sections = [
+            *self._persona_sections(),
+            PromptSection("reply.patch", self._reply_protocol_patch_text()),
+            PromptSection(
+                "streaming_reply.instructions",
+                build_streaming_reply_instruction(
+                    self.reply_tones,
+                    self.reply_portraits,
+                ),
+            ),
+        ]
+        return self._prompt_runtime().build(
+            PromptRecipe("streaming_reply", sections),
+            snapshot,
+        )
 
     def _build_final_reply_result(self, snapshot: ContextSnapshot | None = None):
         sections = [

--- a/app/core/chat_pipeline.py
+++ b/app/core/chat_pipeline.py
@@ -6,6 +6,7 @@ from typing import Any
 from app.agent import AgentEvent, AgentProgress, AgentResult, AgentRuntime, PendingToolAction
 from app.core.cancellation import CancelChecker, check_cancelled
 from app.core.runtime_log import log_event, summarize_messages
+from app.llm.streaming_reply import StreamingReplyUnavailable
 from app.storage.visual_observation import (
     VisualObservationJob,
     VisualObservationStore,
@@ -44,14 +45,38 @@ class ChatPipeline:
                 "messages": summarize_messages(messages),
             },
         )
-        result = self.agent_runtime.handle_user_message(
-            messages,
-            progress_callback=progress_callback,
-            cancel_checker=cancel_checker,
-        )
+        result: AgentResult | None = None
+        visual_jobs = visual_observation_jobs or []
+        should_stream = getattr(self.agent_runtime, "should_stream_user_message", None)
+        stream_message = getattr(self.agent_runtime, "handle_streaming_user_message", None)
+        if (
+            progress_callback is not None
+            and not visual_jobs
+            and callable(should_stream)
+            and callable(stream_message)
+            and should_stream(messages)
+        ):
+            try:
+                result = stream_message(
+                    messages,
+                    progress_callback=progress_callback,
+                    cancel_checker=cancel_checker,
+                )
+            except StreamingReplyUnavailable as exc:
+                log_event(
+                    "ChatWorker",
+                    "普通聊天流式回复不可用，回退完整 Agent 链路",
+                    {"error": str(exc)},
+                )
+        if result is None:
+            result = self.agent_runtime.handle_user_message(
+                messages,
+                progress_callback=progress_callback,
+                cancel_checker=cancel_checker,
+            )
         self._record_visual_observation_from_result(
             "ChatWorker",
-            visual_observation_jobs or [],
+            visual_jobs,
             result,
         )
         return result

--- a/app/core/http_client.py
+++ b/app/core/http_client.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import ipaddress
+import queue
 import socket
 import threading
 import urllib.request
 from collections.abc import Callable
+from collections.abc import Iterator
 from typing import Any
 from urllib.parse import urlparse
 
@@ -15,6 +17,8 @@ from app.core.cancellation import CancelChecker, check_cancelled
 _LOOPBACK_PROXY_BYPASS_OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({}))
 _CANCEL_POLL_SECONDS = 0.05
 _READ_CHUNK_SIZE = 64 * 1024
+_STREAM_QUEUE_SIZE = 128
+_STREAM_DONE = object()
 
 
 def is_loopback_url(url: str) -> bool:
@@ -115,6 +119,78 @@ def read_url_cancellable(
     if isinstance(error, BaseException):
         raise error
     return bytes(state.get("body", b"")), state.get("status")
+
+
+def iter_url_lines_cancellable(
+    opener: Callable[..., Any],
+    request: str | urllib.request.Request,
+    *,
+    timeout: float,
+    cancel_checker: CancelChecker | None = None,
+) -> Iterator[bytes]:
+    """逐行读取流式响应，并允许调用方取消后关闭活动连接。"""
+    if cancel_checker is None:
+        with opener(request, timeout=timeout) as response:
+            while True:
+                line = response.readline()
+                if not line:
+                    return
+                yield bytes(line)
+
+    items: queue.Queue[bytes | BaseException | object] = queue.Queue(
+        maxsize=_STREAM_QUEUE_SIZE
+    )
+    abort = threading.Event()
+    state: dict[str, Any] = {}
+    state_lock = threading.Lock()
+
+    def put_item(item: bytes | BaseException | object) -> None:
+        while not abort.is_set():
+            try:
+                items.put(item, timeout=_CANCEL_POLL_SECONDS)
+                return
+            except queue.Full:
+                continue
+
+    def run() -> None:
+        try:
+            with opener(request, timeout=timeout) as response:
+                with state_lock:
+                    state["response"] = response
+                while not abort.is_set():
+                    line = response.readline()
+                    if not line:
+                        break
+                    put_item(bytes(line))
+        except BaseException as exc:  # noqa: BLE001 - 原样回传 urllib/socket 异常
+            if not abort.is_set():
+                put_item(exc)
+        finally:
+            put_item(_STREAM_DONE)
+
+    threading.Thread(target=run, name="sakura-http-stream", daemon=True).start()
+    try:
+        while True:
+            check_cancelled(cancel_checker)
+            try:
+                item = items.get(timeout=_CANCEL_POLL_SECONDS)
+            except queue.Empty:
+                continue
+            if item is _STREAM_DONE:
+                return
+            if isinstance(item, BaseException):
+                raise item
+            yield bytes(item)
+    finally:
+        abort.set()
+        with state_lock:
+            response = state.get("response")
+        close = getattr(response, "close", None)
+        if callable(close):
+            try:
+                close()
+            except OSError:
+                pass
 
 
 def _request_url(url: str | urllib.request.Request) -> str:

--- a/app/core/mobile_chat_bridge.py
+++ b/app/core/mobile_chat_bridge.py
@@ -1,19 +1,24 @@
 from __future__ import annotations
 
 import threading
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
+from app.agent.actions import AgentProgress
 from app.agent.runtime import AgentRuntime
 from app.agent.tools.registry import ToolRegistry
 from app.config.character_loader import CharacterProfile, load_character_system_prompt
+from app.core.runtime_log import log_event
 from app.llm.api_client import ChatMessage, OpenAICompatibleClient
 from app.llm.context_trimming import trim_messages_for_model
+from app.llm.streaming_reply import STREAMING_REPLY_STAGE, StreamingReplyUnavailable
 from app.storage.chat_history import ChatHistoryEntry, ChatHistoryStore
 
 
 MAX_MOBILE_HISTORY_MESSAGES = 24
 MOBILE_IMAGE_MARKER = "（手机端发送了一张图片）"
+MobileProgressCallback = Callable[[dict[str, Any]], None]
 
 
 class MobileChatBusyError(RuntimeError):
@@ -58,7 +63,27 @@ class MobileChatBridge:
             raise RuntimeError("移动端聊天调度器尚未就绪。")
         return submit(self, character_id, text, image_data_url)
 
-    def execute_chat(self, character_id: str, text: str, image_data_url: str = "") -> dict[str, Any]:
+    def chat_stream(
+        self,
+        character_id: str,
+        text: str,
+        image_data_url: str = "",
+        *,
+        progress_callback: MobileProgressCallback,
+    ) -> dict[str, Any]:
+        submit = getattr(self._host, "submit_mobile_chat_stream", None)
+        if not callable(submit):
+            return self.chat(character_id, text, image_data_url)
+        return submit(self, character_id, text, image_data_url, progress_callback)
+
+    def execute_chat(
+        self,
+        character_id: str,
+        text: str,
+        image_data_url: str = "",
+        *,
+        progress_callback: MobileProgressCallback | None = None,
+    ) -> dict[str, Any]:
         """Execute one request inside the host-controlled Qt worker queue."""
         clean_text = text.strip()
         clean_image = image_data_url.strip()
@@ -90,7 +115,31 @@ class MobileChatBridge:
             previous_scope = memory_store.scope_id
             memory_store.set_scope(session.profile.id)
             try:
-                result = runtime.handle_user_message(messages)
+                result = None
+                should_stream = getattr(runtime, "should_stream_user_message", None)
+                stream_message = getattr(runtime, "handle_streaming_user_message", None)
+                if (
+                    progress_callback is not None
+                    and callable(should_stream)
+                    and callable(stream_message)
+                    and should_stream(messages)
+                ):
+                    try:
+                        result = stream_message(
+                            messages,
+                            progress_callback=lambda progress: _forward_mobile_progress(
+                                progress,
+                                progress_callback,
+                            ),
+                        )
+                    except StreamingReplyUnavailable as exc:
+                        log_event(
+                            "MobileChatBridge",
+                            "手机端流式回复不可用，回退完整回复",
+                            {"error": str(exc)},
+                        )
+                if result is None:
+                    result = runtime.handle_user_message(messages)
             finally:
                 memory_store.set_scope(previous_scope)
 
@@ -120,6 +169,8 @@ class MobileChatBridge:
             "tone": result.reply.tone,
             "segments": [_segment_for_mobile(segment) for segment in segments],
             "actions": [action.type for action in result.actions],
+            "streamed": bool((result._debug or {}).get("streamed")),
+            "incomplete": bool((result._debug or {}).get("incomplete")),
         }
 
     def _session(self, character_id: str) -> _MobileCharacterSession:
@@ -214,3 +265,33 @@ def _segment_for_mobile(segment: Any) -> dict[str, str]:
         "tone": segment.tone,
         "portrait": segment.portrait,
     }
+
+
+def _forward_mobile_progress(
+    progress: AgentProgress,
+    callback: MobileProgressCallback,
+) -> None:
+    if progress.stage != STREAMING_REPLY_STAGE:
+        return
+    segments = [
+        _segment_for_mobile(segment)
+        for segment in progress.reply.segments
+        if segment.text.strip()
+    ]
+    if not segments:
+        return
+    try:
+        callback(
+            {
+                "event": "segment",
+                "stage": progress.stage,
+                "segments": segments,
+                "metadata": dict(progress.metadata),
+            }
+        )
+    except Exception as exc:  # noqa: BLE001 - 网页连接异常不得中断模型回复
+        log_event(
+            "MobileChatBridge",
+            "转发手机端流式句段失败",
+            {"error": str(exc)},
+        )

--- a/app/core/mobile_chat_worker.py
+++ b/app/core/mobile_chat_worker.py
@@ -11,16 +11,32 @@ class MobileChatWorker(QObject):
     finished = Signal(object)
     failed = Signal(str)
 
-    def __init__(self, bridge: Any, character_id: str, text: str, image_data_url: str) -> None:
+    def __init__(
+        self,
+        bridge: Any,
+        character_id: str,
+        text: str,
+        image_data_url: str,
+        *,
+        progress_callback: Any = None,
+    ) -> None:
         super().__init__()
         self._bridge = bridge
         self._character_id = character_id
         self._text = text
         self._image_data_url = image_data_url
+        self._progress_callback = progress_callback
 
     @Slot()
     def run(self) -> None:
         try:
-            self.finished.emit(self._bridge.execute_chat(self._character_id, self._text, self._image_data_url))
+            self.finished.emit(
+                self._bridge.execute_chat(
+                    self._character_id,
+                    self._text,
+                    self._image_data_url,
+                    progress_callback=self._progress_callback,
+                )
+            )
         except Exception as exc:  # noqa: BLE001 - delivered to the HTTP caller below
             self.failed.emit(str(exc))

--- a/app/llm/api_client.py
+++ b/app/llm/api_client.py
@@ -6,12 +6,17 @@ import ssl
 import time
 import urllib.error
 import urllib.request
+from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any, Callable
 from urllib.parse import urlparse, urlunparse
 
 from app.core.cancellation import CancelChecker, cancellable_sleep, check_cancelled
-from app.core.http_client import read_url_cancellable, urlopen_direct_for_loopback
+from app.core.http_client import (
+    iter_url_lines_cancellable,
+    read_url_cancellable,
+    urlopen_direct_for_loopback,
+)
 from app.llm.chat_reply import ChatReply, parse_chat_reply, sanitize_reply_tones
 from app.core.retry_policy import MAX_AUTO_RETRY_ATTEMPTS
 from app.core.runtime_log import log_event
@@ -312,6 +317,123 @@ class OpenAICompatibleClient:
         )
         return result
 
+    def stream_raw_text(
+        self,
+        system_prompt: str,
+        messages: list[ChatMessage],
+        temperature: float = 0.8,
+        *,
+        cancel_checker: CancelChecker | None = None,
+        runtime_context: str = "",
+        **chat_params: Any,
+    ) -> Iterator[str]:
+        """从 OpenAI 兼容 chat/completions 端点逐块返回 assistant 文本。"""
+        self._ensure_chat_config("缺少 API Key。请在 data/config/api.yaml 中配置 llm.api_key。")
+        check_cancelled(cancel_checker)
+        runtime_context_role = self._runtime_context_role
+        payload = _build_chat_completion_payload(
+            model=self.settings.model,
+            system_prompt=system_prompt,
+            messages=_messages_with_runtime_context(
+                messages, runtime_context, runtime_context_role
+            ),
+            temperature=temperature,
+            chat_params={**chat_params, "stream": True},
+        )
+        model_name = payload.get("model")
+        started_at = time.perf_counter()
+        chunk_count = 0
+        output_chars = 0
+        first_chunk_ms: int | None = None
+        self._emit_llm_event("llm.request.started", {"model": model_name, "stream": True})
+        log_event(
+            "API",
+            "准备发送流式聊天补全请求",
+            {
+                "base_url": _normalize_openai_base_url(self.settings.base_url),
+                "configured_base_url": self.settings.base_url,
+                "endpoint_host": urlparse(_normalize_openai_base_url(self.settings.base_url)).netloc,
+                "model": self.settings.model,
+                "timeout_seconds": self.settings.timeout_seconds,
+                "temperature": temperature,
+                "message_count": len(payload["messages"]),
+                "has_image": messages_contain_image(payload["messages"]),
+                "chat_params": _filter_supported_chat_params(chat_params),
+            },
+        )
+        try:
+            try:
+                chunks = self._stream_chat_completions_with_compatibility_fallbacks(
+                    payload,
+                    cancel_checker=cancel_checker,
+                )
+                for chunk in chunks:
+                    check_cancelled(cancel_checker)
+                    if not chunk:
+                        continue
+                    if first_chunk_ms is None:
+                        first_chunk_ms = int((time.perf_counter() - started_at) * 1000)
+                    chunk_count += 1
+                    output_chars += len(chunk)
+                    yield chunk
+            except ApiRequestError as exc:
+                if (
+                    chunk_count == 0
+                    and runtime_context.strip()
+                    and runtime_context_role == "system"
+                    and _is_runtime_context_role_unsupported_error(exc)
+                ):
+                    self._runtime_context_role = "user"
+                    payload = _build_chat_completion_payload(
+                        model=self.settings.model,
+                        system_prompt=system_prompt,
+                        messages=_messages_with_runtime_context(messages, runtime_context, "user"),
+                        temperature=temperature,
+                        chat_params={**chat_params, "stream": True},
+                    )
+                    log_event(
+                        "API",
+                        "流式端点不支持尾部 system 上下文，已回退为 user 上下文",
+                        {"error": str(exc)},
+                    )
+                    for chunk in self._stream_chat_completions_with_compatibility_fallbacks(
+                        payload,
+                        cancel_checker=cancel_checker,
+                    ):
+                        check_cancelled(cancel_checker)
+                        if not chunk:
+                            continue
+                        if first_chunk_ms is None:
+                            first_chunk_ms = int((time.perf_counter() - started_at) * 1000)
+                        chunk_count += 1
+                        output_chars += len(chunk)
+                        yield chunk
+                else:
+                    raise
+        except Exception as exc:  # noqa: BLE001 - 派发失败事件后原样抛出
+            self._emit_llm_event(
+                "llm.request.failed",
+                {"model": model_name, "stream": True, "error": str(exc)},
+            )
+            raise
+        else:
+            self._emit_llm_event(
+                "llm.request.finished",
+                {"model": model_name, "stream": True},
+            )
+        finally:
+            log_event(
+                "API",
+                "流式聊天补全结束",
+                {
+                    "model": self.settings.model,
+                    "chunk_count": chunk_count,
+                    "output_chars": output_chars,
+                    "first_chunk_ms": first_chunk_ms,
+                    "elapsed_ms": int((time.perf_counter() - started_at) * 1000),
+                },
+            )
+
     def complete_with_tools(
         self,
         system_prompt: str,
@@ -472,6 +594,58 @@ class OpenAICompatibleClient:
                 raise
         raise ApiRequestError("API 兼容性自动回退已达到最大次数。")
 
+    def _stream_chat_completions_with_compatibility_fallbacks(
+        self,
+        payload: dict[str, Any],
+        *,
+        cancel_checker: CancelChecker | None = None,
+    ) -> Iterator[str]:
+        fallback_payload = dict(payload)
+        for param in self._unsupported_chat_params:
+            fallback_payload.pop(param, None)
+        for attempt in range(1, MAX_AUTO_RETRY_ATTEMPTS + 1):
+            check_cancelled(cancel_checker)
+            emitted = False
+            try:
+                for chunk in self._stream_chat_completions(
+                    fallback_payload,
+                    cancel_checker=cancel_checker,
+                ):
+                    emitted = True
+                    yield chunk
+                return
+            except ApiRequestError as exc:
+                if emitted:
+                    raise
+                if "response_format" in fallback_payload and _is_response_format_unsupported_error(exc):
+                    self._unsupported_chat_params.add("response_format")
+                    fallback_payload.pop("response_format", None)
+                    log_event(
+                        "API",
+                        "流式 response_format 不受支持，已回退普通流式请求",
+                        {
+                            "attempt": attempt,
+                            "max_attempts": MAX_AUTO_RETRY_ATTEMPTS,
+                            "error": str(exc),
+                        },
+                    )
+                    continue
+                if "temperature" in fallback_payload and _is_temperature_unsupported_error(exc):
+                    self._unsupported_chat_params.add("temperature")
+                    fallback_payload.pop("temperature", None)
+                    log_event(
+                        "API",
+                        "流式模型不支持自定义 temperature，已回退默认温度",
+                        {
+                            "attempt": attempt,
+                            "max_attempts": MAX_AUTO_RETRY_ATTEMPTS,
+                            "error": str(exc),
+                        },
+                    )
+                    continue
+                raise
+        raise ApiRequestError("流式 API 兼容性自动回退已达到最大次数。")
+
     def _ensure_chat_config(self, api_key_message: str) -> None:
         if not self.settings.api_key:
             raise ApiConfigError(api_key_message)
@@ -525,6 +699,88 @@ class OpenAICompatibleClient:
 
         self._emit_llm_event("llm.request.finished", {"model": model_name})
         return data
+
+    def _stream_chat_completions(
+        self,
+        payload: dict[str, Any],
+        *,
+        cancel_checker: CancelChecker | None = None,
+    ) -> Iterator[str]:
+        check_cancelled(cancel_checker)
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        base_url = _normalize_openai_base_url(self.settings.base_url)
+        url = f"{base_url}/chat/completions"
+        request = urllib.request.Request(
+            url=url,
+            data=body,
+            method="POST",
+            headers={
+                "Authorization": f"Bearer {self.settings.api_key}",
+                "Content-Type": "application/json",
+                "Accept": "text/event-stream",
+            },
+        )
+        last_error: BaseException | None = None
+        for attempt in range(1, MAX_AUTO_RETRY_ATTEMPTS + 1):
+            check_cancelled(cancel_checker)
+            emitted = False
+            started_at = time.perf_counter()
+            try:
+                for raw_line in iter_url_lines_cancellable(
+                    urlopen_direct_for_loopback,
+                    request,
+                    timeout=self.settings.timeout_seconds,
+                    cancel_checker=cancel_checker,
+                ):
+                    check_cancelled(cancel_checker)
+                    line = raw_line.decode("utf-8", errors="replace").strip()
+                    if not line or line.startswith((":", "event:", "id:", "retry:")):
+                        continue
+                    data_text = line[5:].strip() if line.startswith("data:") else line
+                    if data_text == "[DONE]":
+                        return
+                    try:
+                        data = json.loads(data_text)
+                    except json.JSONDecodeError as exc:
+                        raise ApiRequestError(f"流式 API 返回无法解析：{data_text[:500]}") from exc
+                    error = _stream_error_message(data)
+                    if error:
+                        raise ApiRequestError(error)
+                    for chunk in _extract_stream_text_chunks(data):
+                        emitted = True
+                        yield chunk
+                return
+            except urllib.error.HTTPError as exc:
+                error_body = exc.read().decode("utf-8", errors="replace")
+                if emitted or exc.code not in {429, 500, 502, 503, 504} or attempt == MAX_AUTO_RETRY_ATTEMPTS:
+                    raise ApiRequestError(_format_api_http_error(exc.code, error_body, url)) from exc
+                last_error = exc
+            except urllib.error.URLError as exc:
+                if emitted or attempt == MAX_AUTO_RETRY_ATTEMPTS:
+                    raise ApiRequestError(f"流式 API 请求失败：{exc.reason}") from exc
+                last_error = exc
+            except TimeoutError as exc:
+                if emitted or attempt == MAX_AUTO_RETRY_ATTEMPTS:
+                    raise ApiRequestError("流式 API 请求超时。") from exc
+                last_error = exc
+            except (ssl.SSLError, ConnectionError, http.client.RemoteDisconnected) as exc:
+                if emitted or attempt == MAX_AUTO_RETRY_ATTEMPTS:
+                    raise ApiRequestError(f"流式 API 连接中断：{exc}") from exc
+                last_error = exc
+
+            log_event(
+                "API",
+                "准备重试流式请求",
+                {
+                    "attempt": attempt,
+                    "max_attempts": MAX_AUTO_RETRY_ATTEMPTS,
+                    "delay_seconds": API_RETRY_DELAY_SECONDS * attempt,
+                    "elapsed_ms": int((time.perf_counter() - started_at) * 1000),
+                    "last_error": str(last_error),
+                },
+            )
+            cancellable_sleep(API_RETRY_DELAY_SECONDS * attempt, cancel_checker)
+        raise ApiRequestError("流式 API 请求失败。")
 
     def _send_with_retries(
         self,
@@ -627,6 +883,57 @@ class OpenAICompatibleClient:
             cancellable_sleep(API_RETRY_DELAY_SECONDS * attempt, cancel_checker)
 
         raise ApiRequestError("API 请求失败。")
+
+
+def _extract_stream_text_chunks(data: Any) -> Iterator[str]:
+    if not isinstance(data, dict):
+        return
+    choices = data.get("choices")
+    if not isinstance(choices, list):
+        return
+    for choice in choices:
+        if not isinstance(choice, dict):
+            continue
+        delta = choice.get("delta")
+        if isinstance(delta, dict):
+            yield from _coerce_stream_content(delta.get("content"))
+            continue
+        message = choice.get("message")
+        if isinstance(message, dict):
+            yield from _coerce_stream_content(message.get("content"))
+
+
+def _coerce_stream_content(content: Any) -> Iterator[str]:
+    if isinstance(content, str):
+        if content:
+            yield content
+        return
+    if not isinstance(content, list):
+        return
+    for item in content:
+        if isinstance(item, str):
+            if item:
+                yield item
+            continue
+        if not isinstance(item, dict):
+            continue
+        text = item.get("text")
+        if isinstance(text, str) and text:
+            yield text
+
+
+def _stream_error_message(data: Any) -> str:
+    if not isinstance(data, dict):
+        return ""
+    error = data.get("error")
+    if isinstance(error, str):
+        return error.strip()
+    if not isinstance(error, dict):
+        return ""
+    message = error.get("message")
+    if isinstance(message, str) and message.strip():
+        return message.strip()
+    return json.dumps(error, ensure_ascii=False, default=str)
 
 
 def _build_segmented_reply_instruction(

--- a/app/llm/streaming_reply.py
+++ b/app/llm/streaming_reply.py
@@ -1,0 +1,383 @@
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from app.llm.chat_reply import (
+    ChatReply,
+    ChatSegment,
+    parse_chat_reply_result,
+    sanitize_reply_tones,
+)
+
+
+STREAMING_REPLY_STAGE = "stream_segment"
+STREAM_LINE_DELIMITERS = ("|||", "||", "\t", "｜")
+_STREAM_TOOL_KEYWORDS = (
+    "屏幕",
+    "截图",
+    "桌面",
+    "窗口",
+    "点击",
+    "操作",
+    "打开",
+    "关闭",
+    "输入",
+    "复制",
+    "粘贴",
+    "提醒",
+    "记住",
+    "忘记",
+    "搜索",
+    "查一下",
+    "查询",
+    "查找",
+    "联网",
+    "网页",
+    "浏览器",
+    "最新",
+    "新闻",
+    "天气",
+    "价格",
+    "汇率",
+    "文件",
+    "删除",
+    "移动",
+    "保存",
+    "运行",
+    "执行",
+    "启动",
+    "切换",
+    "最小化",
+    "最大化",
+    "按下",
+    "拖动",
+    "记得",
+    "以后",
+    "从今",
+    "今后",
+    "叫我",
+    "称呼我",
+    "偏好",
+    "习惯",
+    "上次",
+    "之前说",
+    "闹钟",
+    "定时",
+    "喊我",
+    "当前页面",
+    "这个页面",
+    "当前视频",
+    "这个视频",
+    "刚才那个视频",
+    "弹幕",
+    "powershell",
+    "cmd",
+    "mcp",
+    "鼠标",
+    "键盘",
+    "screen",
+    "screenshot",
+    "desktop",
+    "window",
+    "click",
+    "open ",
+    "close ",
+    "search",
+    "look up",
+    "remind",
+    "remember",
+    "forget",
+    "browser",
+    "file",
+    "save ",
+    "run ",
+    "execute",
+    "launch",
+    "switch ",
+    "minimize",
+    "maximize",
+    "press ",
+    "drag ",
+    "do you remember",
+    "call me",
+    "my preference",
+    "timer",
+    "alarm",
+)
+_URL_RE = re.compile(r"https?://", re.IGNORECASE)
+_JSON_SEGMENTS_RE = re.compile(r"^\{\s*[\"']segments[\"']\s*:", re.IGNORECASE)
+_MULTILINE_JSON_OBJECT_RE = re.compile(r"^\{[^\S\r\n]*\n\s*[\"']")
+_PROTOCOL_NOISE_PREFIXES = (
+    "输出格式",
+    "格式说明",
+    "json line",
+    "jsonl",
+    "字段说明",
+    "示例：",
+    "示例:",
+    "```",
+)
+
+
+class StreamingReplyUnavailable(RuntimeError):
+    """流式回复未产出可展示句段，可回退原有非流式链路。"""
+
+
+class StreamedReplyParser:
+    """把模型增量文本解析为可立即进入字幕/TTS 队列的 ChatSegment。"""
+
+    def __init__(self, allowed_tones: list[str] | None = None) -> None:
+        self.allowed_tones = [*allowed_tones] if allowed_tones is not None else []
+        self._buffer = ""
+        self._document_mode = False
+
+    def feed(self, chunk: str) -> list[ChatSegment]:
+        text = str(chunk or "")
+        if not text:
+            return []
+        self._buffer += text.replace("\r\n", "\n").replace("\r", "\n")
+        if self._document_mode or _looks_like_json_document_start(self._buffer):
+            self._document_mode = True
+            return []
+        if _looks_like_ambiguous_json_prefix(self._buffer):
+            return []
+
+        segments: list[ChatSegment] = []
+        while "\n" in self._buffer:
+            line, self._buffer = self._buffer.split("\n", 1)
+            segments.extend(self._parse_line(line))
+        return segments
+
+    def finish(self) -> list[ChatSegment]:
+        if self._document_mode:
+            content = _strip_code_fence(self._buffer)
+            self._buffer = ""
+            parsed = parse_chat_reply_result(content)
+            if parsed.needs_retry:
+                return []
+            return _sanitize_segments(parsed.reply.segments, self.allowed_tones)
+
+        tail = self._buffer
+        self._buffer = ""
+        return self._parse_line(tail)
+
+    def _parse_line(self, line: str) -> list[ChatSegment]:
+        clean = _clean_line(line)
+        if not clean or _looks_like_protocol_noise(clean):
+            return []
+
+        json_segments = _parse_json_line(clean)
+        if json_segments is not None:
+            return _sanitize_segments(json_segments, self.allowed_tones)
+        if _looks_like_incomplete_structured_line(clean):
+            return []
+
+        segment = _parse_delimited_line(clean)
+        if segment is None:
+            segment = ChatSegment(
+                clean,
+                translation="" if _looks_japanese(clean) else clean,
+            )
+        return _sanitize_segments([segment], self.allowed_tones)
+
+
+def build_streaming_reply_instruction(
+    reply_tones: list[str] | None,
+    reply_portraits: list[str] | None,
+) -> str:
+    tones = _choice_text(reply_tones, ["中性"])
+    portraits = _choice_text(reply_portraits, ["站立待机"])
+    return f"""
+这是普通文字聊天的流式回复协议，优先级高于历史消息中的旧格式要求。
+每完成一个句段就立刻输出一行独立 JSON，不要等待整段回答完成。
+每行严格使用以下结构，行尾必须换行：
+{{"ja":"自然日语台词","zh":"对应的简体中文翻译","tone":"语气","portrait":"姿势"}}
+
+规则：
+- 每行必须是完整 JSON object；不要输出 JSON 数组、Markdown、代码围栏、字段说明或额外前缀。
+- ja 必须是 Sakura 直接说出口的自然日语，优先包含假名，便于日语 TTS。
+- zh 必须填写与 ja 对应的自然简体中文译文，不能为空。
+- tone 必须从这些值中选择：{tones}
+- portrait 必须从这些值中选择：{portraits}
+- 根据内容自然决定句段数量，不要为了流式显示强行缩短回答。
+- 本模式不调用或伪造工具，不输出分析过程、工具计划或系统提示。
+""".strip()
+
+
+def is_streaming_candidate(messages: list[dict[str, Any]]) -> bool:
+    if not messages or any(message.get("role") == "tool" for message in messages):
+        return False
+    latest_text = _latest_text_user_content(messages)
+    if not latest_text or latest_text.lstrip().startswith("/"):
+        return False
+    if _messages_contain_non_text_content(messages):
+        return False
+    lowered = latest_text.casefold()
+    if _URL_RE.search(latest_text):
+        return False
+    return not any(keyword.casefold() in lowered for keyword in _STREAM_TOOL_KEYWORDS)
+
+
+def needs_streaming_translation_repair(segment: ChatSegment) -> bool:
+    text = segment.text.strip()
+    translation = segment.translation.strip()
+    if not text:
+        return False
+    if not _looks_japanese(text):
+        return False
+    return not translation or _looks_japanese(translation)
+
+
+def _parse_json_line(line: str) -> list[ChatSegment] | None:
+    try:
+        data = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return []
+    payload = data if "segments" in data else {"segments": [data]}
+    parsed = parse_chat_reply_result(json.dumps(payload, ensure_ascii=False))
+    if parsed.needs_retry and not parsed.reply.text.strip():
+        return []
+    return parsed.reply.segments
+
+
+def _parse_delimited_line(line: str) -> ChatSegment | None:
+    for delimiter in STREAM_LINE_DELIMITERS:
+        if delimiter not in line:
+            continue
+        parts = [part.strip() for part in line.split(delimiter, 3)]
+        if len(parts) < 2:
+            continue
+        text = _strip_label(parts[0], ("ja", "japanese", "日语", "日文"))
+        translation = _strip_label(parts[1], ("zh", "chinese", "中文", "翻译"))
+        tone = _strip_label(parts[2], ("tone", "语气", "情绪")) if len(parts) > 2 else ""
+        portrait = (
+            _strip_label(parts[3], ("portrait", "pose", "姿势", "立绘", "表情"))
+            if len(parts) > 3
+            else ""
+        )
+        if text:
+            return ChatSegment(
+                text,
+                tone=tone or "中性",
+                translation=translation,
+                portrait=portrait,
+            )
+        if translation:
+            return ChatSegment(
+                translation,
+                tone=tone or "中性",
+                translation=translation,
+                portrait=portrait,
+            )
+    return None
+
+
+def _sanitize_segments(
+    segments: list[ChatSegment],
+    allowed_tones: list[str],
+) -> list[ChatSegment]:
+    clean = [segment for segment in segments if segment.text.strip()]
+    if not clean:
+        return []
+    return sanitize_reply_tones(ChatReply(clean), allowed_tones).segments
+
+
+def _looks_like_json_document_start(buffer: str) -> bool:
+    stripped = buffer.lstrip()
+    return (
+        stripped.startswith("```")
+        or bool(_JSON_SEGMENTS_RE.match(stripped))
+        or bool(_MULTILINE_JSON_OBJECT_RE.match(stripped))
+    )
+
+
+def _looks_like_ambiguous_json_prefix(buffer: str) -> bool:
+    stripped = buffer.lstrip()
+    return bool(stripped) and stripped.startswith("{") and not stripped[1:].strip()
+
+
+def _strip_code_fence(content: str) -> str:
+    lines = content.strip().splitlines()
+    if len(lines) >= 3 and lines[0].strip().startswith("```") and lines[-1].strip() == "```":
+        return "\n".join(lines[1:-1]).strip()
+    return content.strip()
+
+
+def _clean_line(line: str) -> str:
+    text = " ".join(str(line or "").split()).strip()
+    for marker in ("- ", "* ", "• "):
+        if text.startswith(marker):
+            return text[len(marker) :].strip()
+    return text
+
+
+def _looks_like_protocol_noise(line: str) -> bool:
+    lowered = line.casefold().lstrip("# ")
+    return any(
+        lowered.startswith(prefix.casefold())
+        for prefix in _PROTOCOL_NOISE_PREFIXES
+    )
+
+
+def _looks_like_incomplete_structured_line(line: str) -> bool:
+    return line.lstrip().startswith(("{", "[", "```"))
+
+
+def _strip_label(text: str, labels: tuple[str, ...]) -> str:
+    value = text.strip()
+    lowered = value.casefold()
+    for label in labels:
+        for separator in (":", "："):
+            prefix = f"{label}{separator}".casefold()
+            if lowered.startswith(prefix):
+                return value[len(prefix) :].strip()
+    return value
+
+
+def _choice_text(values: list[str] | None, fallback: list[str]) -> str:
+    choices = list(
+        dict.fromkeys(str(value or "").strip() for value in (values or []) if str(value or "").strip())
+    )
+    return "、".join(choices or fallback)
+
+
+def _latest_text_user_content(messages: list[dict[str, Any]]) -> str:
+    for message in reversed(messages):
+        if message.get("role") != "user":
+            continue
+        content = message.get("content")
+        if isinstance(content, str):
+            return content.strip()
+        if not isinstance(content, list):
+            return ""
+        parts = [
+            str(part.get("text") or "").strip()
+            for part in content
+            if isinstance(part, dict) and part.get("type") == "text"
+        ]
+        return "\n".join(part for part in parts if part)
+    return ""
+
+
+def _messages_contain_non_text_content(messages: list[dict[str, Any]]) -> bool:
+    for message in messages:
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        if any(
+            not isinstance(part, dict) or part.get("type") != "text"
+            for part in content
+        ):
+            return True
+    return False
+
+
+def _looks_japanese(value: str) -> bool:
+    return any(
+        "\u3040" <= char <= "\u30ff" or "\uff66" <= char <= "\uff9f"
+        for char in value
+    )

--- a/app/plugins/services.py
+++ b/app/plugins/services.py
@@ -153,6 +153,10 @@ class PluginMobileService:
         self._characters_sink: Callable[[], list[dict[str, str]]] | None = None
         self._history_sink: Callable[[str, int], list[dict[str, str]]] | None = None
         self._chat_sink: Callable[[str, str, str], dict[str, Any]] | None = None
+        self._chat_stream_sink: (
+            Callable[[str, str, str, Callable[[dict[str, Any]], None]], dict[str, Any]]
+            | None
+        ) = None
         self._theme_sink: Callable[[], dict[str, object]] | None = None
 
     def set_backends(
@@ -161,6 +165,10 @@ class PluginMobileService:
         characters_sink: Callable[[], list[dict[str, str]]] | None = None,
         history_sink: Callable[[str, int], list[dict[str, str]]] | None = None,
         chat_sink: Callable[[str, str, str], dict[str, Any]] | None = None,
+        chat_stream_sink: (
+            Callable[[str, str, str, Callable[[dict[str, Any]], None]], dict[str, Any]]
+            | None
+        ) = None,
         theme_sink: Callable[[], dict[str, object]] | None = None,
     ) -> None:
         if characters_sink is not None:
@@ -169,6 +177,8 @@ class PluginMobileService:
             self._history_sink = history_sink
         if chat_sink is not None:
             self._chat_sink = chat_sink
+        if chat_stream_sink is not None:
+            self._chat_stream_sink = chat_stream_sink
         if theme_sink is not None:
             self._theme_sink = theme_sink
 
@@ -186,6 +196,23 @@ class PluginMobileService:
         if self._chat_sink is None:
             raise RuntimeError("移动端聊天服务尚未就绪。")
         return self._chat_sink(character_id, text, image_data_url)
+
+    def chat_stream(
+        self,
+        character_id: str,
+        text: str,
+        image_data_url: str = "",
+        *,
+        progress_callback: Callable[[dict[str, Any]], None],
+    ) -> dict[str, Any]:
+        if self._chat_stream_sink is None:
+            return self.chat(character_id, text, image_data_url)
+        return self._chat_stream_sink(
+            character_id,
+            text,
+            image_data_url,
+            progress_callback,
+        )
 
     def theme(self) -> dict[str, object]:
         if self._theme_sink is None:
@@ -390,6 +417,10 @@ class PluginServices:
         mobile_characters_sink: Callable[[], list[dict[str, str]]] | None = None,
         mobile_history_sink: Callable[[str, int], list[dict[str, str]]] | None = None,
         mobile_chat_sink: Callable[[str, str, str], dict[str, Any]] | None = None,
+        mobile_chat_stream_sink: (
+            Callable[[str, str, str, Callable[[dict[str, Any]], None]], dict[str, Any]]
+            | None
+        ) = None,
         mobile_theme_sink: Callable[[], dict[str, object]] | None = None,
     ) -> None:
         """宿主装配时一次性注入真实后端（任意项可省略）。"""
@@ -405,6 +436,7 @@ class PluginServices:
             characters_sink=mobile_characters_sink,
             history_sink=mobile_history_sink,
             chat_sink=mobile_chat_sink,
+            chat_stream_sink=mobile_chat_stream_sink,
             theme_sink=mobile_theme_sink,
         )
 

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -4606,6 +4606,7 @@ class PetWindow(QWidget):
                 mobile_characters_sink=self._mobile_characters,
                 mobile_history_sink=self._mobile_history,
                 mobile_chat_sink=self._mobile_chat,
+                mobile_chat_stream_sink=self._mobile_chat_stream,
                 mobile_theme_sink=self._mobile_theme,
             )
         except Exception as exc:  # noqa: BLE001 — 装配失败不得阻断启动
@@ -4620,17 +4621,79 @@ class PetWindow(QWidget):
     def _mobile_chat(self, character_id: str, text: str, image_data_url: str) -> dict[str, Any]:
         return self.mobile_chat_bridge.chat(character_id, text, image_data_url)
 
+    def _mobile_chat_stream(
+        self,
+        character_id: str,
+        text: str,
+        image_data_url: str,
+        progress_callback: Callable[[dict[str, Any]], None],
+    ) -> dict[str, Any]:
+        return self.mobile_chat_bridge.chat_stream(
+            character_id,
+            text,
+            image_data_url,
+            progress_callback=progress_callback,
+        )
+
     def _mobile_theme(self) -> dict[str, object]:
         return theme_colors_to_mapping(getattr(self, "theme_settings", DEFAULT_THEME_SETTINGS))
 
     def mobile_context_providers(self, _profile: CharacterProfile) -> list[Any]:
         return list(getattr(self.plugin_manager, "context_providers", []))
 
-    def submit_mobile_chat(self, bridge: MobileChatBridge, character_id: str, text: str, image_data_url: str) -> dict[str, Any]:
+    def submit_mobile_chat(
+        self,
+        bridge: MobileChatBridge,
+        character_id: str,
+        text: str,
+        image_data_url: str,
+    ) -> dict[str, Any]:
+        return self._submit_mobile_chat_request(
+            bridge,
+            character_id,
+            text,
+            image_data_url,
+        )
+
+    def submit_mobile_chat_stream(
+        self,
+        bridge: MobileChatBridge,
+        character_id: str,
+        text: str,
+        image_data_url: str,
+        progress_callback: Callable[[dict[str, Any]], None],
+    ) -> dict[str, Any]:
+        return self._submit_mobile_chat_request(
+            bridge,
+            character_id,
+            text,
+            image_data_url,
+            progress_callback=progress_callback,
+        )
+
+    def _submit_mobile_chat_request(
+        self,
+        bridge: MobileChatBridge,
+        character_id: str,
+        text: str,
+        image_data_url: str,
+        *,
+        progress_callback: Callable[[dict[str, Any]], None] | None = None,
+    ) -> dict[str, Any]:
         """Marshal an HTTP request into the single host Agent worker lane."""
         if self._mobile_chat_busy():
             raise MobileChatBusyError(MOBILE_CHAT_BUSY_MESSAGE)
-        request: dict[str, Any] = {"bridge": bridge, "character_id": character_id, "text": text, "image_data_url": image_data_url, "done": threading.Event(), "result": None, "error": "", "busy": False}
+        request: dict[str, Any] = {
+            "bridge": bridge,
+            "character_id": character_id,
+            "text": text,
+            "image_data_url": image_data_url,
+            "progress_callback": progress_callback,
+            "done": threading.Event(),
+            "result": None,
+            "error": "",
+            "busy": False,
+        }
         self.mobile_chat_requested.emit(request)
         if not request["done"].wait(timeout=300):
             raise TimeoutError("移动端聊天等待超时。")
@@ -4677,7 +4740,13 @@ class PetWindow(QWidget):
             return
         request = self._mobile_chat_requests.pop(0)
         self._active_mobile_chat_request = request
-        worker = MobileChatWorker(request["bridge"], str(request["character_id"]), str(request["text"]), str(request["image_data_url"]))
+        worker = MobileChatWorker(
+            request["bridge"],
+            str(request["character_id"]),
+            str(request["text"]),
+            str(request["image_data_url"]),
+            progress_callback=request.get("progress_callback"),
+        )
         self.resource_manager.spawn_qt_worker(
             worker, parent=self, owner=self, thread_attr="worker_thread", worker_attr="worker",
             signal_bindings=[(worker.finished, self._handle_mobile_chat_result), (worker.failed, self._handle_mobile_chat_error)],

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -86,6 +86,7 @@ from app.agent.runtime_events import (
 )
 from app.llm.chat_reply import ChatReply, ChatSegment, parse_chat_reply_result
 from app.llm.context_trimming import trim_messages_for_model
+from app.llm.streaming_reply import STREAMING_REPLY_STAGE
 from app.core.chat_worker import ChatWorker, EventWorker
 from app.core.cancellation import CancellationToken, OperationCancelled
 from app.config.model_slots import ResolvedModelSlot, resolve_model_slot
@@ -3232,6 +3233,9 @@ class PetWindow(QWidget):
                 "metadata": progress.metadata,
             },
         )
+        if progress.stage == STREAMING_REPLY_STAGE:
+            self._show_reply_segments(reply.segments)
+            return
         self.messages.append(
             {
                 "role": "assistant",
@@ -3290,7 +3294,8 @@ class PetWindow(QWidget):
                     "character_id": self.character_profile.id,
                 },
             )
-        self._show_reply_segments(reply.segments)
+        if not (result._debug or {}).get("streamed"):
+            self._show_reply_segments(reply.segments)
         self._apply_pending_action_from_result(result)
 
     def _queue_screen_observation_followup(self, result: AgentResult) -> bool:

--- a/plugins/sakura_mobile/README.md
+++ b/plugins/sakura_mobile/README.md
@@ -33,7 +33,7 @@
 
 插件中的 HTTP 服务使用 Python 标准库 `ThreadingHTTPServer`，不依赖 Flask、FastAPI 或单独的 Node 前端。移动网页的 HTML、CSS、JavaScript 内嵌在 `server.py`，因此部署时不需要额外构建静态资源。
 
-`MobileChatBridge` 只接受桌面当前角色的手机请求。它使用当前角色自己的提示词、聊天历史和记忆作用域；为避免手机端无法处理高风险确认，手机会话不暴露宿主工具。每次手机发消息前，它还会从主程序刷新 API Key、模型和上下文提供者，所以在电脑设置中更换模型后，下一条手机消息会自动使用新配置。
+`MobileChatBridge` 只接受桌面当前角色的手机请求。它使用当前角色自己的提示词、聊天历史和记忆作用域；为避免手机端无法处理高风险确认，手机会话不暴露宿主工具。普通文字聊天复用桌面端的流式句段协议，通过 SSE 立即推送已完成句段；图片或不适合流式处理的请求自动回退完整回复。每次手机发消息前，它还会从主程序刷新 API Key、模型和上下文提供者，所以在电脑设置中更换模型后，下一条手机消息会自动使用新配置。
 
 ## 对 Sakura 主体的改动
 
@@ -42,7 +42,7 @@
 | 文件 | 改动目的 |
 | --- | --- |
 | `app/core/mobile_chat_bridge.py` | 新增手机请求到 Sakura 运行时的桥接层，处理当前角色校验、聊天历史、图片消息、分段回复与记忆作用域。 |
-| `app/plugins/services.py` | 新增 `PluginMobileService`，只暴露 `characters()`、`history()`、`chat()` 三个能力。 |
+| `app/plugins/services.py` | 新增 `PluginMobileService`，只暴露角色、历史以及普通/流式聊天能力。 |
 | `app/plugins/__init__.py` | 导出新增的插件服务类型。 |
 | `app/ui/pet_window.py` | 在桌面主窗口准备好后，将真实角色、历史和聊天回调注入 `PluginMobileService`；手机回合完成时接入原有自动记忆整理计数。 |
 | `plugins/sakura_mobile/` | 插件清单、生命周期、Tauri 设置项、HTTP 服务和手机网页界面。 |
@@ -50,7 +50,7 @@
 这种设计有两个关键点：
 
 1. 手机端只允许访问桌面当前角色；聊天执行通过宿主队列串行化，避免网页端跨角色记忆串线。
-2. 插件只能通过 `PluginMobileService` 调用三项经过限定的能力，避免网页服务直接耦合 Sakura 内部 UI 和存储实现。
+2. 插件只能通过 `PluginMobileService` 调用经过限定的移动聊天能力，避免网页服务直接耦合 Sakura 内部 UI 和存储实现。
 
 
 ## 使用方法
@@ -131,10 +131,11 @@ data/plugins/sakura_mobile/config.json
 | `GET` | `/api/characters` | 获取桌面当前角色。 |
 | `GET` | `/api/history` | 获取角色历史消息。 |
 | `POST` | `/api/chat` | 发送文字和可选图片，获得回复分段。 |
+| `POST` | `/api/chat/stream` | 发送聊天请求，并通过 `ready`、`segment`、`done`、`error` SSE 事件接收回复。 |
 
 所有接口都需要 token。网页会从 URL 中读取 token，API 也接受查询参数、JSON 请求体或 `X-Sakura-Mobile-Token` 请求头中的 token。
 
-单次上传的请求体上限为 12 MiB。插件默认关闭；启用后的默认监听地址为 `0.0.0.0`，可供同一局域网设备访问。服务还会使用 30 秒连接超时、最多 8 个并发请求以及每客户端每分钟 60 次请求的限制。图片会作为 `data:image/...` 数据传给桌面端，再转为模型兼容的 `image_url` 消息；是否能够理解图片取决于当前选择的模型是否支持视觉输入。
+单次上传的请求体上限为 12 MiB。插件默认关闭；启用后的默认监听地址为 `0.0.0.0`，可供同一局域网设备访问。服务还会使用 30 秒连接超时、最多 8 个并发请求以及每客户端每分钟 60 次请求的限制。SSE 回复等待期间每 10 秒发送一次保活注释。图片会作为 `data:image/...` 数据传给桌面端，再转为模型兼容的 `image_url` 消息；是否能够理解图片取决于当前选择的模型是否支持视觉输入。
 
 ## 日志与排查
 

--- a/plugins/sakura_mobile/server.py
+++ b/plugins/sakura_mobile/server.py
@@ -7,10 +7,12 @@ import socket
 import threading
 import time
 from collections import deque
+from collections.abc import Callable
 from datetime import datetime
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from queue import Empty, Queue
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
@@ -110,6 +112,24 @@ class MobilePluginService:
     def chat(self, character_id: str, text: str, image_data_url: str = "") -> dict[str, Any]:
         return self.mobile_service.chat(character_id, text, image_data_url)
 
+    def chat_stream(
+        self,
+        character_id: str,
+        text: str,
+        image_data_url: str = "",
+        *,
+        progress_callback: Callable[[dict[str, Any]], None],
+    ) -> dict[str, Any]:
+        chat_stream = getattr(self.mobile_service, "chat_stream", None)
+        if callable(chat_stream):
+            return chat_stream(
+                character_id,
+                text,
+                image_data_url,
+                progress_callback=progress_callback,
+            )
+        return self.chat(character_id, text, image_data_url)
+
     def theme(self) -> dict[str, object]:
         theme = getattr(self.mobile_service, "theme", None)
         if callable(theme):
@@ -184,6 +204,7 @@ def _is_lan_ipv4(address: str) -> bool:
 def _build_handler(service: MobilePluginService, token: str) -> type[BaseHTTPRequestHandler]:
     class MobileRequestHandler(BaseHTTPRequestHandler):
         server_version = "SakuraMobile/0.1"
+        protocol_version = "HTTP/1.1"
 
         def do_GET(self) -> None:  # noqa: N802
             try:
@@ -220,11 +241,14 @@ def _build_handler(service: MobilePluginService, token: str) -> type[BaseHTTPReq
                 parsed = urlparse(self.path)
                 self._require_rate_limit()
                 self._log_request_start("POST", parsed.path)
-                if parsed.path != "/api/chat":
+                if parsed.path not in {"/api/chat", "/api/chat/stream"}:
                     self._send_error(HTTPStatus.NOT_FOUND, "Not found")
                     return
                 data = self._read_json_body()
                 self._require_token(parsed, data)
+                if parsed.path == "/api/chat/stream":
+                    self._send_chat_stream(data)
+                    return
                 result = service.chat(
                     str(data.get("character_id") or ""),
                     str(data.get("text") or ""),
@@ -315,6 +339,65 @@ def _build_handler(service: MobilePluginService, token: str) -> type[BaseHTTPReq
             self.send_header("Content-Length", str(len(payload)))
             self.end_headers()
             self.wfile.write(payload)
+
+        def _send_chat_stream(self, data: dict[str, Any]) -> None:
+            events: Queue[tuple[str, dict[str, Any]]] = Queue()
+
+            def progress_callback(payload: dict[str, Any]) -> None:
+                event_name = str(payload.get("event") or "progress").strip() or "progress"
+                events.put((event_name, dict(payload)))
+
+            def run_chat() -> None:
+                try:
+                    result = service.chat_stream(
+                        str(data.get("character_id") or ""),
+                        str(data.get("text") or ""),
+                        str(data.get("image") or data.get("image_data_url") or ""),
+                        progress_callback=progress_callback,
+                    )
+                except MobileChatBusyError as exc:
+                    events.put(
+                        (
+                            "error",
+                            {"ok": False, "busy": True, "error": str(exc)},
+                        )
+                    )
+                except Exception as exc:  # noqa: BLE001 - 通过 SSE 返回给请求方
+                    events.put(("error", {"ok": False, "error": str(exc)}))
+                else:
+                    events.put(("done", result))
+
+            worker = threading.Thread(
+                target=run_chat,
+                name="SakuraMobileStream",
+                daemon=True,
+            )
+            worker.start()
+
+            self.send_response(HTTPStatus.OK.value)
+            self._send_common_headers()
+            self.send_header("Content-Type", "text/event-stream; charset=utf-8")
+            self.send_header("Cache-Control", "no-store, no-transform")
+            self.send_header("X-Accel-Buffering", "no")
+            self.end_headers()
+            self._write_sse_event("ready", {"ok": True})
+
+            while True:
+                try:
+                    event_name, payload = events.get(timeout=10)
+                except Empty:
+                    self.wfile.write(b": keepalive\n\n")
+                    self.wfile.flush()
+                    continue
+                self._write_sse_event(event_name, payload)
+                if event_name in {"done", "error"}:
+                    return
+
+        def _write_sse_event(self, event_name: str, data: dict[str, Any]) -> None:
+            payload = json.dumps(data, ensure_ascii=False, default=str)
+            event = event_name.replace("\r", "").replace("\n", "").strip() or "message"
+            self.wfile.write(f"event: {event}\ndata: {payload}\n\n".encode("utf-8"))
+            self.wfile.flush()
 
         def _send_common_headers(self) -> None:
             self.send_header("Access-Control-Allow-Origin", "*")
@@ -499,6 +582,75 @@ async function fetchJson(path, options = {{}}) {{
   if (!res.ok) throw new Error(data.error || '请求失败');
   return data;
 }}
+function decodeEventBlock(block) {{
+  let eventName = 'message';
+  const dataLines = [];
+  for (const rawLine of block.split('\\n')) {{
+    const line = rawLine.trimEnd();
+    if (!line || line.startsWith(':')) continue;
+    if (line.startsWith('event:')) {{
+      eventName = line.slice(6).trim() || 'message';
+      continue;
+    }}
+    if (line.startsWith('data:')) dataLines.push(line.slice(5).trimStart());
+  }}
+  if (!dataLines.length) return null;
+  return {{ eventName, payload: JSON.parse(dataLines.join('\\n')) }};
+}}
+async function readEventStream(response, onEvent) {{
+  const dispatch = block => {{
+    const decoded = decodeEventBlock(block);
+    if (decoded) onEvent(decoded.eventName, decoded.payload);
+  }};
+  if (!response.body || typeof response.body.getReader !== 'function') {{
+    const textBody = (await response.text()).replace(/\\r\\n/g, '\\n');
+    for (const block of textBody.split('\\n\\n')) dispatch(block);
+    return;
+  }}
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  while (true) {{
+    const chunk = await reader.read();
+    buffer += decoder.decode(chunk.value || new Uint8Array(), {{ stream: !chunk.done }});
+    buffer = buffer.replace(/\\r\\n/g, '\\n');
+    let boundary = buffer.indexOf('\\n\\n');
+    while (boundary >= 0) {{
+      dispatch(buffer.slice(0, boundary));
+      buffer = buffer.slice(boundary + 2);
+      boundary = buffer.indexOf('\\n\\n');
+    }}
+    if (chunk.done) break;
+  }}
+  if (buffer.trim()) dispatch(buffer);
+}}
+async function fetchChatStream(payload, onEvent) {{
+  const res = await fetchWithTimeout(api('/api/chat/stream'), {{
+    method: 'POST',
+    headers: {{ 'Content-Type': 'application/json' }},
+    body: JSON.stringify(payload)
+  }});
+  if (!res.ok) {{
+    let errorData = {{}};
+    try {{ errorData = await res.json(); }} catch (_err) {{}}
+    throw new Error(errorData.error || '请求失败');
+  }}
+  let finalResult = null;
+  await readEventStream(res, (eventName, eventPayload) => {{
+    if (eventName === 'error') {{
+      const error = new Error(eventPayload.error || '请求失败');
+      error.busy = Boolean(eventPayload.busy);
+      throw error;
+    }}
+    if (eventName === 'done') {{
+      finalResult = eventPayload;
+      return;
+    }}
+    onEvent(eventName, eventPayload);
+  }});
+  if (!finalResult) throw new Error('流式回复提前结束。');
+  return finalResult;
+}}
 function errorText(err) {{
   if (err && err.name === 'AbortError') return '请求超时，请稍后再试。';
   return String(err && err.message ? err.message : err);
@@ -626,6 +778,7 @@ form.addEventListener('submit', async (event) => {{
   if (!value && !file) return;
   send.disabled = true;
   setStatus(thinkingText());
+  let pendingTyping = null;
   try {{
     await loadHistory();
     addMessage('user', value + (file ? '\\n（已附加图片）' : ''));
@@ -634,24 +787,43 @@ form.addEventListener('submit', async (event) => {{
     image.value = '';
     camera.value = '';
     syncMediaSelection('');
-    const data = await fetchJson('/api/chat', {{
-      method: 'POST',
-      headers: {{ 'Content-Type': 'application/json' }},
-      body: JSON.stringify({{
-        token: TOKEN,
-        character_id: character.value,
-        text: value,
-        image: imageData
-      }})
+    pendingTyping = addTypingMessage();
+    let streamedSegmentCount = 0;
+    const data = await fetchChatStream({{
+      token: TOKEN,
+      character_id: character.value,
+      text: value,
+      image: imageData
+    }}, (eventName, eventPayload) => {{
+      if (eventName !== 'segment') return;
+      const segments = Array.isArray(eventPayload.segments) ? eventPayload.segments : [];
+      for (const segment of segments) {{
+        const content = cleanAssistantText(segment.content);
+        if (!content) continue;
+        if (pendingTyping) {{
+          pendingTyping.remove();
+          pendingTyping = null;
+        }}
+        addMessage('assistant', content);
+        streamedSegmentCount += 1;
+      }}
+      if (streamedSegmentCount) setStatus('');
     }});
-    const segments = Array.isArray(data.segments) ? data.segments : [];
-    if (segments.length) {{
-      await showAssistantSegments(segments);
-    }} else {{
-      await showAssistantSegments([{{ content: data.reply || '' }}]);
+    if (pendingTyping) {{
+      pendingTyping.remove();
+      pendingTyping = null;
+    }}
+    if (!streamedSegmentCount) {{
+      const segments = Array.isArray(data.segments) ? data.segments : [];
+      if (segments.length) {{
+        await showAssistantSegments(segments);
+      }} else {{
+        await showAssistantSegments([{{ content: data.reply || '' }}]);
+      }}
     }}
     setStatus('');
   }} catch (err) {{
+    if (pendingTyping) pendingTyping.remove();
     setStatus(errorText(err));
   }} finally {{
     send.disabled = false;

--- a/tests/integration/test_chat_pipeline.py
+++ b/tests/integration/test_chat_pipeline.py
@@ -4,9 +4,10 @@ import json
 import uuid
 from pathlib import Path
 
-from app.agent import AgentEvent, AgentResult, PendingToolAction
+from app.agent import AgentEvent, AgentProgress, AgentResult, PendingToolAction
 from app.core.chat_pipeline import ChatPipeline
-from app.llm.chat_reply import parse_chat_reply
+from app.llm.chat_reply import ChatReply, ChatSegment, parse_chat_reply
+from app.llm.streaming_reply import StreamingReplyUnavailable
 from app.storage.visual_observation import VisualObservationJob, VisualObservationStore
 
 
@@ -222,3 +223,53 @@ def test_chat_pipeline_keeps_images_and_records_visual_observation_after_reply()
         assert "截图里有一张设置页" in raw
     finally:
         path.unlink(missing_ok=True)
+
+
+def test_chat_pipeline_uses_streaming_for_simple_chat() -> None:
+    class StreamingRuntime(RuntimeStub):
+        def should_stream_user_message(self, _messages):  # type: ignore[no-untyped-def]
+            return True
+
+        def handle_streaming_user_message(
+            self,
+            _messages,
+            *,
+            progress_callback,
+            cancel_checker=None,
+        ):  # type: ignore[no-untyped-def]
+            if cancel_checker is not None:
+                cancel_checker()
+            self.calls.append("stream")
+            segment = ChatSegment("うん。", translation="嗯。")
+            progress_callback(AgentProgress(ChatReply([segment]), stage="stream_segment"))
+            return AgentResult(ChatReply([segment]), _debug={"streamed": True})
+
+    runtime = StreamingRuntime()
+    progress: list[AgentProgress] = []
+    result = ChatPipeline(runtime).run_user_message(  # type: ignore[arg-type]
+        [{"role": "user", "content": "陪我聊聊"}],
+        progress_callback=progress.append,
+    )
+
+    assert runtime.calls == ["stream"]
+    assert result._debug == {"streamed": True}
+    assert [item.stage for item in progress] == ["stream_segment"]
+
+
+def test_chat_pipeline_falls_back_when_streaming_is_unavailable() -> None:
+    class StreamingRuntime(RuntimeStub):
+        def should_stream_user_message(self, _messages):  # type: ignore[no-untyped-def]
+            return True
+
+        def handle_streaming_user_message(self, *_args, **_kwargs):  # type: ignore[no-untyped-def]
+            self.calls.append("stream")
+            raise StreamingReplyUnavailable("provider closed the stream")
+
+    runtime = StreamingRuntime()
+    result = ChatPipeline(runtime).run_user_message(  # type: ignore[arg-type]
+        [{"role": "user", "content": "陪我聊聊"}],
+        progress_callback=lambda _progress: None,
+    )
+
+    assert runtime.calls == ["stream", "user:1"]
+    assert result.reply.text == "はい"

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -8574,6 +8574,77 @@ def test_progress_reply_records_segments_as_separate_history_entries() -> None:
     ]
 
 
+def test_streaming_progress_queues_segments_without_transient_history() -> None:
+    from app.agent import AgentProgress
+    from app.llm.streaming_reply import STREAMING_REPLY_STAGE
+    from app.ui.pet_window import PetWindow
+
+    class MinimalProgressWindow:
+        _handle_progress_reply = PetWindow._handle_progress_reply
+
+    window = MinimalProgressWindow()
+    from app.ui.state import PetUiStateStore
+
+    window.ui_state = PetUiStateStore()
+    window.messages = [{"role": "user", "content": "陪我聊聊"}]
+    window._log_interaction_stage = lambda *_args, **_kwargs: None
+    shown: list[ChatSegment] = []
+    history: list[object] = []
+    window._show_reply_segments = lambda segments: shown.extend(segments)
+    window._record_assistant_reply_history = history.append
+    segment = ChatSegment("うん。", translation="嗯。")
+
+    window._handle_progress_reply(
+        AgentProgress(
+            reply=ChatReply([segment]),
+            stage=STREAMING_REPLY_STAGE,
+        )
+    )
+
+    assert shown == [segment]
+    assert window.messages == [{"role": "user", "content": "陪我聊聊"}]
+    assert history == []
+
+
+def test_streamed_final_reply_records_once_without_replaying_segments() -> None:
+    from app.ui.pet_window import PetWindow
+
+    class CharacterProfile:
+        id = "sakura"
+
+    class MinimalReplyWindow:
+        _handle_reply = PetWindow._handle_reply
+
+    window = MinimalReplyWindow()
+    window.messages = [{"role": "user", "content": "陪我聊聊"}]
+    window.character_profile = CharacterProfile()
+    window._log_interaction_stage = lambda *_args, **_kwargs: None
+    window._queue_screen_observation_followup = lambda _result: False
+    recorded: list[tuple[ChatReply, dict | None]] = []
+    window._record_assistant_reply_history = (
+        lambda reply, _debug=None: recorded.append((reply, _debug))
+    )
+    plugin_events: list[tuple[object, object]] = []
+    window._emit_plugin_event = (
+        lambda event_type, payload, **_kwargs: plugin_events.append((event_type, payload))
+    )
+    shown: list[ChatSegment] = []
+    window._show_reply_segments = lambda segments: shown.extend(segments)
+    window._apply_pending_action_from_result = lambda _result: None
+    segment = ChatSegment("うん。", translation="嗯。")
+    result = AgentResult(
+        reply=ChatReply([segment]),
+        _debug={"streamed": True},
+    )
+
+    window._handle_reply(result)
+
+    assert window.messages[-1] == {"role": "assistant", "content": "うん。"}
+    assert recorded == [(result.reply, {"streamed": True})]
+    assert len(plugin_events) == 1
+    assert shown == []
+
+
 def test_assistant_reply_history_records_tone_and_portrait() -> None:
     from app.llm.chat_reply import ChatReply
     from app.ui.pet_window import PetWindow

--- a/tests/unit/test_agent_runtime.py
+++ b/tests/unit/test_agent_runtime.py
@@ -50,6 +50,7 @@ from app.llm.api_client import (
     OpenAICompatibleClient,
 )
 from app.llm.chat_reply import ChatReply, ChatSegment
+from app.llm.streaming_reply import StreamingReplyUnavailable
 from app.storage.chat_history import ChatHistoryEntry
 
 
@@ -798,3 +799,97 @@ class TestAgentRuntimeBasics:
             )
 
         assert executed == []
+
+    def test_streaming_user_message_emits_segments_and_returns_final_reply(self) -> None:
+        client = _dummy_api_client()
+        client.runtime_context_role = "system"
+        client.stream_raw_text.return_value = iter(
+            [
+                '{"ja":"うん。","zh":"嗯。","tone":"开心",',
+                '"portrait":"站立待机"}\n',
+                '{"ja":"ゆっくり話そう。","zh":"慢慢聊吧。",'
+                '"tone":"中性","portrait":"站立待机"}\n',
+            ]
+        )
+        runtime = AgentRuntime(
+            client,
+            _dummy_system_prompt(),
+            reply_tones=["中性", "开心"],
+            reply_portraits=["站立待机"],
+        )
+        progress = []
+
+        result = runtime.handle_streaming_user_message(
+            [ChatMessage(role="user", content="今天陪我聊一会儿")],
+            progress_callback=progress.append,
+        )
+
+        assert [item.stage for item in progress] == [
+            "stream_segment",
+            "stream_segment",
+        ]
+        assert [item.reply.segments[0] for item in progress] == result.reply.segments
+        assert result.reply.translation == "嗯。\n慢慢聊吧。"
+        assert result._debug == {
+            "source": "streaming_chat",
+            "streamed": True,
+            "incomplete": False,
+        }
+        system_prompt = client.stream_raw_text.call_args.args[0]
+        assert "每完成一个句段就立刻输出一行独立 JSON" in system_prompt
+        runtime_context = client.stream_raw_text.call_args.kwargs["runtime_context"]
+        assert 'context id="runtime.agent_progress"' in runtime_context
+        client.complete_with_tools.assert_not_called()
+
+    def test_streaming_user_message_falls_back_before_first_segment(self) -> None:
+        client = _dummy_api_client()
+        client.stream_raw_text.side_effect = ApiRequestError("stream unsupported")
+        runtime = AgentRuntime(client, _dummy_system_prompt())
+
+        with pytest.raises(StreamingReplyUnavailable, match="stream unsupported"):
+            runtime.handle_streaming_user_message(
+                [ChatMessage(role="user", content="陪我聊聊")],
+                progress_callback=lambda _progress: None,
+            )
+
+    def test_streaming_user_message_keeps_completed_segments_after_disconnect(self) -> None:
+        client = _dummy_api_client()
+        client.runtime_context_role = "system"
+
+        def interrupted_stream():  # type: ignore[no-untyped-def]
+            yield '{"ja":"うん。","zh":"嗯。","tone":"中性"}\n'
+            raise ApiRequestError("connection reset")
+
+        client.stream_raw_text.return_value = interrupted_stream()
+        runtime = AgentRuntime(client, _dummy_system_prompt(), reply_tones=["中性"])
+        progress = []
+
+        result = runtime.handle_streaming_user_message(
+            [ChatMessage(role="user", content="陪我聊聊")],
+            progress_callback=progress.append,
+        )
+
+        assert result.reply.translation == "嗯。"
+        assert len(progress) == 1
+        assert result._debug == {
+            "source": "streaming_chat",
+            "streamed": True,
+            "incomplete": True,
+            "stream_error": "connection reset",
+        }
+
+    def test_streaming_translation_repair_fills_missing_chinese_subtitle(self) -> None:
+        client = _dummy_api_client()
+        client.complete_with_tools.return_value = MagicMock(content='{"zh":"你好。"}')
+        runtime = AgentRuntime(client, _dummy_system_prompt())
+
+        repaired = runtime._repair_streaming_segment_translation(
+            ChatSegment("こんにちは。", "中性", "", "站立待机")
+        )
+
+        assert repaired == ChatSegment(
+            "こんにちは。",
+            "中性",
+            "你好。",
+            "站立待机",
+        )

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import json
 from typing import Any
 
 from app.core.retry_policy import MAX_AUTO_RETRY_ATTEMPTS
@@ -1018,3 +1019,108 @@ def test_parse_chat_reply_suppresses_tts_for_safe_parse_failure() -> None:
 
     assert reply.segments[0].text
     assert reply.segments[0].suppress_tts is True
+
+
+def test_stream_raw_text_parses_openai_sse_and_sends_stream_flag(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    captured: dict[str, Any] = {}
+    client = OpenAICompatibleClient(
+        ApiSettings(
+            base_url="https://api.example.com/v1",
+            api_key="key",
+            model="model",
+        )
+    )
+
+    def fake_iter(_opener, request, **kwargs):  # type: ignore[no-untyped-def]
+        captured["url"] = request.full_url
+        captured["payload"] = json.loads(request.data.decode("utf-8"))
+        captured["accept"] = request.get_header("Accept")
+        captured["cancel_checker"] = kwargs.get("cancel_checker")
+        yield b'data: {"choices":[{"delta":{"role":"assistant"}}]}\n'
+        yield b'data: {"choices":[{"delta":{"content":"kon"}}]}\n'
+        yield b'data: {"choices":[{"delta":{"content":[{"type":"text","text":"nichiwa"}]}}]}\n'
+        yield b"data: [DONE]\n"
+
+    monkeypatch.setattr("app.llm.api_client.iter_url_lines_cancellable", fake_iter)
+
+    chunks = list(
+        client.stream_raw_text(
+            "system",
+            [{"role": "user", "content": "hello"}],
+            top_p=0.9,
+        )
+    )
+
+    assert chunks == ["kon", "nichiwa"]
+    assert captured["url"] == "https://api.example.com/v1/chat/completions"
+    assert captured["accept"] == "text/event-stream"
+    assert captured["payload"]["stream"] is True
+    assert captured["payload"]["top_p"] == 0.9
+
+
+def test_stream_raw_text_falls_back_runtime_context_role(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    client = OpenAICompatibleClient(
+        ApiSettings("https://api.example.com/v1", "key", "model")
+    )
+    calls: list[dict[str, Any]] = []
+
+    def fake_stream(payload, **_kwargs):  # type: ignore[no-untyped-def]
+        calls.append(payload)
+        if len(calls) == 1:
+            raise ApiRequestError("system role is not allowed after user messages")
+        return iter(["ok"])
+
+    monkeypatch.setattr(
+        client,
+        "_stream_chat_completions_with_compatibility_fallbacks",
+        fake_stream,
+    )
+
+    chunks = list(
+        client.stream_raw_text(
+            "system",
+            [{"role": "user", "content": "hello"}],
+            runtime_context="runtime facts",
+        )
+    )
+
+    assert chunks == ["ok"]
+    assert calls[0]["messages"][-1] == {
+        "role": "system",
+        "content": "runtime facts",
+    }
+    assert calls[1]["messages"][-1]["role"] == "user"
+    assert "runtime facts" in calls[1]["messages"][-1]["content"]
+    assert client.runtime_context_role == "user"
+
+
+def test_stream_compatibility_fallback_removes_rejected_params(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    client = OpenAICompatibleClient(
+        ApiSettings("https://api.example.com/v1", "key", "model")
+    )
+    calls: list[dict[str, Any]] = []
+
+    def fake_stream(payload, **_kwargs):  # type: ignore[no-untyped-def]
+        calls.append(dict(payload))
+        if "response_format" in payload:
+            raise ApiRequestError("unsupported response_format json_object")
+        if "temperature" in payload:
+            raise ApiRequestError("temperature only supports the default value")
+        return iter(["ok"])
+
+    monkeypatch.setattr(client, "_stream_chat_completions", fake_stream)
+
+    chunks = list(
+        client.stream_raw_text(
+            "system",
+            [{"role": "user", "content": "hello"}],
+            response_format={"type": "json_object"},
+        )
+    )
+
+    assert chunks == ["ok"]
+    assert len(calls) == MAX_AUTO_RETRY_ATTEMPTS
+    assert "response_format" in calls[0]
+    assert "response_format" not in calls[1]
+    assert "temperature" in calls[1]
+    assert "temperature" not in calls[2]

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -93,3 +93,71 @@ def test_read_url_cancellable_returns_without_waiting_for_blocked_read() -> None
         )
 
     assert time.monotonic() - started < 1
+
+
+def test_iter_url_lines_cancellable_yields_complete_lines() -> None:
+    closed = False
+
+    class FakeResponse:
+        def __init__(self) -> None:
+            self.lines = iter([b"first\n", b"second\n", b""])
+
+        def __enter__(self):  # type: ignore[no-untyped-def]
+            return self
+
+        def __exit__(self, *_args):  # type: ignore[no-untyped-def]
+            self.close()
+
+        def readline(self) -> bytes:
+            return next(self.lines)
+
+        def close(self) -> None:
+            nonlocal closed
+            closed = True
+
+    lines = list(
+        http_client.iter_url_lines_cancellable(
+            lambda *_args, **_kwargs: FakeResponse(),
+            "https://example.test",
+            timeout=60,
+        )
+    )
+
+    assert lines == [b"first\n", b"second\n"]
+    assert closed
+
+
+def test_iter_url_lines_cancellable_closes_blocked_stream_on_cancel() -> None:
+    token = CancellationToken()
+    entered = threading.Event()
+    released = threading.Event()
+
+    class BlockingResponse:
+        def __enter__(self):  # type: ignore[no-untyped-def]
+            return self
+
+        def __exit__(self, *_args):  # type: ignore[no-untyped-def]
+            return None
+
+        def readline(self) -> bytes:
+            entered.set()
+            released.wait(5)
+            return b""
+
+        def close(self) -> None:
+            released.set()
+
+    threading.Thread(target=lambda: (entered.wait(1), token.cancel()), daemon=True).start()
+    started = time.monotonic()
+    with pytest.raises(OperationCancelled):
+        list(
+            http_client.iter_url_lines_cancellable(
+                lambda *_args, **_kwargs: BlockingResponse(),
+                "https://example.test",
+                timeout=60,
+                cancel_checker=token.throw_if_cancelled,
+            )
+        )
+
+    assert released.wait(1)
+    assert time.monotonic() - started < 1

--- a/tests/unit/test_plugin_services.py
+++ b/tests/unit/test_plugin_services.py
@@ -65,6 +65,40 @@ def test_set_backends_wires_mobile_theme_sink() -> None:
     assert theme["text_color"] == DEFAULT_THEME_SETTINGS.text_color
 
 
+def test_set_backends_wires_mobile_stream_sink() -> None:
+    services = PluginServices()
+    progress: list[dict[str, object]] = []
+
+    def stream_chat(
+        character_id: str,
+        text: str,
+        image_data_url: str,
+        callback,  # type: ignore[no-untyped-def]
+    ) -> dict[str, object]:
+        callback({"event": "segment", "text": text})
+        return {
+            "character_id": character_id,
+            "image": image_data_url,
+            "reply": "done",
+        }
+
+    services.set_backends(mobile_chat_stream_sink=stream_chat)
+
+    result = services.mobile.chat_stream(
+        "demo",
+        "hello",
+        "data:image/png;base64,AA==",
+        progress_callback=progress.append,
+    )
+
+    assert progress == [{"event": "segment", "text": "hello"}]
+    assert result == {
+        "character_id": "demo",
+        "image": "data:image/png;base64,AA==",
+        "reply": "done",
+    }
+
+
 def test_mobile_service_requires_permission() -> None:
     services = PluginServices()
 

--- a/tests/unit/test_sakura_mobile.py
+++ b/tests/unit/test_sakura_mobile.py
@@ -10,13 +10,15 @@ from types import SimpleNamespace
 
 import pytest
 
-from app.agent.actions import AgentResult
+from app.agent.actions import AgentProgress, AgentResult
 from app.agent.runtime_limits import RuntimeLoopSettings
 from app.agent.tools import Tool, ToolRegistry
 from app.config.character_loader import CharacterProfile
 from app.core.http_client import urlopen_direct_for_loopback
 from app.core.mobile_chat_bridge import MobileChatBridge, MobileChatBusyError
+from app.core.mobile_chat_worker import MobileChatWorker
 from app.llm.chat_reply import ChatReply, ChatSegment
+from app.llm.streaming_reply import STREAMING_REPLY_STAGE
 from app.plugins.capabilities import PluginCapabilityRegistry
 from app.storage.chat_history import ChatHistoryEntry
 from app.ui.theme import ThemeSettings, theme_colors_to_mapping
@@ -116,6 +118,17 @@ def test_mobile_page_refreshes_history_before_submit_message() -> None:
     submit_handler = html[html.index("form.addEventListener('submit'") : html.index("loadCharacters().catch")]
 
     assert submit_handler.index("await loadHistory();") < submit_handler.index("addMessage('user'")
+
+
+def test_mobile_page_uses_streaming_chat_endpoint() -> None:
+    html = mobile_server._mobile_html("secret")
+    submit_handler = html[html.index("form.addEventListener('submit'") : html.index("loadCharacters().catch")]
+
+    assert "api('/api/chat/stream')" in html
+    assert "response.body.getReader()" in html
+    assert "eventName !== 'segment'" in submit_handler
+    assert "streamedSegmentCount" in submit_handler
+    assert "fetchJson('/api/chat'" not in submit_handler
 
 
 def test_mobile_page_writes_theme_variables() -> None:
@@ -223,6 +236,101 @@ def test_mobile_chat_busy_returns_409() -> None:
         thread.join(timeout=5)
 
 
+def test_mobile_chat_stream_emits_segments_before_done() -> None:
+    class StreamingBackend:
+        def characters(self) -> list[dict[str, str]]:
+            return []
+
+        def history(self, _character_id: str, *, limit: int = 50) -> list[dict[str, str]]:
+            return []
+
+        def chat_stream(
+            self,
+            _character_id: str,
+            _text: str,
+            _image_data_url: str = "",
+            *,
+            progress_callback,  # type: ignore[no-untyped-def]
+        ) -> dict[str, object]:
+            progress_callback(
+                {
+                    "event": "segment",
+                    "stage": STREAMING_REPLY_STAGE,
+                    "segments": [{"content": "第一句。"}],
+                    "metadata": {"segment_index": 0},
+                }
+            )
+            return {
+                "reply": "第一句。",
+                "segments": [{"content": "第一句。"}],
+                "streamed": True,
+            }
+
+    base_dir = _runtime_root("stream")
+    server = mobile_server.run_mobile_server(
+        base_dir,
+        StreamingBackend(),
+        host="127.0.0.1",
+        port=0,
+        token="secret",
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        port = server.server_address[1]
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{port}/api/chat/stream?token=secret",
+            data=b'{"text":"hello"}',
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urlopen_direct_for_loopback(request, timeout=5) as response:
+            payload = response.read().decode("utf-8")
+            content_type = response.headers.get("Content-Type", "")
+
+        assert content_type.startswith("text/event-stream")
+        assert "event: ready" in payload
+        assert "event: segment" in payload
+        assert '"content": "第一句。"' in payload
+        assert "event: done" in payload
+        assert payload.index("event: segment") < payload.index("event: done")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_mobile_chat_worker_forwards_stream_callback() -> None:
+    progress: list[dict[str, object]] = []
+    results: list[dict[str, object]] = []
+
+    class Bridge:
+        def execute_chat(
+            self,
+            _character_id: str,
+            _text: str,
+            _image_data_url: str,
+            *,
+            progress_callback,  # type: ignore[no-untyped-def]
+        ) -> dict[str, object]:
+            progress_callback({"event": "segment"})
+            return {"reply": "done"}
+
+    worker = MobileChatWorker(
+        Bridge(),
+        "demo",
+        "hello",
+        "",
+        progress_callback=progress.append,
+    )
+    worker.finished.connect(results.append)
+
+    worker.run()
+
+    assert progress == [{"event": "segment"}]
+    assert results == [{"reply": "done"}]
+
+
 def test_mobile_session_keeps_empty_tool_registry(monkeypatch: pytest.MonkeyPatch) -> None:
     import app.core.mobile_chat_bridge as bridge_module
     base_dir = _runtime_root("empty_tools")
@@ -317,6 +425,28 @@ def test_mobile_chat_returns_without_inline_memory_curation(monkeypatch: pytest.
         def handle_user_message(self, _messages: list[object]) -> AgentResult:
             return AgentResult(ChatReply([ChatSegment("返事。", translation="回复。")]))
 
+        def should_stream_user_message(self, _messages: list[object]) -> bool:
+            return True
+
+        def handle_streaming_user_message(
+            self,
+            _messages: list[object],
+            *,
+            progress_callback,  # type: ignore[no-untyped-def]
+        ) -> AgentResult:
+            segment = ChatSegment("続き。", translation="继续。")
+            progress_callback(
+                AgentProgress(
+                    ChatReply([segment]),
+                    stage=STREAMING_REPLY_STAGE,
+                    metadata={"segment_index": 0},
+                )
+            )
+            return AgentResult(
+                ChatReply([segment]),
+                _debug={"streamed": True},
+            )
+
     class HistoryStore:
         def __init__(self) -> None:
             self.entries: list[ChatHistoryEntry] = []
@@ -391,6 +521,32 @@ def test_mobile_chat_returns_without_inline_memory_curation(monkeypatch: pytest.
     assert result["reply"] == "回复。"
     assert completed.payload is not None
     assert [entry.role for entry in history_store.load()] == ["user", "assistant"]
+
+    progress: list[dict[str, object]] = []
+    stream_result = MobileChatBridge(host).execute_chat(
+        "demo",
+        "stream",
+        progress_callback=progress.append,
+    )
+
+    assert stream_result["reply"] == "继续。"
+    assert stream_result["streamed"] is True
+    assert progress == [
+        {
+            "event": "segment",
+            "stage": STREAMING_REPLY_STAGE,
+            "segments": [
+                {
+                    "content": "继续。",
+                    "raw_content": "続き。",
+                    "translation": "继续。",
+                    "tone": "中性",
+                    "portrait": "",
+                }
+            ],
+            "metadata": {"segment_index": 0},
+        }
+    ]
 
 
 def test_mobile_chat_only_exposes_current_character() -> None:

--- a/tests/unit/test_streaming_reply.py
+++ b/tests/unit/test_streaming_reply.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import json
+
+from app.llm.chat_reply import ChatSegment
+from app.llm.streaming_reply import (
+    StreamedReplyParser,
+    is_streaming_candidate,
+    needs_streaming_translation_repair,
+)
+
+
+def test_parser_streams_jsonl_when_first_chunk_is_only_open_brace() -> None:
+    parser = StreamedReplyParser(["中性"])
+
+    assert parser.feed("{") == []
+    segments = parser.feed(
+        '"ja":"ちゃんと聞いてるよ。","zh":"我在认真听。",'
+        '"tone":"中性","portrait":"站立待机"}\n'
+    )
+
+    assert segments == [
+        ChatSegment(
+            "ちゃんと聞いてるよ。",
+            "中性",
+            "我在认真听。",
+            "站立待机",
+        )
+    ]
+    assert parser.finish() == []
+
+
+def test_parser_accepts_pretty_structured_json_at_finish() -> None:
+    parser = StreamedReplyParser(["中性"])
+    payload = json.dumps(
+        {
+            "segments": [
+                {
+                    "ja": "大丈夫だよ。",
+                    "zh": "没关系。",
+                    "tone": "中性",
+                    "portrait": "站立待机",
+                }
+            ]
+        },
+        ensure_ascii=False,
+        indent=2,
+    )
+
+    assert parser.feed(payload) == []
+    assert parser.finish() == [
+        ChatSegment("大丈夫だよ。", "中性", "没关系。", "站立待机")
+    ]
+
+
+def test_parser_keeps_user_facing_lines_that_mention_protocol_terms() -> None:
+    parser = StreamedReplyParser(["中性"])
+
+    segments = parser.feed(
+        "「segments」は内部字段だよ。 || 「segments」是内部字段。 || 中性 || 站立待机\n"
+    )
+
+    assert segments == [
+        ChatSegment(
+            "「segments」は内部字段だよ。",
+            "中性",
+            "「segments」是内部字段。",
+            "站立待机",
+        )
+    ]
+
+
+def test_parser_drops_incomplete_json_tail_instead_of_showing_protocol_text() -> None:
+    parser = StreamedReplyParser(["中性"])
+    first = parser.feed(
+        '{"ja":"うん。","zh":"嗯。","tone":"中性"}\n'
+        '{"ja":"途中で切れた。"'
+    )
+
+    assert first == [ChatSegment("うん。", "中性", "嗯。")]
+    assert parser.finish() == []
+
+
+def test_streaming_candidate_is_conservative_about_tools_memory_and_media() -> None:
+    assert is_streaming_candidate(
+        [{"role": "user", "content": "Sakura，今天陪我聊一会儿"}]
+    )
+    assert not is_streaming_candidate(
+        [{"role": "user", "content": "你还记得我上次说的偏好吗？"}]
+    )
+    assert not is_streaming_candidate(
+        [{"role": "user", "content": "看看这个页面：https://example.com"}]
+    )
+    assert not is_streaming_candidate(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "看看这张图"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,AAAA"},
+                    },
+                ],
+            }
+        ]
+    )
+
+
+def test_translation_repair_only_targets_japanese_without_chinese_subtitle() -> None:
+    assert needs_streaming_translation_repair(ChatSegment("こんにちは。"))
+    assert needs_streaming_translation_repair(
+        ChatSegment("こんにちは。", translation="こんにちは。")
+    )
+    assert not needs_streaming_translation_repair(
+        ChatSegment("こんにちは。", translation="你好。")
+    )
+    assert not needs_streaming_translation_repair(
+        ChatSegment("你好。", translation="你好。")
+    )


### PR DESCRIPTION
## 改动

- 为 OpenAI 兼容 `chat/completions` 增加 `stream=true` 请求，解析 SSE 和逐行 JSON 数据。
- 流式请求支持取消、首块前重试、运行时上下文角色回退以及不兼容参数自动移除；开始输出后不再自动重试，避免重复回复。
- 普通纯文字聊天走低延迟 fast path；工具调用、图片、URL、浏览器/桌面操作和记忆指令继续使用完整 Agent 链路。
- 模型每完成一个结构化句段就发送到桌面字幕与 TTS 队列；流中断时保留已完成句段，最终结果不会重复播放。
- 手机网页新增 `POST /api/chat/stream`，通过 `ready`、`segment`、`done`、`error` SSE 事件逐段显示，等待期间每 10 秒保活。
- 原有 `/api/chat` JSON 接口保持兼容；图片或不适合流式处理的手机请求自动回退完整回复。

## 用户影响

普通聊天不再等待整段模型输出完成。桌面端和手机网页都会在第一个完整句段生成后立即展示，后续句段继续进入同一回复序列。

## 验证

- 完整测试：1479 passed, 3 skipped
- 流式与手机相关宽范围测试：417 passed
- 移动网页 JavaScript 通过 `node --check`
- 真实浏览器验证：约 450ms 时 DOM 只有第一句，第二句稍后到达；完成后无重复消息
- 390x844 手机视口截图检查通过，无控件或消息重叠
- OpenAI 兼容中转站实测：首个有效块约 2583ms，3 个句段，总耗时约 3539ms
- `git diff --check` 与敏感信息扫描通过

## 兼容性与风险

没有持久化配置格式变化。不支持流式的供应商会自动回退原有完整 Agent 请求。fast path 使用保守规则排除可能需要工具或媒体处理的消息。手机浏览器断开连接后，宿主已经开始的回合仍会完成并写入历史，避免产生半条历史，但可能继续消耗当前一次模型请求。