### PR TITLE
fix: 提升 macOS 发布下载可靠性

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,9 @@ jobs:
           raise SystemExit('no matching asset found')
           ")
           echo "Downloading: $ASSET_URL"
-          curl -fL --connect-timeout 15 --max-time 600 -o python-standalone.tar.gz "$ASSET_URL"
+          curl -fL --retry 5 --retry-all-errors --retry-delay 5 \
+            --connect-timeout 15 --max-time 600 \
+            -o python-standalone.tar.gz "$ASSET_URL"
 
       - name: Extract Python to runtime/
         shell: bash


### PR DESCRIPTION
## 变更

- 为 Release 工作流中的 macOS `python-build-standalone` 下载增加最多 5 次重试
- 使用 `--retry-all-errors` 覆盖 Release #15 遇到的 TLS/CDN 临时错误
- 保持 TLS 证书校验开启

## 根因

Release #15 的 macOS runner 在 GitHub 资源 CDN 下载阶段收到自签名证书，`curl` 以 60 退出；矩阵 fail-fast 随后取消 Windows job，发布 job 因此跳过。

## 影响

仅提高发布工作流的下载可靠性，不修改应用代码、版本号或产物结构。

## 验证

- `release.yml` YAML 解析通过
- `python -m pytest tests/unit/test_tauri_studio.py -q`：27 passed
- `git diff --check` 通过