### PR TITLE
fix(runtime): 未配置 Provider 时保留当前角色展示

### DIFF
--- a/app/config/core_config_reader.py
+++ b/app/config/core_config_reader.py
@@ -69,9 +69,13 @@ def _stable_error(code: str) -> StableReadinessError:
     return StableReadinessError(state=state, code=code, message=message)
 
 
-def _problem_result(code: str) -> CoreConfigReadResult:
+def _problem_result(
+    code: str,
+    *,
+    current_character_id: str | None = None,
+) -> CoreConfigReadResult:
     return CoreConfigReadResult(
-        current_character_id=None,
+        current_character_id=current_character_id,
         provider_selection=None,
         config_problem=_stable_error(code),
     )
@@ -141,6 +145,41 @@ def _read_optional_characters_mapping(
     if not isinstance(loaded, Mapping):
         return None, _stable_error("CONFIG_DATA_INVALID")
     return dict(loaded), None
+
+
+def _read_current_character_id(
+    config_dir: Path,
+) -> tuple[str | None, StableReadinessError | None]:
+    characters, problem = _read_optional_characters_mapping(
+        config_dir / "characters.yaml"
+    )
+    if problem is not None:
+        return None, problem
+    assert characters is not None
+    current_character_id = characters.get("current_character_id")
+    if current_character_id is not None and not isinstance(current_character_id, str):
+        return None, _stable_error("CONFIG_DATA_INVALID")
+    current_character_id = (
+        current_character_id.strip()
+        if isinstance(current_character_id, str)
+        else None
+    )
+    return current_character_id or None, None
+
+
+def _problem_result_with_character(
+    config_dir: Path,
+    code: str,
+) -> CoreConfigReadResult:
+    if code != "PROVIDER_SETUP_REQUIRED":
+        return _problem_result(code)
+    current_character_id, problem = _read_current_character_id(config_dir)
+    if problem is not None:
+        return _problem_result(problem.code)
+    return _problem_result(
+        code,
+        current_character_id=current_character_id,
+    )
 
 
 def _parse_profiles(
@@ -288,22 +327,22 @@ class CoreConfigReader:
 
         api_data, problem = _read_auxiliary_mapping(config_dir / "api.yaml")
         if problem is not None:
-            return _problem_result(problem.code)
+            return _problem_result_with_character(config_dir, problem.code)
         assert api_data is not None
 
         selections, problem = _parse_model_selection(api_data)
         if problem is not None:
-            return _problem_result(problem.code)
+            return _problem_result_with_character(config_dir, problem.code)
         profiles, problem = _parse_profiles(api_data)
         if problem is not None:
-            return _problem_result(problem.code)
+            return _problem_result_with_character(config_dir, problem.code)
         assert profiles is not None and selections is not None
 
         raw_llm = api_data.get("llm", {})
         if raw_llm is None:
             raw_llm = {}
         if not isinstance(raw_llm, Mapping):
-            return _problem_result("CONFIG_DATA_INVALID")
+            return _problem_result_with_character(config_dir, "CONFIG_DATA_INVALID")
         timeout_seconds = raw_llm.get("timeout_seconds", 60)
         max_tokens = raw_llm.get("max_tokens")
         if (
@@ -319,7 +358,7 @@ class CoreConfigReader:
                 )
             )
         ):
-            return _problem_result("CONFIG_DATA_INVALID")
+            return _problem_result_with_character(config_dir, "CONFIG_DATA_INVALID")
         base_settings = ClientApiSettings(
             base_url="",
             api_key="",
@@ -335,29 +374,19 @@ class CoreConfigReader:
                 base_settings,
             )
         except Exception:
-            return _problem_result("CONFIG_DATA_INVALID")
+            return _problem_result_with_character(config_dir, "CONFIG_DATA_INVALID")
         if resolved is None:
-            return _problem_result("PROVIDER_SETUP_REQUIRED")
+            return _problem_result_with_character(config_dir, "PROVIDER_SETUP_REQUIRED")
         settings = resolved.settings
         if not settings.base_url.strip() or not settings.api_key.strip() or not settings.model.strip():
-            return _problem_result("PROVIDER_SETUP_REQUIRED")
+            return _problem_result_with_character(config_dir, "PROVIDER_SETUP_REQUIRED")
         problem = _validate_provider_url(settings.base_url)
         if problem is not None:
-            return _problem_result(problem.code)
+            return _problem_result_with_character(config_dir, problem.code)
 
-        characters_path = config_dir / "characters.yaml"
-        characters, problem = _read_optional_characters_mapping(characters_path)
+        current_character_id, problem = _read_current_character_id(config_dir)
         if problem is not None:
             return _problem_result(problem.code)
-        assert characters is not None
-        current_character_id = characters.get("current_character_id")
-        if current_character_id is not None and not isinstance(current_character_id, str):
-            return _problem_result("CONFIG_DATA_INVALID")
-        current_character_id = (
-            current_character_id.strip() if isinstance(current_character_id, str) else None
-        )
-        if not current_character_id:
-            current_character_id = None
 
         return CoreConfigReadResult(
             current_character_id=current_character_id,

--- a/app/core_host/assistant_adapter.py
+++ b/app/core_host/assistant_adapter.py
@@ -185,12 +185,25 @@ class AssistantAdapter:
             self._check_active(cancel)
             if config.config_problem is not None:
                 problem = config.config_problem
+                presentation = None
+                if (
+                    problem.code == "PROVIDER_SETUP_REQUIRED"
+                    and config.current_character_id is not None
+                ):
+                    registry = CharacterRegistry(
+                        self._user_root,
+                        issue_sink=_safe_character_issue_sink,
+                    )
+                    profile = registry.profiles.get(config.current_character_id)
+                    if profile is not None:
+                        presentation = project_character_presentation(profile)
                 return ReadinessResult(
                     state=problem.state,
                     code=problem.code,
                     message=problem.message,
                     retryable=False,
                     current_character_summary=None,
+                    current_character_presentation=presentation,
                 )
 
             registry = CharacterRegistry(

--- a/app/core_host/server.py
+++ b/app/core_host/server.py
@@ -286,7 +286,8 @@ class ReadinessController:
                     "retryable": problem.retryable,
                 }
                 self._current_character_summary = None
-                self._current_character_presentation = None
+                if problem.code != "PROVIDER_SETUP_REQUIRED":
+                    self._current_character_presentation = None
                 self._revision += 1
             return
 

--- a/desktop/frontend/settings/character-switch-runtime.js
+++ b/desktop/frontend/settings/character-switch-runtime.js
@@ -1,4 +1,4 @@
-const READY_STATES = new Set(["ready", "degraded"]);
+const PRESENTATION_READY_STATES = new Set(["ready", "setup_required", "degraded"]);
 const TERMINAL_FAILURE_STATES = new Set(["setup_required", "failed"]);
 // Core can spend up to 5s stopping the old tree, then 3s/5s on the
 // hello/initialize handshakes and 30s reaching stable readiness. Keep the UI
@@ -97,7 +97,7 @@ export async function waitForCharacterSwitch({
       && presentation?.generationId === supervisor.generationId;
     if (
       generationConsistent
-      && READY_STATES.has(snapshot.readiness)
+      && PRESENTATION_READY_STATES.has(snapshot.readiness)
       && presentation.characterId === receipt.targetCharacterId
     ) return lifecycle;
     if (

--- a/desktop/frontend/tests/character-switch-runtime.test.js
+++ b/desktop/frontend/tests/character-switch-runtime.test.js
@@ -137,6 +137,17 @@ test("switch completion requires a newer consistent ready generation and target 
   assert.equal(publications.length, 0);
 });
 
+test("provider setup still completes a switch when the target presentation is ready", async () => {
+  const result = await waitForCharacterSwitch({
+    receipt,
+    previousGenerationNumber: 1,
+    readLifecycle: async () => lifecycle({ readiness: "setup_required" }),
+    delay: async () => {},
+  });
+  assert.equal(result.snapshot.readiness, "setup_required");
+  assert.equal(result.characterPresentation.characterId, "character-b");
+});
+
 test("switch coordinator clears old role state before waiting and always leaves switching", async () => {
   const sequence = [];
   await applyCharacterSwitch({

--- a/desktop/src-tauri/src/core_host_runtime.rs
+++ b/desktop/src-tauri/src/core_host_runtime.rs
@@ -3795,6 +3795,18 @@ mod tests {
     }
 
     #[test]
+    fn provider_setup_snapshot_can_keep_character_presentation() {
+        let mut snapshot =
+            valid_assistant_snapshot("PROVIDER_SETUP_REQUIRED", "setup_required", Value::Null);
+        snapshot["characterPresentation"] = valid_character_presentation();
+        let mut cache = CoreSnapshotCache::new(GENERATION_ID).expect("generation cache");
+
+        cache
+            .store_python_snapshot(&snapshot)
+            .expect("provider setup keeps the selected character visible");
+    }
+
+    #[test]
     fn character_summary_requires_the_exact_five_public_fields_and_types() {
         let valid = valid_assistant_snapshot("READY", "ready", valid_character_summary());
         let mut cache = CoreSnapshotCache::new(GENERATION_ID).expect("generation cache");

--- a/desktop/src-tauri/src/shell_lifecycle.rs
+++ b/desktop/src-tauri/src/shell_lifecycle.rs
@@ -994,7 +994,10 @@ fn ready_character_generation(
     let ready = publication.supervisor.generation_number > previous_generation_number
         && generation_id != previous_generation_id
         && snapshot.generation_id == generation_id
-        && matches!(snapshot.readiness.as_str(), "ready" | "degraded")
+        && matches!(
+            snapshot.readiness.as_str(),
+            "ready" | "setup_required" | "degraded"
+        )
         && presentation.get("generationId").and_then(Value::as_str) == Some(generation_id.as_str())
         && presentation.get("characterId").and_then(Value::as_str) == Some(target_character_id);
     ready.then_some(generation_id)
@@ -1821,6 +1824,11 @@ mod tests {
                 log_location: "Sakura application logs",
             },
         };
+        assert_eq!(
+            ready_character_generation(&publication, "generation-a", 1, "beta").as_deref(),
+            Some("generation-b")
+        );
+        publication.snapshot.as_mut().expect("snapshot").readiness = "setup_required".to_string();
         assert_eq!(
             ready_character_generation(&publication, "generation-a", 1, "beta").as_deref(),
             Some("generation-b")

--- a/tests/integration/test_core_host_lifecycle.py
+++ b/tests/integration/test_core_host_lifecycle.py
@@ -390,6 +390,36 @@ def test_real_host_initializes_in_background_and_returns_python_snapshot(tmp_pat
         stop_host(process)
 
 
+def test_real_host_keeps_character_visible_while_provider_setup_is_required(
+    tmp_path: Path,
+) -> None:
+    app_root = isolated_app_root(tmp_path, ready=True)
+    (app_root / "config" / "api.yaml").unlink()
+    process = start_host(app_root)
+    try:
+        assert exchange(process, request("hello", "system.hello"))["ok"] is True
+        assert exchange(process, request("initialize", "core.initialize"))["ok"] is True
+
+        deadline = time.monotonic() + 2
+        while True:
+            snapshot = exchange(process, request("snapshot", "core.snapshot"))["payload"]
+            if snapshot["readiness"] == "setup_required":
+                break
+            assert time.monotonic() < deadline
+
+        assert snapshot["components"]["assistant"] == {
+            "state": "setup_required",
+            "code": "PROVIDER_SETUP_REQUIRED",
+            "retryable": False,
+        }
+        assert snapshot["currentCharacterSummary"] is None
+        assert snapshot["characterPresentation"]["characterId"] == "sakura"
+        assert exchange(process, request("shutdown", "system.shutdown"))["ok"] is True
+        assert process.wait(timeout=5) == 0
+    finally:
+        stop_host(process)
+
+
 def test_real_host_rejects_fixture_modes_and_remains_responsive(tmp_path: Path) -> None:
     process = start_host(isolated_app_root(tmp_path))
     try:

--- a/tests/unit/test_core_host_config_reader.py
+++ b/tests/unit/test_core_host_config_reader.py
@@ -174,7 +174,7 @@ def _assert_problem(
 ) -> None:
     result, _opened = _read_with_guards(root, monkeypatch)
     assert result == CoreConfigReadResult(
-        current_character_id=None,
+        current_character_id="sakura" if code == "PROVIDER_SETUP_REQUIRED" else None,
         provider_selection=None,
         config_problem=EXPECTED_PROBLEMS[code],
     )
@@ -277,6 +277,20 @@ def test_auxiliary_config_frozen_file_rows(
     if file_name == "api.yaml" and code == "CORE_CONFIG_SETUP_REQUIRED":
         code = "PROVIDER_SETUP_REQUIRED"
     _assert_problem(root, monkeypatch, code)
+
+
+def test_missing_provider_does_not_mask_invalid_character_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = _fresh_root(tmp_path)
+    (root / "config" / "api.yaml").unlink()
+    (root / "config" / "characters.yaml").write_text(
+        "current_character_id: [\n",
+        encoding="utf-8",
+    )
+
+    _assert_problem(root, monkeypatch, "CONFIG_DATA_INVALID")
 
 
 VALID_API_PREFIX = """\

--- a/tests/unit/test_core_host_provider_settings.py
+++ b/tests/unit/test_core_host_provider_settings.py
@@ -680,6 +680,18 @@ def test_provider_readiness_transitions_replace_only_the_session(
     from app.core_host.assistant_adapter import ReadinessResult
     from app.core_host.server import HostConfig, ReadinessController
 
+    presentation = {
+        "schemaVersion": 1,
+        "generationId": "initializer-owned",
+        "characterId": "fixture-character",
+        "displayName": "Fixture Character",
+        "initialMessage": "hello",
+        "themeTokens": {},
+        "defaultPortraitKey": "__default__",
+        "portraitKeys": ["__default__"],
+        "portraitResourceIds": {"__default__": "fixture-resource"},
+    }
+
     class Provider:
         def __init__(self) -> None:
             self.settings: list[object] = []
@@ -701,6 +713,7 @@ def test_provider_readiness_transitions_replace_only_the_session(
                 message="ready",
                 retryable=False,
                 current_character_summary=None,
+                current_character_presentation=presentation,
                 session=SimpleNamespace(provider=provider),
             )
 
@@ -750,6 +763,8 @@ def test_provider_readiness_transitions_replace_only_the_session(
         time.sleep(0.01)
     assert controller.readiness() == "ready"
     initial_revision = controller.snapshot()["revision"]
+    expected_presentation = {**presentation, "generationId": GENERATION}
+    assert controller.snapshot()["characterPresentation"] == expected_presentation
     original_session = controller.published_session()
     plugin_application = PluginApplication()
     with controller._lock:
@@ -765,6 +780,7 @@ def test_provider_readiness_transitions_replace_only_the_session(
     assert controller.readiness() == "setup_required"
     assert controller.published_session() is None
     assert controller.snapshot()["revision"] == initial_revision + 1
+    assert controller.snapshot()["characterPresentation"] == expected_presentation
     assert initializer.retired == 1
     assert plugin_application.unbound == 1
 


### PR DESCRIPTION
## 背景

在 Runtime v2 的 1.0.0 macOS 包中，如果用户已经选择了角色、但尚未配置对话模型 Provider，Core 会进入 `setup_required`。此前该状态同时清空 `characterPresentation`，导致桌宠无法显示已选角色，角色切换流程也会被前端判定为初始化失败；实包日志会反复出现 `CHARACTER_PRESENTATION_NOT_READY`。

## 修改

- 仅在 `PROVIDER_SETUP_REQUIRED` 状态下继续读取并保留 `current_character_id`；损坏、非法或不兼容的配置仍按原有错误 fail-closed。
- Provider 尚未配置时，从有效角色档案投影 `characterPresentation`，但保持 `currentCharacterSummary = null` 且不创建 Assistant session。
- Provider 热更新回到 `setup_required` 时保留当前角色展示，仍撤销旧 session 与插件绑定。
- 角色切换和原生窗口 reveal gate 接受带有正确 generation、目标角色一致的 `setup_required` presentation；`failed` 等状态仍不会放行。
- 增加 Python、前端和 Rust 回归测试，覆盖首启、热更新、generation/角色一致性与损坏角色配置不被掩盖。

## 安全边界

- 本修改不会绕过 Provider 配置，也不会让未就绪状态发送模型请求。
- 无 Provider 时，`chat.send` 仍稳定返回 `ASSISTANT_NOT_READY`。
- 仅角色展示可以在 `setup_required` 下发布；角色运行摘要和 Assistant session 仍为空。
- 未修改 TTS、模型设备选择、Updater 或签名策略。

## 验证

- Python Runtime v2 release focused suite：`337 passed`
- Python 全量单测：`859 passed, 33 skipped`
- 最终补丁相关回归：`103 passed`
- 前端全量：`305 passed`
- Rust 全集过滤验证：`344 passed, 5 ignored`
- `cargo fmt --check`、Python `py_compile`、`git diff --check`：通过
- release distribution staging/smoke：通过（1.0.0，9,794 files）
- macOS arm64 Tauri release app + DMG：构建、DMG 校验/挂载、资源与架构检查通过
- fork 手动打包 [Actions #33317179146](https://github.com/Nothing1596/sakura/actions/runs/33317179146)：提交 `637665b9` 的 macOS arm64（8m48s）与 Windows x64（12m24s）均通过
- 下载并复核云端 macOS artifact：ZIP 完整性与 DMG CRC 通过，artifact SHA-256 与 size report 一致；staging inventory 的 9,794 个文件逐项哈希一致，最终 `.app` 仅由 Tauri 额外加入 `icon.icns`
- 实包首次启动：未配置 Provider 时 `QA Sakura` 角色与头像正常显示，发送按钮保持禁用
- 云端 macOS artifact 完成设置页用户流程验收：
  - 设置窗口与“记忆”页面可立即打开和切换，未复现设置窗口卡死
  - 在 UI 中新增 `QA Loopback`、自动检测到 `qa-model` 并通过“测试连接”
  - 应用设置后主窗口角色保持可见，发送按钮启用，并收到完整聊天回复
  - 重新打开设置后 Provider、Base URL 与模型槽位均正确恢复，API Key 仍以掩码展示
  - 测试密钥未出现在运行日志；通过桌宠菜单退出后 Core、插件和测试 Provider 均无残留进程
- 本地构建与云端 macOS artifact 均通过实包 Core 闭环：
  - `setup_required` 下发布 `qa_sakura` presentation，summary 为空
  - 无 Provider 聊天返回 `ASSISTANT_NOT_READY`
  - 经设置协议写入本地假 Provider 后转为 `ready`
  - 真正发出一次 `chat.send`，收到 `chat.completed`
  - Core、插件与假 Provider 全部正常退出，无残留进程

- 重建到最新 `main` 后的定点验证：Python `89 passed`、前端 `305 passed`、Rust 相关回归 `2 passed`；`git diff --check` 通过。

## CI 与发布说明

- PR 已重建到最新 `main`，当前 head 为 `a61fab48`，仓库 `Test` 与 `Runtime v2 platform foundation` checks 已触发。
- 当前 workflow 明确生成 unsigned local package，因此本地包不具备正式分发签名；签名和 notarization 不属于本修复范围。
