### PR TITLE
ci: 发布 Sakura 服务版本元数据

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -417,3 +417,65 @@ jobs:
           tag_name: ${{ needs.metadata.outputs.tag }}
           token: ${{ github.token }}
           files: release-assets/latest.json
+
+  publish-service-metadata:
+    needs: [metadata, publish-portable]
+    if: needs.metadata.outputs.prerelease == 'false'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Generate the Sakura service release metadata
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.metadata.outputs.tag }}
+          VERSION: ${{ needs.metadata.outputs.version }}
+        run: |
+          set -euo pipefail
+          published_at="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" \
+            --jq .published_at)"
+          jq -n \
+            --arg version "$VERSION" \
+            --arg tag "$TAG" \
+            --arg publishedAt "$published_at" \
+            '{
+              schema: 1,
+              latest: $version,
+              minimumSupported: null,
+              releaseUrl: ("https://github.com/Rvosy/Sakura/releases/tag/" + $tag),
+              publishedAt: $publishedAt,
+              urgent: false,
+              downloads: {
+                windowsX64Setup: ("https://github.com/Rvosy/Sakura/releases/download/" + $tag + "/Sakura-" + $version + "-windows-x64-setup.exe"),
+                windowsX64Portable: ("https://github.com/Rvosy/Sakura/releases/download/" + $tag + "/Sakura-" + $version + "-windows-x64-portable.zip"),
+                macosArm64Dmg: ("https://github.com/Rvosy/Sakura/releases/download/" + $tag + "/Sakura-" + $version + "-macos-arm64.dmg")
+              },
+              updaterManifestUrl: "https://github.com/Rvosy/Sakura/releases/latest/download/latest.json"
+            }' > service-releases.json
+
+      - name: Configure the restricted deployment identity
+        shell: bash
+        env:
+          DEPLOY_KEY: ${{ secrets.SAKURA_SERVICE_DEPLOY_KEY }}
+          KNOWN_HOSTS: ${{ secrets.SAKURA_SERVICE_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          test -n "$DEPLOY_KEY"
+          test -n "$KNOWN_HOSTS"
+          install -d -m 700 ~/.ssh
+          printf '%s\n' "$DEPLOY_KEY" > ~/.ssh/sakura-service
+          printf '%s\n' "$KNOWN_HOSTS" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/sakura-service ~/.ssh/known_hosts
+
+      - name: Publish the release metadata to Sakura Service
+        shell: bash
+        run: |
+          set -euo pipefail
+          ssh -T \
+            -i ~/.ssh/sakura-service \
+            -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=yes \
+            sakura-release@sakura.cialloo.cn \
+            < service-releases.json

--- a/docs/specs/runtime-v2/release-distribution-and-storage.md
+++ b/docs/specs/runtime-v2/release-distribution-and-storage.md
@@ -123,6 +123,13 @@ ZIP 只含程序域、`portable.flag` 和当前 `sakura.exe`，不得携带任�
 把 ZIP 追加到同一 Release，并用包含 Portable URL 与 SHA-256 的最终 `latest.json` 覆盖初始清单。Portable 失败
 不得撤回已经发布的安装版资产；失败必须在 workflow 中明确可见，维护者修复后重新运行完整发行流程。
 
+稳定版的 Portable 与最终 `latest.json` 发布完成后，发行 workflow 必须把控制面版本元数据推送到
+`https://sakura.cialloo.cn/service/v1/releases.json`。该接口是公告、兼容性和下载入口使用的只读控制面，不替代
+Tauri Updater 的签名清单，也不由客户端据此安装更新。schema 1 固定包含 `latest`、可空的
+`minimumSupported`、`releaseUrl`、`publishedAt`、`urgent`、三个公开下载 URL 和
+`updaterManifestUrl`；下载文件仍由 GitHub Release 托管。prerelease 不更新该接口，服务端拒绝格式错误和版本
+降级。部署凭据只能调用服务器端受限发布命令，不得获得通用 shell 或站点其他文件的写权限。
+
 Windows Setup 卸载器无论是否勾选“删除应用数据”，都必须递归删除安装器拥有的 `core/`、`python/`、
 `plugins/builtin/` 和 `plugins/dependencies/` 发行根，包括运行期间在其中产生的字节码缓存；大量小文件的删除
 不得逐文件刷新卸载详情。未勾选时保留安装目录内的用户数据。勾选后必须额外递归删除 Runtime v2 拥有的


### PR DESCRIPTION
## 内容

- 在正式 Release 的 Portable 与最终 updater manifest 完成后生成控制面版本 JSON
- 使用受限 SSH 身份发布到 sakura.cialloo.cn
- prerelease 不更新稳定版控制面
- 补充发行与存储合同

## 服务器侧

静态接口、Nginx 缓存/CORS 规则、forced-command 校验器和仓库 Secrets 已部署并验证。下载资产仍由 GitHub Release 托管。