### PR TITLE
修复 README 中失效的 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,10 +125,10 @@ Sakura 在此基础上进行了适配和修改，用于提供 Playwright 浏览�
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=Rvosy%2Fsakura&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#Rvosy/Sakura&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=Rvosy/sakura&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=Rvosy/sakura&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=Rvosy/sakura&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=Rvosy/Sakura&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=Rvosy/Sakura&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=Rvosy/Sakura&type=date&legend=top-left" />
  </picture>
 </a>

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -69,10 +69,10 @@ Thanks to all open source project authors and contributors.
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=Rvosy%2Fsakura&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#Rvosy/Sakura&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=Rvosy/sakura&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=Rvosy/sakura&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=Rvosy/sakura&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=Rvosy/Sakura&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=Rvosy/Sakura&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=Rvosy/Sakura&type=date&legend=top-left" />
  </picture>
 </a>


### PR DESCRIPTION
当前 README 中的 Star History 图表已无法正常加载，更新根 README 和英文文档中的图表链接，恢复项目星标趋势展示。