### PR TITLE
 feat(tts): 支持远程 TTS 服务器角色文件夹路径映射

### DIFF
--- a/app/config/settings_service.py
+++ b/app/config/settings_service.py
@@ -414,6 +414,8 @@ class AppSettingsService:
         ref_lang = "ja"
         text_lang = "ja"
         timeout_seconds = _int_value(provider_data.get("timeout_seconds"), 60)
+        use_remote_paths = _bool_value(provider_data.get("use_remote_paths"), False)
+        remote_characters_path = str(provider_data.get("remote_characters_path", ""))
         onnx_model_dir = _optional_path(genie_tts.get("onnx_model_dir"), self.base_dir)
         if character_profile is not None:
             if provider == TTS_PROVIDER_GENIE and onnx_model_dir is None:
@@ -431,6 +433,8 @@ class AppSettingsService:
                 tts_config_path=tts_config_path,
                 onnx_model_dir=onnx_model_dir,
                 validate_enabled=validate_enabled,
+                use_remote_paths=use_remote_paths,
+                remote_characters_path=remote_characters_path,
             )
         else:
             if provider == TTS_PROVIDER_GENIE and onnx_model_dir is None:
@@ -487,6 +491,8 @@ class AppSettingsService:
                 "ref_lang": settings.ref_lang.strip(),
                 "text_lang": settings.text_lang.strip(),
                 "timeout_seconds": int(settings.timeout_seconds),
+                "use_remote_paths": bool(settings.use_remote_paths),
+                "remote_characters_path": settings.remote_characters_path,
             }
         data["tts"] = tts_data
         save_yaml_mapping(self.api_config_path, data)

--- a/app/ui/tauri_settings.py
+++ b/app/ui/tauri_settings.py
@@ -1121,6 +1121,7 @@ class TauriSettingsProcess(QObject):
         self.model = model
         self.parent_widget = parent_widget
         self._process: QProcess | None = None
+        self._rpc_response_file = None
         self._nonce = ""
         self._done = False
         self._cleaned = False
@@ -1145,18 +1146,58 @@ class TauriSettingsProcess(QObject):
         process.setProgram(str(binary))
         process.setArguments([])
         process.setWorkingDirectory(str(self.base_dir))
-        process.setProcessEnvironment(QProcessEnvironment.systemEnvironment())
-        process.started.connect(self._handle_started)
-        process.finished.connect(self._handle_finished)
-        process.errorOccurred.connect(self._handle_error)
-        process.readyReadStandardOutput.connect(self._handle_stdout)
 
-        self._process = process
-        self._nonce = str(request["nonce"])
-        self._request_payload = json.dumps(request, ensure_ascii=False).encode("utf-8")
-        self._startup_focus_complete = False
-        process.start()
-        return True
+        rpc_r = None
+        rpc_w = None
+        try:
+            if sys.platform != "win32":
+                # 绕过 std::io::stdin() 的内部 Mutex/BufReader 冲突（改用独立 pipe）
+                _os = __import__("os")
+                rpc_r, rpc_w = _os.pipe()
+                _os.set_inheritable(rpc_r, True)
+                _os.set_inheritable(rpc_w, False)
+                self._rpc_response_file = _os.fdopen(rpc_w, "wb", buffering=0)
+
+                env = QProcessEnvironment.systemEnvironment()
+                env.insert("SAKURA_RPC_RESPONSE_FD", str(rpc_r))
+                process.setProcessEnvironment(env)
+                process.setProcessChannelMode(QProcess.ForwardedErrorChannel)
+            else:
+                self._rpc_response_file = None
+                process.setProcessEnvironment(QProcessEnvironment.systemEnvironment())
+
+            process.started.connect(self._handle_started)
+            process.finished.connect(self._handle_finished)
+            process.errorOccurred.connect(self._handle_error)
+            process.readyReadStandardOutput.connect(self._handle_stdout)
+
+            self._process = process
+            self._nonce = str(request["nonce"])
+            self._request_payload = json.dumps(request, ensure_ascii=False).encode("utf-8")
+            self._startup_focus_complete = False
+            process.start()
+            if sys.platform != "win32" and rpc_r is not None:
+                _os.close(rpc_r)  # 父进程不再需要读端，子进程已继承
+                rpc_r = None
+            return True
+        except Exception as exc:
+            if sys.platform != "win32":
+                _os = __import__("os")
+                if rpc_r is not None:
+                    try:
+                        _os.close(rpc_r)
+                    except OSError:
+                        pass
+                if rpc_w is not None:
+                    try:
+                        if self._rpc_response_file is not None:
+                            self._rpc_response_file.close()
+                            self._rpc_response_file = None
+                        else:
+                            _os.close(rpc_w)
+                    except OSError:
+                        pass
+            raise exc
 
     def focus_window(self) -> bool:
         """把已打开的 Tauri 设置窗口还原并前置（用于重复唤起时找回最小化的窗口）。"""
@@ -1626,9 +1667,17 @@ class TauriSettingsProcess(QObject):
             + "\n"
         )
         try:
-            process.write(line.encode("utf-8"))
-        except RuntimeError:
-            return
+            rpc_file = self._rpc_response_file
+            if rpc_file is not None:
+                rpc_file.write(line.encode("utf-8"))
+                rpc_file.flush()
+            else:
+                process.write(line.encode("utf-8"))
+        except (OSError, RuntimeError) as exc:
+            if not self._done:
+                self._done = True
+                self.failed.emit(f"RPC 响应通道写入失败：{exc}")
+                self._cleanup()
 
     def _queue_rpc_response(
         self,

--- a/app/ui/tauri_settings.py
+++ b/app/ui/tauri_settings.py
@@ -286,6 +286,8 @@ class TauriTtsResult:
     python_path: str = ""
     tts_config_path: str = ""
     timeout_seconds: int = 60
+    use_remote_paths: bool = False
+    remote_characters_path: str = ""
 
 
 @dataclass(frozen=True)
@@ -357,6 +359,8 @@ def tts_settings_from_tauri_result(
     work_dir = _optional_tauri_path(getattr(result_tts, "work_dir", ""), base_dir)
     python_path = _optional_tauri_path(getattr(result_tts, "python_path", ""), base_dir)
     tts_config_path = _optional_tauri_path(getattr(result_tts, "tts_config_path", ""), base_dir)
+    use_remote_paths = bool(getattr(result_tts, "use_remote_paths", False))
+    remote_characters_path = str(getattr(result_tts, "remote_characters_path", ""))
     selected_voice = getattr(selected_profile, "voice", None)
     if enabled and selected_voice is None:
         enabled = False
@@ -385,6 +389,9 @@ def tts_settings_from_tauri_result(
             text_lang=text_lang,
             timeout_seconds=timeout_seconds,
             tone_references=previous.tone_references,
+            use_remote_paths=use_remote_paths,
+            remote_characters_path=remote_characters_path,
+            character_package_dir=getattr(selected_profile, "package_dir", None),
         )
     else:
         settings = GPTSoVITSTTSSettings.from_character_profile(
@@ -400,6 +407,8 @@ def tts_settings_from_tauri_result(
             tts_config_path=tts_config_path,
             onnx_model_dir=onnx_model_dir,
             validate_enabled=False,
+            use_remote_paths=use_remote_paths,
+            remote_characters_path=remote_characters_path,
         )
     return settings
 
@@ -2151,6 +2160,8 @@ def _tts_to_mapping(settings: GPTSoVITSTTSSettings | None, base_dir: Path | None
         "tts_config_path": _path_to_text(current.tts_config_path),
         "provider_defaults": _tts_provider_defaults(base_dir),
         "timeout_seconds": _clamp_int_value(current.timeout_seconds, 1, 600),
+        "use_remote_paths": bool(current.use_remote_paths),
+        "remote_characters_path": current.remote_characters_path,
     }
 
 
@@ -2602,6 +2613,8 @@ def _tts_from_mapping_required(mapping: dict[str, Any]) -> TauriTtsResult:
         python_path=_required_str(mapping, "python_path").strip(),
         tts_config_path=_required_str(mapping, "tts_config_path").strip(),
         timeout_seconds=_clamp_int_value(_required_int(mapping, "timeout_seconds"), 1, 600),
+        use_remote_paths=_required_bool(mapping, "use_remote_paths"),
+        remote_characters_path=_required_str(mapping, "remote_characters_path"),
     )
 
 
@@ -2624,6 +2637,8 @@ def _tts_settings_for_profile(
     work_dir = _optional_path_for_tauri(result_tts.work_dir, base_dir)
     python_path = _optional_path_for_tauri(result_tts.python_path, base_dir)
     tts_config_path = _optional_path_for_tauri(result_tts.tts_config_path, base_dir)
+    use_remote_paths = bool(result_tts.use_remote_paths)
+    remote_characters_path = str(result_tts.remote_characters_path)
     if selected_voice is None or not hasattr(profile, "package_dir"):
         return GPTSoVITSTTSSettings(
             enabled=False,
@@ -2640,6 +2655,9 @@ def _tts_settings_for_profile(
             ref_lang=ref_lang,
             text_lang=text_lang,
             timeout_seconds=result_tts.timeout_seconds,
+            use_remote_paths=use_remote_paths,
+            remote_characters_path=remote_characters_path,
+            character_package_dir=getattr(profile, "package_dir", None),
         )
     return GPTSoVITSTTSSettings.from_character_profile(
         character_profile=profile,
@@ -2654,6 +2672,8 @@ def _tts_settings_for_profile(
         tts_config_path=tts_config_path,
         onnx_model_dir=onnx_model_dir,
         validate_enabled=False,
+        use_remote_paths=use_remote_paths,
+        remote_characters_path=remote_characters_path,
     )
 
 

--- a/app/voice/tts_service.py
+++ b/app/voice/tts_service.py
@@ -1093,14 +1093,18 @@ class TTSServiceSupervisor:
         weights_path: Path,
         fail_callback: Callable[[str], None],
     ) -> bool:
+        remote_path = (
+            self.settings.to_remote_path(weights_path)
+            or str(weights_path)
+        )
         url = _build_tts_endpoint_url(
             self.settings.api_url,
             endpoint,
-            {"weights_path": str(weights_path)},
+            {"weights_path": remote_path},
         )
         request = urllib.request.Request(url=url, method="GET")
         try:
-            log_event("TTS", "请求切换权重", {"endpoint": endpoint, "weights_path": weights_path})
+            log_event("TTS", "请求切换权重", {"endpoint": endpoint, "weights_path": weights_path, "remote_path": remote_path})
             with urlopen_direct_for_loopback(request, timeout=self.settings.timeout_seconds) as response:
                 response.read()
                 log_event(
@@ -1109,6 +1113,7 @@ class TTSServiceSupervisor:
                     {
                         "endpoint": endpoint,
                         "weights_path": weights_path,
+                        "remote_path": remote_path,
                         "status": getattr(response, "status", None),
                     },
                 )

--- a/app/voice/tts_settings.py
+++ b/app/voice/tts_settings.py
@@ -56,6 +56,28 @@ class GPTSoVITSTTSSettings:
     text_lang: str = "ja"
     timeout_seconds: int = 60
     tone_references: dict[str, list[ToneReference]] = field(default_factory=dict)
+    use_remote_paths: bool = False
+    remote_characters_path: str = ""
+    character_package_dir: Path | None = None
+
+    def __post_init__(self) -> None:
+        cleaned = self.remote_characters_path.strip().strip('"').strip("'")
+        if cleaned != self.remote_characters_path:
+            object.__setattr__(self, "remote_characters_path", cleaned)
+
+    def to_remote_path(self, local_path: Path) -> str | None:
+        """将本地绝对路径映射为远程服务器路径（POSIX 风格）。"""
+        if not self.use_remote_paths or not self.remote_characters_path:
+            return None
+        pkg_dir = self.character_package_dir
+        if pkg_dir is None:
+            return None
+        try:
+            relative = local_path.relative_to(pkg_dir)
+        except ValueError:
+            return None
+        remote = Path(self.remote_characters_path) / relative
+        return remote.as_posix()
 
     @classmethod
     def from_character_profile(
@@ -72,15 +94,18 @@ class GPTSoVITSTTSSettings:
         tts_config_path: Path | None = None,
         onnx_model_dir: Path | None = None,
         validate_enabled: bool = True,
+        use_remote_paths: bool = False,
+        remote_characters_path: str = "",
     ) -> "GPTSoVITSTTSSettings":
         provider = _normalize_tts_provider(provider, enabled)
+        package_dir = character_profile.package_dir
         if character_profile.voice is None:
             settings = cls(
                 provider=provider,
                 enabled=enabled,
                 api_url=api_url,
-                ref_audio_path=character_profile.package_dir,
-                ref_text_path=character_profile.package_dir,
+                ref_audio_path=package_dir,
+                ref_text_path=package_dir,
                 ref_text="",
                 ref_lang=ref_lang,
                 text_lang=text_lang,
@@ -90,6 +115,9 @@ class GPTSoVITSTTSSettings:
                 tts_config_path=tts_config_path,
                 character_name=character_profile.display_name or character_profile.id,
                 onnx_model_dir=onnx_model_dir,
+                use_remote_paths=use_remote_paths,
+                remote_characters_path=remote_characters_path,
+                character_package_dir=package_dir,
             )
             if enabled and validate_enabled:
                 settings.validate()
@@ -98,15 +126,15 @@ class GPTSoVITSTTSSettings:
         voice = character_profile.voice
         tone_references = _load_tone_references(
             voice.tone_ref_path,
-            character_profile.package_dir,
+            package_dir,
         )
         neutral_reference = _select_neutral_reference(tone_references)
         settings = cls(
             provider=provider,
             enabled=enabled,
             api_url=api_url,
-            ref_audio_path=neutral_reference.ref_audio_path if neutral_reference else character_profile.package_dir,
-            ref_text_path=neutral_reference.ref_audio_path if neutral_reference else character_profile.package_dir,
+            ref_audio_path=neutral_reference.ref_audio_path if neutral_reference else package_dir,
+            ref_text_path=neutral_reference.ref_audio_path if neutral_reference else package_dir,
             ref_text=neutral_reference.ref_text if neutral_reference else "",
             gpt_model_path=voice.gpt_model_path,
             sovits_model_path=voice.sovits_model_path,
@@ -119,6 +147,9 @@ class GPTSoVITSTTSSettings:
             text_lang=text_lang,
             timeout_seconds=timeout_seconds,
             tone_references=tone_references,
+            use_remote_paths=use_remote_paths,
+            remote_characters_path=remote_characters_path,
+            character_package_dir=package_dir,
         )
         if enabled and validate_enabled:
             settings.validate()

--- a/app/voice/tts_synthesis.py
+++ b/app/voice/tts_synthesis.py
@@ -160,13 +160,17 @@ class GPTSoVITSSynthesisEngine:
                 return None
 
             reference = queue._select_reference(request.tone)
+            ref_audio_path = (
+                settings.to_remote_path(reference.ref_audio_path)
+                or str(reference.ref_audio_path)
+            )
             payload = {
                 "text": request.text,
                 "text_lang": _resolve_request_text_lang(
                     request.text,
                     settings.text_lang,
                 ),
-                "ref_audio_path": str(reference.ref_audio_path),
+                "ref_audio_path": ref_audio_path,
                 "prompt_text": reference.ref_text,
                 "prompt_lang": reference.ref_lang,
                 "text_split_method": "cut1",

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sys
 import ctypes
 import faulthandler
@@ -402,8 +403,22 @@ def _format_data_migration_failure(report: MigrationReport) -> str:
     )
 
 
+def _normalize_proxy_env() -> None:
+    """将环境变量中 ``socks://`` scheme 规范化为 ``socks5://``。
+
+    httpx 只识别 ``http://``、``https://`` 和 ``socks5://`` 三种 proxy scheme，
+    不识别 ``socks://``。部分工具（如 clash）设的 ``ALL_PROXY=socks://…`` 会
+    导致 httpx 初始化时抛出 ``ValueError: Unknown scheme for proxy URL``。
+    """
+    for key in ("ALL_PROXY", "all_proxy"):
+        value = os.environ.get(key)
+        if value and value.startswith("socks://"):
+            os.environ[key] = "socks5://" + value[len("socks://"):]
+
+
 def main() -> int:
     _enable_crash_diagnostics(BASE_DIR)
+    _normalize_proxy_env()
     qInstallMessageHandler(_qt_message_handler)
     _configure_windows_high_dpi()
     app = QApplication(sys.argv)

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -4948,6 +4948,8 @@ def _tauri_settings_result_payload(theme_payload: dict[str, object]) -> dict[str
             "python_path": "",
             "tts_config_path": "",
             "timeout_seconds": 60,
+            "use_remote_paths": False,
+            "remote_characters_path": "",
         },
         "system_extra": {
             "startup": {
@@ -5036,6 +5038,8 @@ def test_tauri_settings_result_parser_accepts_hidden_empty_tts_config_path() -> 
         "python_path": "",
         "tts_config_path": "",
         "timeout_seconds": 60,
+        "use_remote_paths": False,
+        "remote_characters_path": "",
     }
 
     result = parse_tauri_settings_payload(payload, expected_nonce="nonce")

--- a/tests/unit/test_tts.py
+++ b/tests/unit/test_tts.py
@@ -2171,3 +2171,90 @@ def test_purge_tts_cache_removes_residual_files_keeps_dir() -> None:
     assert cache_dir.is_dir()
     assert sub_dir.is_dir()  # 非文件项不应被删除
     assert not any(entry.is_file() for entry in cache_dir.iterdir())
+
+
+def test_gpt_sovits_settings_to_remote_path() -> None:
+    """验证 to_remote_path() 在启用远程路径时正确映射，关闭时返回 None。"""
+    settings = GPTSoVITSTTSSettings(
+        enabled=True,
+        api_url="http://127.0.0.1:9880/tts",
+        ref_audio_path=Path("/local/characters/Sophia/tone_refs/ref.wav"),
+        ref_text_path=Path("/local/characters/Sophia/tone_refs/ref.wav"),
+        ref_text="hello",
+        character_package_dir=Path("/local/characters/Sophia"),
+        use_remote_paths=True,
+        remote_characters_path="C:/Users/UIOPQ/Portable/sakura/characters/Sophia_Lancaster_2",
+    )
+
+    remote = settings.to_remote_path(
+        Path("/local/characters/Sophia/tone_refs/VO03_0056.wav")
+    )
+    assert remote == (
+        "C:/Users/UIOPQ/Portable/sakura/characters/"
+        "Sophia_Lancaster_2/tone_refs/VO03_0056.wav"
+    )
+
+    remote = settings.to_remote_path(
+        Path("/local/characters/Sophia/models/gpt.ckpt")
+    )
+    assert remote == (
+        "C:/Users/UIOPQ/Portable/sakura/characters/"
+        "Sophia_Lancaster_2/models/gpt.ckpt"
+    )
+
+    settings_disabled = GPTSoVITSTTSSettings(
+        enabled=True,
+        api_url="http://127.0.0.1:9880/tts",
+        ref_audio_path=Path("/local/characters/Sophia/tone_refs/ref.wav"),
+        ref_text_path=Path("/local/characters/Sophia/tone_refs/ref.wav"),
+        ref_text="hello",
+        character_package_dir=Path("/local/characters/Sophia"),
+        use_remote_paths=False,
+        remote_characters_path="",
+    )
+    assert settings_disabled.to_remote_path(Path("/local/characters/Sophia/tone_refs/ref.wav")) is None
+
+
+def test_gpt_sovits_settings_to_remote_path_no_package_dir() -> None:
+    """当 character_package_dir 为 None 时，to_remote_path 应返回 None。"""
+    settings = GPTSoVITSTTSSettings(
+        enabled=True,
+        api_url="http://127.0.0.1:9880/tts",
+        ref_audio_path=Path("/local/characters/Sophia/tone_refs/ref.wav"),
+        ref_text_path=Path("/local/characters/Sophia/tone_refs/ref.wav"),
+        ref_text="hello",
+        use_remote_paths=True,
+        remote_characters_path="C:/remote/characters/Sophia",
+        character_package_dir=None,
+    )
+    assert settings.to_remote_path(Path("/local/characters/Sophia/tone_refs/ref.wav")) is None
+
+
+def test_gpt_sovits_settings_to_remote_path_outside_package_dir() -> None:
+    """路径不在 character_package_dir 下时，to_remote_path 应返回 None。"""
+    settings = GPTSoVITSTTSSettings(
+        enabled=True,
+        api_url="http://127.0.0.1:9880/tts",
+        ref_audio_path=Path("/local/characters/Sophia/tone_refs/ref.wav"),
+        ref_text_path=Path("/local/characters/Sophia/tone_refs/ref.wav"),
+        ref_text="hello",
+        character_package_dir=Path("/local/characters/Sophia"),
+        use_remote_paths=True,
+        remote_characters_path="C:/remote/characters/Sophia",
+    )
+    assert settings.to_remote_path(Path("/etc/passwd")) is None
+
+
+def test_gpt_sovits_settings_post_init_strips_remote_path() -> None:
+    """验证 __post_init__ 会去除 remote_characters_path 中的引号。"""
+    settings = GPTSoVITSTTSSettings(
+        enabled=True,
+        api_url="http://127.0.0.1:9880/tts",
+        ref_audio_path=Path("/local/characters/Sophia/tone_refs/ref.wav"),
+        ref_text_path=Path("/local/characters/Sophia/tone_refs/ref.wav"),
+        ref_text="hello",
+        character_package_dir=Path("/local/characters/Sophia"),
+        use_remote_paths=True,
+        remote_characters_path='  "C:/remote/characters/Sophia"  ',
+    )
+    assert settings.remote_characters_path == "C:/remote/characters/Sophia"

--- a/tools/settings-tauri/frontend/index.html
+++ b/tools/settings-tauri/frontend/index.html
@@ -438,6 +438,21 @@
                 <input id="ttsApiUrl" class="wide-input" type="text" />
               </div>
               <div class="setting-row">
+                <label class="setting-row-text" for="ttsUseRemotePaths">
+                  <span class="setting-title">连接到远程服务器</span>
+                  <span class="setting-desc">角色文件在远程服务器上，路径映射到远程端。</span>
+                </label>
+                <span class="setting-toggle"><input id="ttsUseRemotePaths" type="checkbox" /></span>
+              </div>
+              <div id="ttsRemoteCharactersRow" class="setting-row" hidden>
+                <label class="setting-row-text" for="ttsRemoteCharactersPath">
+                  <span class="setting-title">远程服务器角色文件夹路径</span>
+                  <span class="setting-desc">远程服务器上当前角色的完整文件夹路径。</span>
+                </label>
+                <input id="ttsRemoteCharactersPath" class="wide-input" type="text" />
+                <p class="hint">提示：此路径用于将本地角色文件映射到远程服务器。切换角色后，若新角色在远程服务器上的路径不同，请手动更新。</p>
+              </div>
+              <div class="setting-row">
                 <label class="setting-row-text" for="ttsWorkDir">
                   <span class="setting-title">工作目录</span>
                   <span class="setting-desc">TTS 引擎运行所在的工作目录路径。</span>

--- a/tools/settings-tauri/frontend/settings.js
+++ b/tools/settings-tauri/frontend/settings.js
@@ -46,6 +46,9 @@ const fields = {
   ttsResourceCard: document.getElementById("ttsResourceCard"),
   ttsTestButton: document.getElementById("ttsTestButton"),
   ttsTimeout: document.getElementById("ttsTimeout"),
+  ttsUseRemotePaths: document.getElementById("ttsUseRemotePaths"),
+  ttsRemoteCharactersPath: document.getElementById("ttsRemoteCharactersPath"),
+  ttsRemoteCharactersRow: document.getElementById("ttsRemoteCharactersRow"),
   themeColors: document.getElementById("themeColors"),
   visualEffectMode: document.getElementById("visualEffectMode"),
   themeAiButton: document.getElementById("themeAiButton"),
@@ -961,6 +964,13 @@ function syncTtsState() {
   fields.ttsPythonPath.readOnly = false;
   fields.ttsConfigPath.disabled = true;
   setControlDisabled(fields.ttsTestButton, !active);
+
+  // 远程路径相关控件：仅 custom-gpt-sovits 启用编辑
+  const isCustomGptSovits = fields.ttsProvider.value === "custom-gpt-sovits";
+  const remoteChecked = fields.ttsUseRemotePaths.checked;
+  fields.ttsRemoteCharactersRow.hidden = !active || !isCustomGptSovits || !remoteChecked;
+  setControlDisabled(fields.ttsUseRemotePaths, !active || !isCustomGptSovits);
+  setControlDisabled(fields.ttsRemoteCharactersPath, !active || !isCustomGptSovits || !remoteChecked);
   syncTtsBundleNotice();
   syncBackchannelState({ renderResource: false });
   if (request) {
@@ -1008,6 +1018,10 @@ async function testTtsSettings() {
 function handleTtsProviderChange() {
   resourceState.ttsBundleKey = "";
   applyTtsProviderDefaults(lastTtsProvider);
+  if (fields.ttsProvider.value !== "custom-gpt-sovits") {
+    fields.ttsUseRemotePaths.checked = false;
+    fields.ttsRemoteCharactersPath.value = "";
+  }
   syncTtsState();
 }
 
@@ -4103,6 +4117,8 @@ function collectTtsSettings() {
     python_path: fields.ttsPythonPath.value.trim(),
     tts_config_path: fields.ttsConfigPath.value.trim(),
     timeout_seconds: clampInt(fields.ttsTimeout.value, request.limits.tts_timeout_seconds),
+    use_remote_paths: fields.ttsUseRemotePaths.checked,
+    remote_characters_path: fields.ttsRemoteCharactersPath.value.trim(),
   };
 }
 
@@ -4337,6 +4353,8 @@ async function load() {
   fields.ttsPythonPath.value = request.tts.python_path;
   fields.ttsConfigPath.value = request.tts.tts_config_path;
   fields.ttsTimeout.value = request.tts.timeout_seconds;
+  fields.ttsUseRemotePaths.checked = request.tts.use_remote_paths;
+  fields.ttsRemoteCharactersPath.value = request.tts.remote_characters_path || "";
   lastTtsProvider = fields.ttsProvider.value;
   applyTtsProviderDefaults(lastTtsProvider);
 
@@ -4440,6 +4458,7 @@ fields.apiTopPEnabled.addEventListener("change", syncApiAdvancedState);
 fields.apiMaxTokensEnabled.addEventListener("change", syncApiAdvancedState);
 fields.ttsEnabled.addEventListener("change", syncTtsState);
 fields.ttsProvider.addEventListener("change", handleTtsProviderChange);
+fields.ttsUseRemotePaths.addEventListener("change", syncTtsState);
 fields.ttsTestButton.addEventListener("click", testTtsSettings);
 fields.backchannelEnabled.addEventListener("change", syncBackchannelState);
 fields.backchannelMode.addEventListener("change", renderBackchannelResourceCard);

--- a/tools/settings-tauri/src-tauri/src/lib.rs
+++ b/tools/settings-tauri/src-tauri/src/lib.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, Write};
+#[cfg(unix)]
+use std::os::unix::io::FromRawFd;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -252,7 +254,18 @@ fn close_settings_window(window: Window) -> Result<(), String> {
 }
 
 pub fn run() {
-    let (request, rpc, window_control) = match read_request_and_spawn_rpc_reader() {
+    #[cfg(unix)]
+    let rpc_response_fd = std::env::var("SAKURA_RPC_RESPONSE_FD")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+
+    let (request, rpc, window_control) = match {
+        #[cfg(unix)]
+        { read_request_and_spawn_rpc_reader(rpc_response_fd) }
+        #[cfg(not(unix))]
+        { read_request_and_spawn_rpc_reader() }
+    } {
         Ok(state) => state,
         Err(error) => {
             eprintln!("{error}");
@@ -292,8 +305,64 @@ pub fn run() {
         .expect("failed to run Sakura settings window");
 }
 
+#[cfg(unix)]
+fn read_request_and_spawn_rpc_reader(rpc_response_fd: std::os::unix::io::RawFd) -> Result<(Value, HostRpc, WindowControl), String> {
+    if rpc_response_fd < 3 {
+        return Err("SAKURA_RPC_RESPONSE_FD must refer to a non-standard fd".to_string());
+    }
+    let mut initial_line = String::new();
+    {
+        let stdin_guard = std::io::stdin().lock();
+        let mut reader = std::io::BufReader::new(stdin_guard);
+        let bytes = reader
+            .read_line(&mut initial_line)
+            .map_err(|error| error.to_string())?;
+        if bytes == 0 {
+            return Err("request payload is empty".to_string());
+        }
+    }
+    let value: Value = serde_json::from_str(initial_line.trim_end()).map_err(|error| error.to_string())?;
+    if !matches!(value, Value::Object(_)) {
+        return Err("request payload must be a JSON object".to_string());
+    }
+    let rpc = HostRpc::new();
+    let pending = rpc.pending.clone();
+    let window_control = WindowControl::default();
+    let reader_window_control = window_control.clone();
+    std::thread::spawn(move || {
+        // 从独立 pipe fd 读取 RPC 响应，绕过 std::io::stdin() 的全局内部 Mutex。
+        let file = unsafe { std::fs::File::from_raw_fd(rpc_response_fd) };
+        let mut reader = std::io::BufReader::new(file);
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match reader.read_line(&mut line) {
+                Ok(0) => break,
+                Ok(_) => {
+                    let trimmed = line.trim_end();
+                    if let Some(command) = parse_window_control_line(trimmed) {
+                        reader_window_control.execute(command);
+                        continue;
+                    }
+                    if let Some(response) = parse_rpc_response_line(trimmed) {
+                        if let Ok(mut pending) = pending.lock() {
+                            if let Some(sender) = pending.remove(&response.id) {
+                                let _ = sender.send(response);
+                            }
+                        }
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+        clear_pending_rpcs(&pending);
+    });
+    Ok((value, rpc, window_control))
+}
+
+#[cfg(not(unix))]
 fn read_request_and_spawn_rpc_reader() -> Result<(Value, HostRpc, WindowControl), String> {
-    let mut reader = BufReader::new(std::io::stdin());
+    let mut reader = std::io::BufReader::new(std::io::stdin());
     let mut data = String::new();
     let bytes = reader
         .read_line(&mut data)
@@ -310,6 +379,7 @@ fn read_request_and_spawn_rpc_reader() -> Result<(Value, HostRpc, WindowControl)
     let window_control = WindowControl::default();
     let reader_window_control = window_control.clone();
     std::thread::spawn(move || {
+        let mut reader = std::io::BufReader::new(std::io::stdin());
         let mut line = String::new();
         loop {
             line.clear();


### PR DESCRIPTION
## 概述

远程 GPT-SoVITS TTS API 需要服务端本地的音频文件路径作为参考音频，但客户端本地的角色文件夹路径在服务端不可达。本 PR 实现了路径映射机制，允许用户为远程服务器配置对应的本地角色文件夹路径映射关系。

## 变更内容

- **TTS 设置** (`app/voice/tts_settings.py`): 新增 `remote_characters_path` 配置项，存储远程服务器上的角色文件夹路径
- **路径映射** (`app/voice/tts_service.py`): 新增 `to_remote_path()` 方法，将本地路径转换为远程服务器可访问的路径
- **TTS 合成** (`app/voice/tts_synthesis.py`): 合成时对 `ref_audio_path` 进行远程路径映射
- **Tauri 设置页前端** (`tools/settings-tauri/`): Rust RPC 层与前端 JS 新增远程角色路径输入框及保存逻辑
- **Qt 设置页** (`app/ui/tauri_settings.py`): 加载 Tauri 设置页时传递远程角色路径配置
- **配置服务** (`app/config/settings_service.py`): 支持新配置项的读写
- **RPC 修复** (`tools/settings-tauri/src-tauri/src/lib.rs`): 修复双 BufReader 冲突导致的死锁、写入异常处理及 FD 泄露问题
- **测试** (`tests/`): 新增 `test_tts.py` 测试路径映射逻辑，更新 `test_pet_window.py`

## 影响文件

11 个文件变更，+351 / -26 行

### 提交历史

```
da21e51 feat(tts): 支持远程服务器路径映射
```

效果：
可以连接局域网或公网的Windows/Linux运行有GPT-SOVITS的服务器，但是需要保证服务器端也有当前角色包，并填写角色包路径
此功能可以允许性能差的设备借助云端进行语音合成

<img width="988" height="477" alt="截图 2026-07-14 16-52-01" src="https://github.com/user-attachments/assets/f4df5154-aedc-411c-9348-01d899781694" />
