### PR TITLE
修复语音播放中再次对话无回复的问题

### DIFF
--- a/app/legacy_import/importer.py
+++ b/app/legacy_import/importer.py
@@ -1392,20 +1392,54 @@ def _sanitize_tts_runtime_pth_files(tts_root: Path) -> tuple[int, int]:
                 "validating",
                 path.relative_to(tts_root.parent).as_posix(),
             ) from error
+        original_lines = raw.splitlines()
         kept = [
             line
-            for line in raw.splitlines()
+            for line in original_lines
             if not _is_absolute_runtime_path(line.strip())
         ]
-        if len(kept) == len(raw.splitlines()):
+        portable = _portable_gpt_sovits_pth_entries(path)
+        normalized_kept = {line.strip().replace("\\", "/") for line in kept}
+        additions = [entry for entry in portable if entry not in normalized_kept]
+        if len(kept) == len(original_lines) and not additions:
             continue
+        kept.extend(additions)
         if not any(line.strip() and not line.lstrip().startswith("#") for line in kept):
             kept = ["# Legacy absolute paths removed during Sakura import."]
         encoded = "\n".join(kept) + "\n"
+        if encoded == raw:
+            continue
         path.write_text(encoded, encoding="utf-8", newline="\n")
         changed += 1
         byte_delta += len(encoded.encode("utf-8")) - len(raw.encode("utf-8"))
     return changed, byte_delta
+
+
+def _portable_gpt_sovits_pth_entries(path: Path) -> list[str]:
+    """Return relocatable imports for a recognized Windows GPT-SoVITS runtime."""
+
+    if path.name.casefold() != "users.pth" or len(path.parents) < 4:
+        return []
+    site_packages = path.parent
+    work_dir = path.parents[3]
+    if not (work_dir / "api_v2.py").is_file():
+        return []
+    required = (work_dir / "tools", work_dir / "GPT_SoVITS")
+    if any(not target.is_dir() for target in required):
+        return []
+    relatives = (
+        Path("."),
+        Path("GPT_SoVITS/BigVGAN"),
+        Path("tools"),
+        Path("tools/asr"),
+        Path("GPT_SoVITS"),
+        Path("tools/uvr5"),
+    )
+    return [
+        os.path.relpath(work_dir / relative, site_packages).replace("\\", "/")
+        for relative in relatives
+        if (work_dir / relative).is_dir()
+    ]
 
 
 def _sanitize_tts_profile_payload(payload: Mapping[str, object]) -> dict[str, object]:

--- a/desktop/frontend/chat/chat-presentation.js
+++ b/desktop/frontend/chat/chat-presentation.js
@@ -193,7 +193,11 @@ export function createChatPresentationReducer({ initialMessage, defaultPortraitK
       if (event.generationNumber !== state.generationNumber || event.generationId !== state.generationId)
         return result(false);
       if (event.type === "chat.started") {
-        if (!isChatReadyLifecycle(state.lifecycle) || !event.operationId || state.operationId) return result(false);
+        if (!isChatReadyLifecycle(state.lifecycle) || !event.operationId) return result(false);
+        if (
+          state.operationId
+          && (state.phase !== "typing" || event.operationId === state.operationId)
+        ) return result(false);
         if (event.presentation === "silent") {
           state = freezeState({
             ...state,

--- a/desktop/frontend/tests/chat-presentation.test.js
+++ b/desktop/frontend/tests/chat-presentation.test.js
@@ -151,6 +151,46 @@ test("completed replies keep the waiting frame visible until the first subtitle 
   assert.equal(reducer.setWaitingText("...").applied, false);
 });
 
+test("a new request replaces a completed reply that is still typing or playing audio", () => {
+  const reducer = readyReducer();
+  reducer.reduce({
+    type: "chat.started",
+    generationId: "generation-1",
+    generationNumber: 1,
+    operationId: "first",
+  });
+  reducer.reduce({
+    type: "chat.completed",
+    generationId: "generation-1",
+    generationNumber: 1,
+    operationId: "first",
+    reply: { segments: [{ text: "仍在播放的第一轮回复", portrait: "smile" }] },
+  });
+  reducer.setTypingText("");
+
+  const started = reducer.reduce({
+    type: "chat.started",
+    generationId: "generation-1",
+    generationNumber: 1,
+    operationId: "second",
+  });
+  assert.equal(started.applied, true);
+  assert.equal(started.state.phase, "thinking");
+  assert.equal(started.state.operationId, "second");
+  assert.equal(started.state.bubbleText, ".");
+
+  const completed = reducer.reduce({
+    type: "chat.completed",
+    generationId: "generation-1",
+    generationNumber: 1,
+    operationId: "second",
+    reply: { segments: [{ text: "第二轮正常回复", portrait: "calm" }] },
+  });
+  assert.equal(completed.applied, true);
+  assert.equal(completed.state.phase, "typing");
+  assert.equal(completed.state.segments[0].text, "第二轮正常回复");
+});
+
 test("silent proactive requests preserve the current UI until the completed reply starts", () => {
   const reducer = readyReducer();
   reducer.reduce({ type: "chat.started", generationId: "generation-1", generationNumber: 1, operationId: "previous" });

--- a/plugins/builtin/sakura_gpt_sovits/_runtime_profile.py
+++ b/plugins/builtin/sakura_gpt_sovits/_runtime_profile.py
@@ -27,6 +27,7 @@ _ERROR_CODES = {
     "TTS_ACCELERATOR_UNAVAILABLE",
     "TTS_DEVICE_PROBE_FAILED",
     "TTS_PROFILE_GENERATION_FAILED",
+    "TTS_RUNTIME_PATH_REPAIR_FAILED",
 }
 _MANAGED_PATH_FIELDS = (
     "bert_base_path",
@@ -34,6 +35,15 @@ _MANAGED_PATH_FIELDS = (
     "t2s_weights_path",
     "vits_weights_path",
 )
+_MANAGED_IMPORT_PATHS = (
+    Path("."),
+    Path("GPT_SoVITS/BigVGAN"),
+    Path("tools"),
+    Path("tools/asr"),
+    Path("GPT_SoVITS"),
+    Path("tools/uvr5"),
+)
+_REQUIRED_IMPORT_PATHS = (Path("tools"), Path("GPT_SoVITS"))
 
 
 class RuntimeProfileError(RuntimeError):
@@ -94,6 +104,126 @@ def find_runtime_python(work_dir: Path) -> Optional[Path]:
     return None
 
 
+def repair_managed_runtime_paths(
+    work_dir: Path,
+    *,
+    platform: Optional[str] = None,
+) -> bool:
+    """Make the bundled Python import paths survive moving the runtime.
+
+    The Windows GPT-SoVITS archives use an isolated embedded Python whose
+    ``users.pth`` is the only route to ``tools`` and ``GPT_SoVITS``.  Some
+    installed archives contain absolute paths from their previous location.
+    Replace only recognized bundle entries with relative paths, preserving
+    comments, import hooks, and unknown custom entries verbatim.
+    """
+
+    if (platform or sys.platform) != "win32":
+        return False
+    work_dir = Path(work_dir).resolve(strict=False)
+    site_packages = work_dir / "runtime" / "Lib" / "site-packages"
+    users_pth = site_packages / "users.pth"
+    if not users_pth.is_file():
+        return False
+    if any(not (work_dir / relative).is_dir() for relative in _REQUIRED_IMPORT_PATHS):
+        raise RuntimeProfileError("TTS_RUNTIME_PATH_REPAIR_FAILED")
+    try:
+        raw = users_pth.read_text(encoding="utf-8")
+        expected = [
+            (work_dir / relative).resolve(strict=False)
+            for relative in _MANAGED_IMPORT_PATHS
+            if (work_dir / relative).is_dir()
+        ]
+        portable = [
+            os.path.relpath(target, site_packages).replace("\\", "/")
+            for target in expected
+        ]
+        original_lines = raw.splitlines()
+        old_roots = _managed_import_roots(original_lines)
+        kept: list[str] = []
+        insertion = None
+        for line in original_lines:
+            if _is_managed_import_entry(line, site_packages, expected, old_roots):
+                if insertion is None:
+                    insertion = len(kept)
+                continue
+            kept.append(line)
+        if insertion is None:
+            insertion = len(kept)
+        updated_lines = [*kept[:insertion], *portable, *kept[insertion:]]
+        encoded = "\n".join(updated_lines) + "\n"
+        if encoded == raw:
+            return False
+        temporary: Optional[Path] = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                newline="\n",
+                prefix=".users.",
+                suffix=".tmp.pth",
+                dir=str(site_packages),
+                delete=False,
+            ) as handle:
+                handle.write(encoded)
+                handle.flush()
+                os.fsync(handle.fileno())
+                temporary = Path(handle.name)
+            os.replace(temporary, users_pth)
+            temporary = None
+        finally:
+            if temporary is not None:
+                temporary.unlink(missing_ok=True)
+    except RuntimeProfileError:
+        raise
+    except (OSError, UnicodeError, ValueError) as error:
+        raise RuntimeProfileError("TTS_RUNTIME_PATH_REPAIR_FAILED") from error
+    return True
+
+
+def _is_managed_import_entry(
+    line: str,
+    site_packages: Path,
+    expected: list[Path],
+    old_roots: set[tuple[str, ...]],
+) -> bool:
+    value = line.strip()
+    if not value or value.startswith("#") or value.startswith(("import ", "import\t")):
+        return False
+    candidate = (site_packages / value).resolve(strict=False)
+    if any(_path_identity(candidate) == _path_identity(target) for target in expected):
+        return True
+    windows = PureWindowsPath(value.replace("/", "\\"))
+    if not windows.is_absolute():
+        return False
+    parts = tuple(part.casefold() for part in windows.parts)
+    if parts in old_roots:
+        return True
+    for relative in _MANAGED_IMPORT_PATHS[1:]:
+        suffix = tuple(part.casefold() for part in relative.parts)
+        if len(parts) > len(suffix) and parts[-len(suffix) :] == suffix:
+            return True
+    return False
+
+
+def _managed_import_roots(lines: Iterable[str]) -> set[tuple[str, ...]]:
+    roots: set[tuple[str, ...]] = set()
+    for line in lines:
+        value = line.strip()
+        if not value or value.startswith("#") or value.startswith(("import ", "import\t")):
+            continue
+        windows = PureWindowsPath(value.replace("/", "\\"))
+        if not windows.is_absolute():
+            continue
+        parts = tuple(part.casefold() for part in windows.parts)
+        for relative in _MANAGED_IMPORT_PATHS[1:]:
+            suffix = tuple(part.casefold() for part in relative.parts)
+            if len(parts) <= len(suffix) or parts[-len(suffix) :] != suffix:
+                continue
+            roots.add(parts[: -len(suffix)])
+    return roots
+
+
 def select_device_profile(
     candidates: Iterable[DeviceCandidate],
     *,
@@ -145,6 +275,7 @@ def prepare_managed_profile(
     configured = Path(configured_path) if configured_path is not None else None
     if platform != "win32":
         return configured
+    repair_managed_runtime_paths(work_dir, platform=platform)
     if configured is not None and not is_managed_profile(configured, work_dir):
         return configured
     python = Path(runtime_python) if runtime_python is not None else find_runtime_python(work_dir)

--- a/tests/unit/test_gpt_sovits_runtime_profile.py
+++ b/tests/unit/test_gpt_sovits_runtime_profile.py
@@ -227,6 +227,73 @@ def test_user_config_remains_authoritative_without_probe(tmp_path: Path) -> None
     ) == custom
 
 
+def test_runtime_import_paths_are_relocatable_preserve_custom_entries_and_are_idempotent(
+    tmp_path: Path,
+) -> None:
+    work_dir = tmp_path / "relocated-runtime"
+    site_packages = work_dir / "runtime" / "Lib" / "site-packages"
+    site_packages.mkdir(parents=True)
+    for relative in (
+        "GPT_SoVITS/BigVGAN",
+        "tools/asr",
+        "tools/uvr5",
+    ):
+        (work_dir / relative).mkdir(parents=True)
+    users = site_packages / "users.pth"
+    users.write_text(
+        "# vendor hook\n"
+        "D:\\Old Sakura\\tts\\g50\n"
+        "D:/Old Sakura/tts/g50/GPT_SoVITS/BigVGAN\n"
+        "D:/Old Sakura/tts/g50/tools\n"
+        "D:/Old Sakura/tts/g50/tools/asr\n"
+        "D:/Old Sakura/tts/g50/GPT_SoVITS\n"
+        "D:/Old Sakura/tts/g50/tools/uvr5\n"
+        "import runtime_bootstrap\n"
+        "E:\\Shared\\custom-package\n"
+        "./custom-relative\n",
+        encoding="utf-8",
+    )
+
+    assert _runtime_profile.repair_managed_runtime_paths(
+        work_dir,
+        platform="win32",
+    ) is True
+    repaired = users.read_text(encoding="utf-8")
+    assert repaired == (
+        "# vendor hook\n"
+        "../../..\n"
+        "../../../GPT_SoVITS/BigVGAN\n"
+        "../../../tools\n"
+        "../../../tools/asr\n"
+        "../../../GPT_SoVITS\n"
+        "../../../tools/uvr5\n"
+        "import runtime_bootstrap\n"
+        "E:\\Shared\\custom-package\n"
+        "./custom-relative\n"
+    )
+    assert _runtime_profile.repair_managed_runtime_paths(
+        work_dir,
+        platform="win32",
+    ) is False
+    assert users.read_text(encoding="utf-8") == repaired
+
+
+def test_runtime_import_path_repair_failure_keeps_existing_file(tmp_path: Path) -> None:
+    work_dir = tmp_path / "g50"
+    users = work_dir / "runtime" / "Lib" / "site-packages" / "users.pth"
+    users.parent.mkdir(parents=True)
+    users.write_text("D:\\Old Sakura\\tts\\g50\n", encoding="utf-8")
+    before = users.read_bytes()
+
+    with pytest.raises(
+        _runtime_profile.RuntimeProfileError,
+        match="TTS_RUNTIME_PATH_REPAIR_FAILED",
+    ):
+        _runtime_profile.repair_managed_runtime_paths(work_dir, platform="win32")
+
+    assert users.read_bytes() == before
+
+
 def test_host_profile_runner_requires_structured_success(tmp_path: Path) -> None:
     work_dir = tmp_path / "gpt"
     python = work_dir / "runtime" / "python.exe"

--- a/tests/unit/test_legacy_import.py
+++ b/tests/unit/test_legacy_import.py
@@ -3595,8 +3595,16 @@ def test_tts_profile_adaptation_removes_old_install_paths(tmp_path: Path) -> Non
 
 def test_tts_runtime_path_adaptation_removes_old_absolute_pth_entries(tmp_path: Path) -> None:
     tts_root = tmp_path / "payload" / "tts"
-    site_packages = tts_root / "g50" / "runtime" / "Lib" / "site-packages"
+    work_dir = tts_root / "g50"
+    site_packages = work_dir / "runtime" / "Lib" / "site-packages"
     site_packages.mkdir(parents=True)
+    (work_dir / "api_v2.py").write_text("", encoding="utf-8")
+    for relative in (
+        "GPT_SoVITS/BigVGAN",
+        "tools/asr",
+        "tools/uvr5",
+    ):
+        (work_dir / relative).mkdir(parents=True)
     users = site_packages / "users.pth"
     users.write_text(
         "D:\\Old Sakura\\tts\\g50\n"
@@ -3618,7 +3626,14 @@ def test_tts_runtime_path_adaptation_removes_old_absolute_pth_entries(tmp_path: 
     changed, _byte_delta = _sanitize_tts_runtime_pth_files(tts_root)
 
     assert changed == 2
-    assert "Old Sakura" not in users.read_text(encoding="utf-8")
+    assert users.read_text(encoding="utf-8") == (
+        "../../..\n"
+        "../../../GPT_SoVITS/BigVGAN\n"
+        "../../../tools\n"
+        "../../../tools/asr\n"
+        "../../../GPT_SoVITS\n"
+        "../../../tools/uvr5\n"
+    )
     assert mixed.read_text(encoding="utf-8") == (
         "./relative-package\nimport runtime_bootstrap\n"
     )


### PR DESCRIPTION
## 问题

语音还在播放时发送下一条消息，模型虽然已经返回结果，桌宠气泡却会变空，后续语音也不会生成。原因是上一轮回复进入字幕和语音播放阶段后，前端仍保留旧的 `operationId`。第二轮 `chat.started` 被展示状态拒绝，紧接着到达的 `chat.completed` 也因操作 ID 不匹配而被丢弃。

排查过程中还发现，Windows GPT-SoVITS 整合包的 `users.pth` 可能保存旧安装位置的绝对路径。整合包迁移到其他目录或盘符后，Python 会继续从旧位置加载模块；旧目录不存在时则直接启动失败。

## 修改

- 新请求可以接管仍在打字或播放语音的上一轮展示状态，重复事件仍会被拒绝。
- GPT-SoVITS 启动前检查 `users.pth`，将确认属于整合包的旧绝对路径改成相对路径。
- 路径修复采用临时文件原子替换，未知自定义条目、注释和 import hook 保持原样。
- 新安装、已有安装的下次启动和旧数据迁移都走同一套可搬迁路径约束。
- 目录结构不完整或文件无法安全改写时，保留原文件并返回 `TTS_RUNTIME_PATH_REPAIR_FAILED`。

## 验证

- 前端完整测试：329 项通过。
- GPT-SoVITS 与旧数据迁移 focused tests：126 项通过，2 项按平台跳过。
- `journey-tts`：Python、Rust、前端三个 profile 全部通过。
- 将开发整合包放在与旧路径不同的盘符后，`tools.i18n` 和 `GPT_SoVITS` 均从当前目录解析。

Fixes #167