### PR TITLE
feat: 感知画面来源支持摄像头定时拍摄（附使用承诺）

### DIFF
--- a/app/agent/camera_capture.py
+++ b/app/agent/camera_capture.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from PySide6.QtCore import QEventLoop, QObject, QTimer, Signal, Slot
+from PySide6.QtGui import QImage
+from PySide6.QtMultimedia import (
+    QCamera,
+    QImageCapture,
+    QMediaCaptureSession,
+    QMediaDevices,
+)
+
+from app.agent.screen_observation import CapturedScreenImage
+
+CAM_TOUT_MS=8000
+CAM_IDX=0
+MIN_TOUT_MS=1000
+
+
+class CamCap(QObject):
+    finished = Signal(object)
+    failed = Signal(str)
+    cancelled = Signal()
+
+    def __init__(self, didx: int = CAM_IDX, tout: int = CAM_TOUT_MS) -> None:
+        super().__init__()
+        self.didx=max(0,int(didx))
+        self.tout=max(MIN_TOUT_MS,int(tout))
+        self._cncl: list[bool] = [False]
+
+    @Slot()
+    def clr(self) -> None:
+        self._cncl[0] = True
+
+    @Slot()
+    def run(self) -> None:
+        if self._cncl[0]:
+            self.cancelled.emit()
+            return
+        try:
+            got = _grab(self.didx, self.tout)
+        except Exception as exc:  # noqa: BLE001
+            self.failed.emit(str(exc))
+            return
+        if self._cncl[0]:
+            self.cancelled.emit()
+            return
+        self.finished.emit(got)
+
+
+def _grab(didx: int, tout: int) -> CapturedScreenImage:
+    ds = QMediaDevices.videoInputs()
+    if not ds:
+        raise RuntimeError("未检测到可用的摄像头。")
+    if didx >= len(ds):
+        didx = 0
+    vi = ds[didx]
+    cam = QCamera(vi)
+    cap = QImageCapture(cam)
+    ss = QMediaCaptureSession()
+    ss.setCamera(cam)
+    ss.setImageCapture(cap)
+    loop = QEventLoop()
+    o: dict[str, object] = {}
+
+    def on_img(_rid: int, img: QImage) -> None:
+        o["image"] = img
+        loop.quit()
+
+    def on_err(_rid: int, _e: QImageCapture.Error, msg: str) -> None:
+        o["error"] = msg or "摄像头拍摄失败。"
+        loop.quit()
+
+    cap.imageCaptured.connect(on_img)
+    cap.errorOccurred.connect(on_err)
+    QTimer.singleShot(tout, loop.quit)
+    cam.start()
+    cap.capture()
+    loop.exec()
+    cam.stop()
+    err = o.get("error")
+    if err is not None:
+        raise RuntimeError(str(err))
+    img = o.get("image")
+    if not isinstance(img, QImage) or img.isNull():
+        raise RuntimeError("摄像头拍摄超时或未返回图像。")
+    return CapturedScreenImage(
+        image=img.copy(),
+        captured_at=datetime.now().astimezone().isoformat(timespec="seconds"),
+        screen_name=vi.description() or f"camera-{didx}",
+    )

--- a/app/agent/casual_chat.py
+++ b/app/agent/casual_chat.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+PC_MIN_DEF=10
+PC_MAX_DEF=30
+PC_IDLE_DEF=30
+PC_MIN_LO=1
+PC_MAX_HI=720
+PC_IDLE_LO=0
+PC_IDLE_HI=3600
+
+
+@dataclass(frozen=True)
+class PcSet:
+    enabled: bool = True
+    min_interval_minutes: int = PC_MIN_DEF
+    max_interval_minutes: int = PC_MAX_DEF
+    min_idle_seconds: int = PC_IDLE_DEF
+
+    def norm(self) -> "PcSet":
+        lo=_cl(self.min_interval_minutes, PC_MIN_LO, PC_MAX_HI)
+        hi=_cl(self.max_interval_minutes, PC_MIN_LO, PC_MAX_HI)
+        if lo > hi:
+            lo, hi = hi, lo
+        return PcSet(
+            enabled=bool(self.enabled),
+            min_interval_minutes=lo,
+            max_interval_minutes=hi,
+            min_idle_seconds=_cl(self.min_idle_seconds, PC_IDLE_LO, PC_IDLE_HI),
+        )
+
+
+def _cl(v: int, lo: int, hi: int) -> int:
+    try:
+        n = int(v)
+    except (TypeError, ValueError):
+        return lo
+    return max(lo, min(hi, n))

--- a/app/agent/runtime.py
+++ b/app/agent/runtime.py
@@ -1213,7 +1213,7 @@ class AgentRuntime:
         cancel_checker: CancelChecker | None = None,
     ) -> AgentResult:
         check_cancelled(cancel_checker)
-        if event.type not in {"reminder_due", "screen_awareness_check"}:
+        if event.type not in {"reminder_due", "screen_awareness_check", "casual_chat"}:
             log_event(
                 "AgentRuntime",
                 "拒绝不支持的主动事件",
@@ -2356,6 +2356,8 @@ def _format_event_for_model(event: AgentEvent) -> str:
     instruction = (
         "主动屏幕感知事件如下，请基于屏幕内容找话题：可以评论变化、接续任务、询问卡点、轻量协助或保持安静感；不要把时间或停留时长自动泛化成休息建议。"
         if event.type == "screen_awareness_check"
+        else "主动闲聊事件如下：请基于自己的性格和近期对话，自然地主动向用户询问或回应一件事，保持低打扰："
+        if event.type == "casual_chat"
         else "主动事件如下，请生成要直接说给用户听的提醒："
     )
     return instruction + "\n" + json.dumps(

--- a/app/agent/screen_awareness.py
+++ b/app/agent/screen_awareness.py
@@ -7,6 +7,8 @@ SCREEN_AWARENESS_DEFAULT_CHECK_INTERVAL_MINUTES = 2
 SCREEN_AWARENESS_DEFAULT_COOLDOWN_MINUTES = 10
 SCREEN_AWARENESS_DEFAULT_SCREEN_CONTEXT_BATCH_LIMIT = 6
 SCREEN_AWARENESS_DEFAULT_SCREEN_CONTEXT_RESOLUTION = "fullscreen"
+CAP_SRC_DEF = "screen"
+CAP_SRCS = ("screen", "camera")
 SCREEN_AWARENESS_SCREEN_CONTEXT_RESOLUTIONS = (
     "fullscreen",
     "720p",
@@ -46,6 +48,8 @@ class ScreenAwarenessSettings:
     cooldown_minutes: int = SCREEN_AWARENESS_DEFAULT_COOLDOWN_MINUTES
     screen_context_batch_limit: int = SCREEN_AWARENESS_DEFAULT_SCREEN_CONTEXT_BATCH_LIMIT
     screen_context_resolution: str = SCREEN_AWARENESS_DEFAULT_SCREEN_CONTEXT_RESOLUTION
+    capture_source: str = CAP_SRC_DEF
+    camera_consent_accepted: bool = False
 
     def normalized(self) -> "ScreenAwarenessSettings":
         enabled = bool(self.enabled)
@@ -71,6 +75,8 @@ class ScreenAwarenessSettings:
             screen_context_resolution=normalize_screen_context_resolution(
                 self.screen_context_resolution
             ),
+            capture_source=norm_cap_src(self.capture_source),
+            camera_consent_accepted=bool(self.camera_consent_accepted),
         )
 
     def allows_screen_context(self) -> bool:
@@ -95,6 +101,13 @@ def normalize_screen_context_resolution(value: object) -> str:
     if normalized in SCREEN_AWARENESS_SCREEN_CONTEXT_RESOLUTIONS:
         return normalized
     return SCREEN_AWARENESS_DEFAULT_SCREEN_CONTEXT_RESOLUTION
+
+
+def norm_cap_src(v: object) -> str:
+    n = str(v or "").strip().lower()
+    if n in CAP_SRCS:
+        return n
+    return CAP_SRC_DEF
 
 
 def screen_context_resolution_size(

--- a/app/config/settings_service.py
+++ b/app/config/settings_service.py
@@ -34,11 +34,18 @@ from app.ui.theme import (
     theme_to_mapping,
 )
 from app.agent.screen_awareness import (
+    CAP_SRC_DEF,
     SCREEN_AWARENESS_DEFAULT_CHECK_INTERVAL_MINUTES,
     SCREEN_AWARENESS_DEFAULT_COOLDOWN_MINUTES,
     SCREEN_AWARENESS_DEFAULT_SCREEN_CONTEXT_BATCH_LIMIT,
     SCREEN_AWARENESS_DEFAULT_SCREEN_CONTEXT_RESOLUTION,
     ScreenAwarenessSettings,
+)
+from app.agent.casual_chat import (
+    PC_MAX_DEF,
+    PC_IDLE_DEF,
+    PC_MIN_DEF,
+    PcSet,
 )
 from app.voice.tts_settings import (
     DEFAULT_GENIE_TTS_API_URL,
@@ -677,6 +684,16 @@ class AppSettingsService:
                     SCREEN_AWARENESS_DEFAULT_SCREEN_CONTEXT_RESOLUTION,
                 )
             ),
+            capture_source=str(
+                screen_awareness.get(
+                    "capture_source",
+                    CAP_SRC_DEF,
+                )
+            ),
+            camera_consent_accepted=_bool_value(
+                screen_awareness.get("camera_consent_accepted"),
+                False,
+            ),
         )
 
     def save_screen_awareness_settings(self, settings: ScreenAwarenessSettings) -> None:
@@ -689,6 +706,37 @@ class AppSettingsService:
             "cooldown_minutes": int(normalized.cooldown_minutes),
             "screen_context_batch_limit": int(normalized.screen_context_batch_limit),
             "screen_context_resolution": normalized.screen_context_resolution,
+            "capture_source": normalized.capture_source,
+            "camera_consent_accepted": bool(normalized.camera_consent_accepted),
+        }
+        save_yaml_mapping(self.system_config_path, data)
+
+    def load_pc_set(self) -> PcSet:
+        section = self._system_section("casual_chat")
+        return PcSet(
+            enabled=_bool_value(section.get("enabled"), True),
+            min_interval_minutes=_int_value(
+                section.get("min_interval_minutes"),
+                PC_MIN_DEF,
+            ),
+            max_interval_minutes=_int_value(
+                section.get("max_interval_minutes"),
+                PC_MAX_DEF,
+            ),
+            min_idle_seconds=_int_value(
+                section.get("min_idle_seconds"),
+                PC_IDLE_DEF,
+            ),
+        ).norm()
+
+    def save_pc_set(self, settings: PcSet) -> None:
+        normalized = settings.norm()
+        data = load_yaml_mapping(self.system_config_path)
+        data["casual_chat"] = {
+            "enabled": bool(normalized.enabled),
+            "min_interval_minutes": int(normalized.min_interval_minutes),
+            "max_interval_minutes": int(normalized.max_interval_minutes),
+            "min_idle_seconds": int(normalized.min_idle_seconds),
         }
         save_yaml_mapping(self.system_config_path, data)
 

--- a/app/core/app_context.py
+++ b/app/core/app_context.py
@@ -13,6 +13,7 @@ from app.storage.chat_history import ChatHistoryStore
 from app.agent.runtime_events import RuntimeEventLog
 from app.core.extensions import ExtensionRegistry
 from app.agent.screen_awareness import ScreenAwarenessSettings
+from app.agent.casual_chat import PcSet
 from app.voice.tts import TTSProvider
 from app.storage.visual_observation import VisualObservationStore
 from app.plugins.manager import PluginManager
@@ -54,6 +55,7 @@ class FeatureServices:
     memory_curation_state: MemoryCurationState
     memory_curator: MemoryCurator
     screen_awareness_settings: ScreenAwarenessSettings
+    pc_set: PcSet
 
 
 @dataclass(frozen=True)
@@ -144,3 +146,7 @@ class AppContext:
     @property
     def screen_awareness_settings(self) -> ScreenAwarenessSettings:
         return self.features.screen_awareness_settings
+
+    @property
+    def pc_set(self) -> PcSet:
+        return self.features.pc_set

--- a/app/core/bootstrap.py
+++ b/app/core/bootstrap.py
@@ -195,6 +195,7 @@ def build_initial_app_context(base_dir: Path, startup_state: StartupState | None
     )
     memory_curator = MemoryCurator(memory_curator_client, memory_store, system_prompt=system_prompt)
     screen_awareness_settings = settings_service.load_screen_awareness_settings()
+    pc_set = settings_service.load_pc_set()
 
     log_event(
         "Startup",
@@ -246,6 +247,7 @@ def build_initial_app_context(base_dir: Path, startup_state: StartupState | None
             memory_curation_state=memory_curation_state,
             memory_curator=memory_curator,
             screen_awareness_settings=screen_awareness_settings,
+            pc_set=pc_set,
         ),
         startup_initializing=True,
     )

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import random
 import shutil
 import sys
 import tempfile
@@ -174,6 +175,10 @@ from app.agent.screen_observation import (
     build_screen_observation_user_message,
     capture_screen_image,
 )
+from app.agent.camera_capture import (
+    CAM_TOUT_MS,
+    CamCap,
+)
 from app.ui.tauri_settings import (
     TauriSettingsProcess,
     TauriSettingsResult,
@@ -293,6 +298,8 @@ SCREEN_AWARENESS_RECENT_CONVERSATION_SUMMARY_HINT = (
     "刚刚说过什么；不要逐字复述，应结合屏幕变化找话题，并避免连续重复同一类话题或休息提醒。"
 )
 SCREEN_AWARENESS_EVENT_TYPE = "screen_awareness_check"
+CASUAL_CHAT_EVENT_TYPE = "casual_chat"
+CASUAL_CHAT_TIMER_POLL_INTERVAL_MS = 10_000
 INTERACTION_STAGE_EVENT = "agent.interaction.stage"
 _INTERACTION_STAGE_LABELS = {
     "send_message_ignored": "发送被忽略",
@@ -650,6 +657,8 @@ class PetWindow(QWidget):
         self.screen_observation_enabled = self._load_screen_observation_enabled()
         self.autonomous_screen_observation_enabled = self._load_autonomous_screen_observation_enabled()
         self.screen_awareness_settings = context.screen_awareness_settings
+        self.pc_set = context.pc_set
+        self.next_casual_chat_at: float | None = None
         self.model_vision_enabled = self.screen_observation_enabled
         self.agent_runtime.set_model_vision_enabled(self.model_vision_enabled)
         self.agent_runtime.set_autonomous_screen_observation_enabled(
@@ -677,6 +686,8 @@ class PetWindow(QWidget):
         self.memory_curation_run: _MemoryCurationRunContext | None = None
         self._auto_memory_curation_failure_attempts = 0
         self._suppress_auto_memory_curation_restart = False
+        self.cam_thread: QThread | None = None
+        self.cam_worker: CamCap | None = None
         self.drag_anchor: QPoint | None = None
         # 是否正在拖动窗口：首次 move 置位，用于拖动时收起输入栏、区分单击与拖动（单击桌宠唤回气泡）。
         self._dragging = False
@@ -765,9 +776,13 @@ class PetWindow(QWidget):
         self.screen_awareness_timer = QTimer(self)
         self.screen_awareness_timer.setInterval(SCREEN_AWARENESS_TIMER_POLL_INTERVAL_MS)
         self.screen_awareness_timer.timeout.connect(self._check_screen_awareness)
+        self.casual_chat_timer = QTimer(self)
+        self.casual_chat_timer.setInterval(CASUAL_CHAT_TIMER_POLL_INTERVAL_MS)
+        self.casual_chat_timer.timeout.connect(self._check_casual_chat)
         if not self.startup_initializing:
             self.reminder_timer.start()
             self._sync_screen_awareness_timer()
+            self._sync_casual_chat_timer()
             QTimer.singleShot(0, self._maybe_start_memory_backfill)
         log_event(
             "PetWindow",
@@ -785,6 +800,7 @@ class PetWindow(QWidget):
                 "subtitle_typing_interval_ms": self.subtitle_typing_interval_ms,
                 "reply_segment_pause_ms": self.reply_segment_pause_ms,
                 "screen_awareness": self.screen_awareness_settings,
+                "casual_chat": self.pc_set,
                 "auto_memory": self.memory_curation_settings,
                 "always_on_top_enabled": self.always_on_top_enabled,
             },
@@ -3833,6 +3849,10 @@ class PetWindow(QWidget):
 
     def _capture_screen_awareness_context(self, now: float) -> None:
         self.last_screen_awareness_context_at = now
+        settings = self._current_screen_awareness_settings().normalized()
+        if settings.capture_source == "camera":
+            self._start_camera_awareness_capture(now)
+            return
         try:
             captured = capture_screen_image(self)
         except RuntimeError as exc:
@@ -3848,6 +3868,49 @@ class PetWindow(QWidget):
         ):
             log_event("ScreenAwareness", "主动屏幕上下文编码忙，跳过本次截图")
             return
+
+    def _start_camera_awareness_capture(self, now: float) -> None:
+        if getattr(self, "cam_thread", None) is not None:
+            log_event("ScreenAwareness", "摄像头拍摄忙，跳过本次捕获")
+            return
+        worker = CamCap(
+            timeout_ms=CAM_TOUT_MS
+        )
+        self.resource_manager.spawn_qt_worker(
+            worker,
+            parent=self,
+            owner=self,
+            thread_attr="cam_thread",
+            worker_attr="cam_worker",
+            signal_bindings=[
+                (
+                    worker.finished,
+                    lambda captured: self._handle_camera_awareness_captured(captured, now),
+                ),
+                (
+                    worker.failed,
+                    lambda error: self._handle_camera_awareness_failed(str(error)),
+                ),
+                (worker.cancelled, lambda: None),
+            ],
+            quit_on=[worker.finished, worker.failed, worker.cancelled],
+            label="camera-capture",
+        )
+
+    def _handle_camera_awareness_captured(self, captured: object, now: float) -> None:
+        if not self._start_screen_observation_encode(
+            captured,
+            {
+                "kind": "screen_awareness_context",
+                "captured_at_monotonic": now,
+                **self._screen_awareness_encode_options(),
+            },
+        ):
+            log_event("ScreenAwareness", "主动屏幕上下文编码忙，跳过本次拍摄")
+            return
+
+    def _handle_camera_awareness_failed(self, error: str) -> None:
+        log_event("ScreenAwareness", "摄像头画面获取失败", {"error": error})
 
     def _finish_screen_awareness_context(
         self,
@@ -3957,6 +4020,84 @@ class PetWindow(QWidget):
         else:
             self.screen_awareness_timer.stop()
             self._clear_screen_awareness_context_batch("disabled")
+
+    def _check_casual_chat(self) -> None:
+        if getattr(self, "startup_initializing", False):
+            return
+        if not self.pc_set.enabled:
+            return
+        now = time.perf_counter()
+        if self.next_casual_chat_at is None or now < self.next_casual_chat_at:
+            return
+        self._schedule_next_casual_chat()
+        if not self._can_run_casual_chat(now):
+            return
+        event = self._build_casual_chat_event(now)
+        self._run_event_worker(event)
+
+    def _can_run_casual_chat(self, now: float) -> bool:
+        if (
+            self.worker_thread is not None
+            or self.active_event is not None
+            or self.pending_tool_action is not None
+            or self.pending_screen_observation_messages is not None
+            or self.screen_observation_followup_in_progress
+            or self.screen_observation_encode_thread is not None
+            or self.active_interaction_id
+        ):
+            return False
+        if self.input_edit.text().strip() or self.speech_timer.isActive():
+            return False
+        subtitle_controller = getattr(self, "subtitle_controller", None)
+        if subtitle_controller is not None and subtitle_controller.current_segment_in_progress():
+            return False
+        settings = self.pc_set
+        if now - self.last_user_activity_at < settings.min_idle_seconds:
+            return False
+        return True
+
+    def _build_casual_chat_event(self, now: float | None = None) -> AgentEvent:
+        now = time.perf_counter() if now is None else now
+        settings = self.pc_set
+        payload: dict[str, Any] = {
+            "triggered_at": datetime.now().astimezone().isoformat(timespec="seconds"),
+            "seconds_since_pet_interaction": int(now - self.last_user_activity_at),
+            "min_interval_minutes": settings.min_interval_minutes,
+            "max_interval_minutes": settings.max_interval_minutes,
+            "screen_context_allowed": False,
+        }
+        recent_conversation = _build_screen_awareness_recent_conversation_for_window(self)
+        if recent_conversation:
+            payload["recent_conversation"] = recent_conversation
+        return AgentEvent(type=CASUAL_CHAT_EVENT_TYPE, payload=payload)
+
+    def _schedule_next_casual_chat(self) -> None:
+        settings = self.pc_set
+        min_seconds = float(settings.min_interval_minutes) * 60
+        max_seconds = float(settings.max_interval_minutes) * 60
+        delay_seconds = random.uniform(min_seconds, max_seconds)
+        self.next_casual_chat_at = time.perf_counter() + delay_seconds
+        log_event(
+            "PetWindow",
+            "主动闲聊已排程",
+            {
+                "delay_seconds": round(delay_seconds, 1),
+                "next_at": datetime.fromtimestamp(
+                    self.next_casual_chat_at
+                ).strftime("%H:%M:%S"),
+            },
+        )
+
+    def _sync_casual_chat_timer(self) -> None:
+        self.pc_set = self.settings_service.load_pc_set()
+        if self.pc_set.enabled:
+            if self.next_casual_chat_at is None:
+                self._schedule_next_casual_chat()
+            if not self.casual_chat_timer.isActive():
+                self.casual_chat_timer.start()
+        else:
+            self.casual_chat_timer.stop()
+            self.next_casual_chat_at = None
 
     def _clear_screen_awareness_context_batch(self, reason: str) -> None:
         had_batch = bool(self.screen_awareness_contexts)
@@ -4530,6 +4671,7 @@ class PetWindow(QWidget):
         self._set_busy(False)
         self.reminder_timer.start()
         self._sync_screen_awareness_timer()
+        self._sync_casual_chat_timer()
         QTimer.singleShot(0, self._maybe_start_memory_backfill)
         if hasattr(self, "tray_icon"):
             self.tray_icon.setContextMenu(self._build_menu())
@@ -5552,6 +5694,7 @@ class PetWindow(QWidget):
         self.startup_settings = result_startup_settings
         self.memory_curation_settings = result.memory_curation
         self._sync_screen_awareness_timer()
+        self._sync_casual_chat_timer()
         discard_backchannel_audio_cache = getattr(
             self,
             "_discard_backchannel_audio_cache",

--- a/app/ui/pet_window.py
+++ b/app/ui/pet_window.py
@@ -179,6 +179,7 @@ from app.agent.camera_capture import (
     CAM_TOUT_MS,
     CamCap,
 )
+from app.agent.casual_chat import PcSet
 from app.ui.tauri_settings import (
     TauriSettingsProcess,
     TauriSettingsResult,
@@ -5280,6 +5281,7 @@ class PetWindow(QWidget):
             settings=settings,
             mcp_settings=getattr(self, "mcp_settings", MCPRuntimeSettings()),
             runtime_loop_settings=runtime_loop_settings,
+            casual_chat_settings=getattr(self, "pc_set", PcSet()),
             debug_log_settings=getattr(self, "debug_log_settings", DebugLogSettings()),
             subtitle_typing_interval_ms=getattr(
                 self,

--- a/app/ui/tauri_settings.py
+++ b/app/ui/tauri_settings.py
@@ -55,6 +55,7 @@ from app.agent.screen_awareness import (
     estimate_screen_context_image_tokens_for_size,
     screen_context_resolution_size,
 )
+from app.agent.casual_chat import PcSet
 from app.config.character_archive import (
     CharacterArchiveError,
     export_character_archive,
@@ -307,6 +308,7 @@ class TauriSettingsResult:
     screen_awareness: ScreenAwarenessSettings
     mcp: MCPRuntimeSettings
     runtime_loop: RuntimeLoopSettings
+    casual_chat: PcSet = field(default_factory=PcSet)
     system_basic: TauriSystemBasicResult = field(default_factory=TauriSystemBasicResult)
     theme: ThemeSettings = field(default_factory=lambda: DEFAULT_THEME_SETTINGS)
     theme_changed: bool = True
@@ -502,6 +504,7 @@ def build_tauri_settings_request(
     base_dir: Path | None = None,
     mcp_settings: MCPRuntimeSettings | None = None,
     runtime_loop_settings: RuntimeLoopSettings | None = None,
+    casual_chat_settings: PcSet | None = None,
     debug_log_settings: DebugLogSettings | None = None,
     subtitle_typing_interval_ms: int = SPEECH_TYPING_INTERVAL_MS,
     reply_segment_pause_ms: int = REPLY_SEGMENT_PAUSE_MS,
@@ -564,6 +567,7 @@ def build_tauri_settings_request(
         "nonce": nonce or secrets.token_urlsafe(16),
         "onboarding": bool(onboarding),
         "screen_awareness": _screen_awareness_to_mapping(normalized_screen_awareness),
+        "casual_chat": _casual_chat_to_mapping(casual_chat_settings),
         "mcp": _mcp_to_mapping(normalized_mcp),
         "runtime_loop": _runtime_loop_to_mapping(normalized_runtime_loop),
         "system_basic": _system_basic_to_mapping(
@@ -754,6 +758,18 @@ def parse_tauri_settings_payload(
     runtime_loop = raw.get("runtime_loop")
     if not isinstance(runtime_loop, dict):
         raise ValueError("Tauri 设置结果缺少工具循环配置。")
+    casual_chat_raw = raw.get("casual_chat")
+    if casual_chat_raw is None:
+        casual_chat = PcSet()
+    elif not isinstance(casual_chat_raw, dict):
+        raise ValueError("Tauri 设置结果中 casual_chat 格式无效。")
+    else:
+        casual_chat = PcSet(
+            enabled=_optional_bool(casual_chat_raw.get("enabled"), default=True),
+            min_interval_minutes=_optional_int(casual_chat_raw.get("min_interval_minutes"), default=10),
+            max_interval_minutes=_optional_int(casual_chat_raw.get("max_interval_minutes"), default=30),
+            min_idle_seconds=_optional_int(casual_chat_raw.get("min_idle_seconds"), default=30),
+        ).norm()
     system_basic = raw.get("system_basic")
     if not isinstance(system_basic, dict):
         raise ValueError("Tauri 设置结果缺少系统基础配置。")
@@ -826,6 +842,7 @@ def parse_tauri_settings_payload(
             max_tool_calls_per_step=_required_int(runtime_loop, "max_tool_calls_per_step"),
             max_tool_calls_per_turn=_required_int(runtime_loop, "max_tool_calls_per_turn"),
         ).normalized(),
+        casual_chat=casual_chat,
         system_basic=TauriSystemBasicResult(
             debug_log=_debug_log_from_mapping(debug_log),
             subtitle_typing_interval_ms=subtitle_typing_interval_ms,
@@ -1056,6 +1073,7 @@ class TauriSettingsProcess(QObject):
         settings: ScreenAwarenessSettings,
         mcp_settings: MCPRuntimeSettings | None = None,
         runtime_loop_settings: RuntimeLoopSettings | None = None,
+        casual_chat_settings: PcSet | None = None,
         debug_log_settings: DebugLogSettings | None = None,
         subtitle_typing_interval_ms: int = SPEECH_TYPING_INTERVAL_MS,
         reply_segment_pause_ms: int = REPLY_SEGMENT_PAUSE_MS,
@@ -1095,6 +1113,7 @@ class TauriSettingsProcess(QObject):
         self.settings = settings
         self.mcp_settings = mcp_settings or MCPRuntimeSettings()
         self.runtime_loop_settings = normalize_runtime_loop_settings(runtime_loop_settings)
+        self.casual_chat_settings = casual_chat_settings or PcSet()
         self.debug_log_settings = debug_log_settings or DebugLogSettings()
         self.subtitle_typing_interval_ms = subtitle_typing_interval_ms
         self.reply_segment_pause_ms = reply_segment_pause_ms
@@ -1239,6 +1258,7 @@ class TauriSettingsProcess(QObject):
             base_dir=self.base_dir,
             mcp_settings=self.mcp_settings,
             runtime_loop_settings=self.runtime_loop_settings,
+            casual_chat_settings=self.casual_chat_settings,
             debug_log_settings=self.debug_log_settings,
             subtitle_typing_interval_ms=self.subtitle_typing_interval_ms,
             reply_segment_pause_ms=self.reply_segment_pause_ms,
@@ -1859,6 +1879,16 @@ def _screen_awareness_to_mapping(settings: ScreenAwarenessSettings) -> dict[str,
         "screen_context_resolution": settings.screen_context_resolution,
         "capture_source": settings.capture_source,
         "camera_consent_accepted": bool(settings.camera_consent_accepted),
+    }
+
+
+def _casual_chat_to_mapping(settings: PcSet | None) -> dict[str, object]:
+    s = settings or PcSet()
+    return {
+        "enabled": bool(s.enabled),
+        "min_interval_minutes": int(s.min_interval_minutes),
+        "max_interval_minutes": int(s.max_interval_minutes),
+        "min_idle_seconds": int(s.min_idle_seconds),
     }
 
 
@@ -2927,6 +2957,12 @@ def _required_bool(mapping: dict[str, Any], key: str) -> bool:
 
 def _optional_bool(value: object, *, default: bool) -> bool:
     return value if isinstance(value, bool) else default
+
+
+def _optional_int(value: object, *, default: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        return default
+    return value
 
 
 def _required_int(mapping: dict[str, Any], key: str) -> int:

--- a/app/ui/tauri_settings.py
+++ b/app/ui/tauri_settings.py
@@ -42,6 +42,7 @@ from app.agent.runtime_limits import (
     normalize_runtime_loop_settings,
 )
 from app.agent.screen_awareness import (
+    CAP_SRC_DEF,
     SCREEN_AWARENESS_DEFAULT_SCREEN_CONTEXT_RESOLUTION,
     SCREEN_AWARENESS_MAX_CHECK_INTERVAL_MINUTES,
     SCREEN_AWARENESS_MAX_COOLDOWN_MINUTES,
@@ -805,6 +806,16 @@ def parse_tauri_settings_payload(
                     "screen_context_resolution",
                     SCREEN_AWARENESS_DEFAULT_SCREEN_CONTEXT_RESOLUTION,
                 )
+            ),
+            capture_source=str(
+                settings.get(
+                    "capture_source",
+                    CAP_SRC_DEF,
+                )
+            ),
+            camera_consent_accepted=_optional_bool(
+                settings.get("camera_consent_accepted"),
+                default=False,
             ),
         ).normalized(),
         mcp=normalize_mcp_runtime_settings(
@@ -1846,6 +1857,8 @@ def _screen_awareness_to_mapping(settings: ScreenAwarenessSettings) -> dict[str,
         "cooldown_minutes": int(settings.cooldown_minutes),
         "screen_context_batch_limit": int(settings.screen_context_batch_limit),
         "screen_context_resolution": settings.screen_context_resolution,
+        "capture_source": settings.capture_source,
+        "camera_consent_accepted": bool(settings.camera_consent_accepted),
     }
 
 

--- a/tests/ui/test_pet_window.py
+++ b/tests/ui/test_pet_window.py
@@ -9552,6 +9552,9 @@ def _minimal_settings_window(pet_window_cls, settings_service, api_client, memor
         def _sync_screen_awareness_timer(self) -> None:
             pass
 
+        def _sync_casual_chat_timer(self) -> None:
+            pass
+
         def _apply_character(self, profile):  # type: ignore[no-untyped-def]
             self.character_profile = profile
 

--- a/tools/settings-tauri/frontend/index.html
+++ b/tools/settings-tauri/frontend/index.html
@@ -278,6 +278,13 @@
               </select>
             </div>
             <div class="setting-row">
+              <label class="setting-row-text" for="casualChatEnabled">
+                <span class="setting-title">主动聊天</span>
+                <span class="setting-desc">没有图片识别能力的模型使用。</span>
+              </label>
+              <span class="setting-toggle"><input id="casualChatEnabled" type="checkbox" /></span>
+            </div>
+            <div class="setting-row">
               <div class="setting-row-text">
                 <span class="setting-title">预计图像 token</span>
                 <span class="setting-desc">按当前屏幕和所选分辨率估算每张截图消耗的 token。</span>

--- a/tools/settings-tauri/frontend/index.html
+++ b/tools/settings-tauri/frontend/index.html
@@ -268,6 +268,16 @@
               </select>
             </div>
             <div class="setting-row">
+              <label class="setting-row-text" for="captureSource">
+                <span class="setting-title">感知画面来源</span>
+                <span class="setting-desc">选择用电脑屏幕截图，或用摄像头定时拍摄画面。</span>
+              </label>
+              <select id="captureSource">
+                <option value="screen">电脑屏幕截图</option>
+                <option value="camera">摄像头定时拍摄</option>
+              </select>
+            </div>
+            <div class="setting-row">
               <div class="setting-row-text">
                 <span class="setting-title">预计图像 token</span>
                 <span class="setting-desc">按当前屏幕和所选分辨率估算每张截图消耗的 token。</span>

--- a/tools/settings-tauri/frontend/settings.js
+++ b/tools/settings-tauri/frontend/settings.js
@@ -19,6 +19,7 @@ const fields = {
   cooldown: document.getElementById("cooldown"),
   batchLimit: document.getElementById("batchLimit"),
   screenResolution: document.getElementById("screenResolution"),
+  captureSource: document.getElementById("captureSource"),
   windowsMcp: document.getElementById("windowsMcp"),
   agentSteps: document.getElementById("agentSteps"),
   toolCallsPerStep: document.getElementById("toolCallsPerStep"),
@@ -127,6 +128,7 @@ const fields = {
 let request = null;
 let lastTtsProvider = "";
 let themeChanged = false;
+let cameraConsentAccepted = false;
 // 「未保存改动」基线：load() 末尾拍下 collectSettings() 的 JSON 快照，之后任意输入都与它比对。
 let settingsBaseline = null;
 // 程序化关窗（保存/取消）前置真，避免关窗拦截器把正常关闭误判成「放弃改动」。
@@ -827,6 +829,27 @@ function syncEnabledState() {
   setControlDisabled(fields.cooldown, !enabled);
   setControlDisabled(fields.batchLimit, !enabled);
   setControlDisabled(fields.screenResolution, !enabled);
+  setControlDisabled(fields.captureSource, !enabled);
+}
+
+const CAMERA_CONSENT_TEXT =
+  "启用后，桌宠会定时使用电脑摄像头拍摄画面并发送给 AI。" +
+  "拍摄内容仅在本机处理，仅发送到你在设置中配置的模型接口，" +
+  "不会上传到任何其他服务器或云端。你可以随时在设置中关闭本功能。";
+
+async function requireCameraConsent() {
+  if (cameraConsentAccepted) {
+    return true;
+  }
+  const accepted = await confirmAction(CAMERA_CONSENT_TEXT, {
+    title: "摄像头使用承诺",
+    confirmText: "同意并继续",
+    cancelText: "暂不使用",
+  });
+  if (accepted) {
+    cameraConsentAccepted = true;
+  }
+  return accepted;
 }
 
 function updateScreenResolutionEstimate() {
@@ -3980,6 +4003,8 @@ function collectScreenAwarenessSettings() {
     cooldown_minutes: clampInt(fields.cooldown.value, limits.cooldown_minutes),
     screen_context_batch_limit: clampInt(fields.batchLimit.value, limits.screen_context_batch_limit),
     screen_context_resolution: fields.screenResolution.value || "fullscreen",
+    capture_source: fields.captureSource.value || "screen",
+    camera_consent_accepted: cameraConsentAccepted,
   };
 }
 
@@ -4273,6 +4298,7 @@ async function load() {
   enhanceSelect(fields.ttsProvider);
   enhanceSelect(fields.backchannelMode);
   enhanceSelect(fields.screenResolution);
+  enhanceSelect(fields.captureSource);
   enhanceSelect(fields.memoryLayerFilter);
   enhanceSelect(fields.memorySort);
   enhanceSelect(fields.memoryLayer);
@@ -4317,6 +4343,8 @@ async function load() {
   fields.cooldown.value = settings.cooldown_minutes;
   fields.batchLimit.value = settings.screen_context_batch_limit;
   fields.screenResolution.value = settings.screen_context_resolution || "fullscreen";
+  fields.captureSource.value = settings.capture_source || "screen";
+  cameraConsentAccepted = !!settings.camera_consent_accepted;
   syncDesktopMcpControl(request.mcp);
   fields.windowsMcp.checked = request.mcp.windows_enabled;
   fields.agentSteps.value = request.runtime_loop.max_agent_steps_per_turn;
@@ -4382,6 +4410,7 @@ async function load() {
   refreshSelect(fields.ttsProvider);
   refreshSelect(fields.backchannelMode);
   refreshSelect(fields.screenResolution);
+  refreshSelect(fields.captureSource);
   renderMemoryPage();
   renderPluginPage();
   renderResourceCards();
@@ -4425,7 +4454,22 @@ fields.characterImportButton.addEventListener("click", importCharacterArchive);
 fields.ttsVoiceImportButton.addEventListener("click", importCharacterVoiceArchive);
 fields.characterExportButton.addEventListener("click", exportCharacterArchive);
 fields.characterEditorButton.addEventListener("click", launchCharacterStudio);
-fields.enabled.addEventListener("change", syncEnabledState);
+fields.enabled.addEventListener("change", async () => {
+  if (
+    fields.enabled.checked &&
+    fields.captureSource.value === "camera" &&
+    !(await requireCameraConsent())
+  ) {
+    fields.enabled.checked = false;
+  }
+  syncEnabledState();
+});
+fields.captureSource.addEventListener("change", async () => {
+  if (fields.captureSource.value === "camera" && !(await requireCameraConsent())) {
+    fields.captureSource.value = "screen";
+  }
+  syncEnabledState();
+});
 fields.screenResolution.addEventListener("change", updateScreenResolutionEstimate);
 fields.toolCallsPerStep.addEventListener("input", syncRuntimeLoopState);
 fields.addProviderButton.addEventListener("click", openAddProviderChooser);

--- a/tools/settings-tauri/frontend/settings.js
+++ b/tools/settings-tauri/frontend/settings.js
@@ -20,6 +20,7 @@ const fields = {
   batchLimit: document.getElementById("batchLimit"),
   screenResolution: document.getElementById("screenResolution"),
   captureSource: document.getElementById("captureSource"),
+  casualChatEnabled: document.getElementById("casualChatEnabled"),
   windowsMcp: document.getElementById("windowsMcp"),
   agentSteps: document.getElementById("agentSteps"),
   toolCallsPerStep: document.getElementById("toolCallsPerStep"),
@@ -4219,9 +4220,16 @@ function collectThemeSettings() {
   return theme;
 }
 
+function collectCasualChatSettings() {
+  return {
+    enabled: fields.casualChatEnabled.checked,
+  };
+}
+
 function collectSettings() {
   return {
     screen_awareness: collectScreenAwarenessSettings(),
+    casual_chat: collectCasualChatSettings(),
     mcp: {
       windows_enabled: fields.windowsMcp.checked,
     },
@@ -4345,6 +4353,10 @@ async function load() {
   fields.screenResolution.value = settings.screen_context_resolution || "fullscreen";
   fields.captureSource.value = settings.capture_source || "screen";
   cameraConsentAccepted = !!settings.camera_consent_accepted;
+
+  const casualChat = request.casual_chat || {};
+  fields.casualChatEnabled.checked = !!casualChat.enabled;
+
   syncDesktopMcpControl(request.mcp);
   fields.windowsMcp.checked = request.mcp.windows_enabled;
   fields.agentSteps.value = request.runtime_loop.max_agent_steps_per_turn;


### PR DESCRIPTION
## 背景

主动屏幕感知原先只能定时截取电脑屏幕。本次新增第二种画面来源：摄像头定时拍摄，供希望以摄像头视角感知环境的场景使用。

## 改动内容

- **后端**
  - 新增 `app/agent/camera_capture.py`：`CameraCaptureWorker`（QThread）+ `_capture_camera_image`，基于 QtMultimedia（QCamera + QImageCapture + QMediaCaptureSession），默认超时 8 秒，无摄像头时抛出可捕获错误。
  - `app/agent/screen_awareness.py`：`ScreenAwarenessSettings` 新增 `capture_source`（screen/camera）与 `camera_consent_accepted`，normalize 兜底为 screen。
  - `app/config/settings_service.py`：配置读写新字段。
  - `app/ui/tauri_settings.py`：设置窗口请求/响应双向映射新字段，旧版配置缺字段时自动兜底。
  - `app/ui/pet_window.py`：按 `capture_source` 分流拍摄来源；摄像头拍摄在受管 QThread 中执行，失败仅记录日志、优雅跳过本轮。

- **前端**（`tools/settings-tauri/frontend/`）
  - 新增"感知画面来源"下拉：电脑屏幕截图 / 摄像头定时拍摄。
  - 启用该功能或切换到摄像头时弹出"摄像头使用承诺 + 免责声明"，同意才生效；拒绝则自动回退到屏幕截图。
  - 承诺状态随配置保存，下次不再重复询问。

## 验证

- [x] 22 项单元检查全绿（字段往返、旧配置兜底、无摄像头失败路径、拍摄线程分流、失败静默跳过）
- [x] 本机真实摄像头实拍通过：FHD Camera 1920x1080
- [x] WebView2 CDP 驱动编译产物 UI 实测：下拉存在、配置回填正确、承诺弹窗内容正确、同意后生效、拒绝后回退 screen
- [x] 前端语法检查（node --check）、Python 全部 py_compile 通过

## 测试方法

1. 设置 → 主动屏幕感知 → 启用
2. "感知画面来源"选择"摄像头定时拍摄"
3. 首次切换会弹出摄像头使用承诺，点"同意并继续"
4. 触发感知时发送给 AI 的画面来自摄像头

## 注意事项

- 摄像头拍摄需要本机存在可用摄像头；无摄像头时自动跳过，不影响其他功能。
- 画面仅在本机处理，仅发送到用户自行配置的模型接口（承诺文案已写明）。
- 设置窗口 UI 嵌入编译产物（sakura-settings.exe），合并后需按仓库现有方式重建 Tauri 二进制前端才会生效。