### PR TITLE
优化运行日志提示并缩短 GPT-SoVITS 启动时间

### DIFF
--- a/desktop/frontend/runtime-log/runtime-log-presentation.js
+++ b/desktop/frontend/runtime-log/runtime-log-presentation.js
@@ -179,7 +179,10 @@ export function viewerInlineSummary(record, limit = 3) {
     return elapsed ? `${elapsed.label}=${elapsed.value}` : "";
   }
   return record.details
-    .filter((detail) => INLINE_DETAIL_LABELS.has(detail.label))
+    .filter((detail) => (
+      INLINE_DETAIL_LABELS.has(detail.label)
+      && !(record.eventCode.startsWith("ipc.request.") && detail.label === "状态")
+    ))
     .slice(0, Math.max(0, limit))
     .map((detail) => `${detail.label}=${detail.value}`)
     .join(" · ");

--- a/desktop/frontend/runtime-log/styles.css
+++ b/desktop/frontend/runtime-log/styles.css
@@ -212,7 +212,9 @@ h1 {
   font-size: 12px;
 }
 .record-category {
-  flex: 0 0 auto;
+  flex: 0 0 64px;
+  width: 64px;
+  overflow: hidden;
   border-radius: 6px;
   padding: 1px 6px;
   color: var(--secondary-text);
@@ -220,6 +222,9 @@ h1 {
   font-size: 11px;
   font-weight: 700;
   letter-spacing: .02em;
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .record-level {
   flex: 0 0 auto;

--- a/desktop/frontend/tests/runtime-log-presentation.test.js
+++ b/desktop/frontend/tests/runtime-log-presentation.test.js
@@ -177,6 +177,23 @@ test("GPT-SoVITS lifecycle rows show only the translated duration inline", () =>
   assert.match(viewerCopyText({ record: lifecycle }), /服务：GPT-SoVITS/);
 });
 
+test("Core request rows do not repeat their outcome beside a specific title", () => {
+  const request = record(1, {
+    category: "CORE",
+    eventCode: "ipc.request.completed",
+    message: "读取运行状态完成",
+    details: [
+      { label: "请求", value: "core.snapshot" },
+      { label: "状态", value: "completed" },
+      { label: "耗时", value: "16 ms" },
+    ],
+  });
+
+  assert.equal(viewerInlineSummary(request), "耗时=16 ms");
+  assert.match(viewerCopyText({ record: request }), /请求：core\.snapshot/);
+  assert.match(viewerCopyText({ record: request }), /状态：completed/);
+});
+
 test("runtime log entrypoint is a module and styles honor reduced motion", () => {
   const html = readFileSync(new URL("../runtime-log/index.html", import.meta.url), "utf8");
   const css = readFileSync(new URL("../runtime-log/styles.css", import.meta.url), "utf8");

--- a/desktop/frontend/tests/runtime-log-presentation.test.js
+++ b/desktop/frontend/tests/runtime-log-presentation.test.js
@@ -249,6 +249,17 @@ test("runtime log uses each summary row as its only details disclosure", () => {
   assert.match(css, /\.record-headline/);
 });
 
+test("runtime log reserves a fixed category column so messages align", () => {
+  const css = readFileSync(new URL("../runtime-log/styles.css", import.meta.url), "utf8");
+  const categoryRule = css.match(/\.record-category\s*\{[\s\S]*?\}/)?.[0] || "";
+
+  assert.match(categoryRule, /flex:\s*0 0 64px/);
+  assert.match(categoryRule, /width:\s*64px/);
+  assert.match(categoryRule, /text-align:\s*center/);
+  assert.match(categoryRule, /text-overflow:\s*ellipsis/);
+  assert.match(categoryRule, /white-space:\s*nowrap/);
+});
+
 test("runtime log removes decorative signals and theme-styles auto scroll", () => {
   const html = readFileSync(new URL("../runtime-log/index.html", import.meta.url), "utf8");
   const css = readFileSync(new URL("../runtime-log/styles.css", import.meta.url), "utf8");

--- a/desktop/src-tauri/src/runtime_log.rs
+++ b/desktop/src-tauri/src/runtime_log.rs
@@ -1021,7 +1021,7 @@ fn project_viewer_record(
         severity: severity.as_str().to_string(),
         category: display_channel(&record.channel, &record.event),
         event_code: record.event.clone(),
-        message: viewer_record_message(record, severity).to_string(),
+        message: viewer_record_message(record, severity),
         description: viewer_problem_description(record, severity).map(str::to_string),
         details: viewer_details(record),
         correlation_id: viewer_correlation(record),
@@ -1038,7 +1038,14 @@ fn viewer_event_is_visible(event: &str, severity: Severity) -> bool {
     severity == Severity::Info && business_message(event).is_some()
 }
 
-fn viewer_record_message(record: &RuntimeLogRecord, severity: Severity) -> &'static str {
+fn viewer_record_message(record: &RuntimeLogRecord, severity: Severity) -> String {
+    if let Some(message) = viewer_ipc_request_message(record) {
+        return message;
+    }
+    viewer_record_default_message(record, severity).to_string()
+}
+
+fn viewer_record_default_message(record: &RuntimeLogRecord, severity: Severity) -> &'static str {
     if viewer_is_gpt_sovits(record) {
         match record.event.as_str() {
             "tts.service.started" => return "正在启动 GPT-SoVITS 服务",
@@ -1068,6 +1075,67 @@ fn viewer_record_message(record: &RuntimeLogRecord, severity: Severity) -> &'sta
         "tts.service.probe.failed" => "语音服务尚未就绪",
         _ => viewer_message(&record.event, severity),
     }
+}
+
+fn viewer_ipc_request_message(record: &RuntimeLogRecord) -> Option<String> {
+    let suffix = match record.event.as_str() {
+        "ipc.request.started" => "中",
+        "ipc.request.completed" => "完成",
+        "ipc.request.cancelled" => "已取消",
+        "ipc.request.failed" => "失败",
+        _ => return None,
+    };
+    let command = viewer_attribute_strings(record, &["command"]).next()?;
+    let action = match command {
+        "system.hello" => "连接后台程序",
+        "system.health" => "检查后台程序状态",
+        "system.shutdown" => "停止后台程序",
+        "core.initialize" => "初始化后台程序",
+        "core.snapshot" => "读取运行状态",
+        "chat.send" => "发送对话",
+        "chat.cancel" => "取消对话",
+        "settings.provider_model.get" => "读取模型设置",
+        "settings.provider_model.save" => "保存模型设置",
+        "settings.provider_model.list_models" => "获取模型列表",
+        "settings.provider_model.test_connection" => "测试模型连接",
+        "settings.provider_model.cancel" => "取消模型测试",
+        "tools.settings.get" => "读取工具设置",
+        "tools.settings.save" => "保存工具设置",
+        "mcp.status.get" => "读取工具服务状态",
+        "plugins.settings.get" => "读取插件设置",
+        "plugins.settings.save" => "保存插件设置",
+        "plugins.enabled.set" => "更改插件开关",
+        "plugins.settings.action" => "执行插件操作",
+        "plugins.install" => "安装插件",
+        "plugins.uninstall" => "卸载插件",
+        "plugins.collection.query" => "读取插件数据",
+        "plugins.collection.create" => "新增插件数据",
+        "plugins.collection.update" => "更新插件数据",
+        "plugins.collection.delete" => "删除插件数据",
+        "ui.composer_tools.get" => "读取输入栏工具",
+        "ui.composer_tools.invoke" => "运行输入栏工具",
+        "tts.synthesis.start" => "提交语音生成",
+        "tts.synthesis.cancel" => "取消语音生成",
+        "tts.settings.get" => "读取语音设置",
+        "tts.settings.save" => "保存语音设置",
+        "tts.status.get" => "读取语音状态",
+        "tts.playback.observe" => "更新语音播放状态",
+        "screen_awareness.settings.get" => "读取屏幕感知设置",
+        "screen_awareness.settings.save" => "保存屏幕感知设置",
+        "characters.settings.get" => "读取角色设置",
+        "characters.settings.import" => "导入角色",
+        "characters.settings.select" => "切换角色",
+        "storage.settings.get" => "读取存储设置",
+        "storage.settings.choose_tts_root" => "更改语音数据目录",
+        "storage.settings.reset_tts_root" => "恢复默认语音目录",
+        "ui.history.page" => "读取对话记录",
+        _ => return None,
+    };
+    Some(if record.event == "ipc.request.started" {
+        format!("正在{action}")
+    } else {
+        format!("{action}{suffix}")
+    })
 }
 
 fn viewer_is_gpt_sovits(record: &RuntimeLogRecord) -> bool {
@@ -3440,7 +3508,7 @@ mod tests {
         assert_eq!(snapshot.records[0].message, "Sakura 已启动");
         assert_eq!(snapshot.records[0].description, None);
         assert_eq!(snapshot.records[1].event_code, "ipc.request.completed");
-        assert_eq!(snapshot.records[1].message, "Core 请求完成");
+        assert_eq!(snapshot.records[1].message, "读取插件设置完成");
         assert_eq!(
             snapshot.records[1].details,
             vec![
@@ -3470,6 +3538,53 @@ mod tests {
             .contains("不应展示的正文"));
         assert!(log.shutdown(Duration::from_millis(500)));
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn wp_5_06_viewer_names_core_requests_in_plain_chinese() {
+        let record = |event: &str, command: &str| RuntimeLogRecord {
+            schema_version: 1,
+            sequence: 1,
+            timestamp: "12:34:56".to_string(),
+            run_id: "run-test".to_string(),
+            source: "rust".to_string(),
+            pid: 1,
+            severity: "info".to_string(),
+            verbosity: "info".to_string(),
+            channel: "core.ipc".to_string(),
+            event: event.to_string(),
+            message: "ignored".to_string(),
+            generation_id: None,
+            generation_number: None,
+            core_pid: None,
+            request_id: None,
+            operation_id: None,
+            action_id: None,
+            trace_id: None,
+            attributes: Some(json!({"command": command})),
+        };
+
+        assert_eq!(
+            viewer_ipc_request_message(&record("ipc.request.started", "core.snapshot")).as_deref(),
+            Some("正在读取运行状态")
+        );
+        assert_eq!(
+            viewer_ipc_request_message(&record("ipc.request.completed", "core.snapshot"))
+                .as_deref(),
+            Some("读取运行状态完成")
+        );
+        assert_eq!(
+            viewer_ipc_request_message(&record("ipc.request.cancelled", "chat.send")).as_deref(),
+            Some("发送对话已取消")
+        );
+        assert_eq!(
+            viewer_ipc_request_message(&record("ipc.request.failed", "plugins.install")).as_deref(),
+            Some("安装插件失败")
+        );
+        assert_eq!(
+            viewer_ipc_request_message(&record("ipc.request.completed", "future.command")),
+            None
+        );
     }
 
     #[test]

--- a/docs/specs/runtime-v2/WP-5-06-runtime-log-viewer.md
+++ b/docs/specs/runtime-v2/WP-5-06-runtime-log-viewer.md
@@ -4,7 +4,7 @@ status: normative
 audience: maintainer
 source_of_truth: self
 status_source: ../../plans/runtime-v2/work-packages.md
-updated: 2026-09-01
+updated: 2026-09-02
 ---
 
 # WP-5-06 Runtime v2 运行日志查看器
@@ -27,9 +27,9 @@ updated: 2026-09-01
 - 查看器 DTO 使用 `schemaVersion: 2`，只能包含序号、`HH:MM:SS`、软件/TTS scope、等级、固定频道、
   稳定事件代码、固定中文消息、warning/error 必有的固定中文说明、中文标签的安全详情和最多一个 8 字符
   关联编号。说明只解释发生了什么及影响，不提供重试、重装等操作建议，也不得从 `diagnostic` 原文生成。
-  IPC 事件可将稳定的 `command` 作为“请求”详情展示，
-  使同类完成记录能够区分具体操作；不得包含正文、Prompt、Memory、工具参数/结果、绝对路径、环境变量、
-  凭据或原始异常对象。
+  IPC 事件按稳定的 `command` 显示具体中文动作，例如“读取运行状态完成”和“读取插件设置完成”；未知命令
+  使用通用请求文案。原始 `command` 保留为“请求”详情，方便排查。不得包含正文、Prompt、Memory、工具
+  参数/结果、绝对路径、环境变量、凭据或原始异常对象。
 - 窗口只通过 `runtime_log_viewer_bootstrap` 和带 `afterSequence` 的
   `runtime_log_viewer_snapshot` 增量读取。游标落后于已淘汰记录时返回完整当前缓冲及 `resetRequired=true`。
   两个 command 必须校验调用窗口标签为 `runtime-log`。
@@ -43,7 +43,8 @@ updated: 2026-09-01
 - 托管 GPT-SoVITS 只显示“启动服务、等待服务就绪、服务就绪、加载角色语音模型、角色语音模型就绪”五个核心
   状态；`tts.service.warmup_queued` 继续留在底层文本日志但不进入查看器。完成行摘要只追加以一位小数秒数展示的
   耗时；展开区把稳定 Provider、阶段和状态枚举翻译为中文，错误仍保留稳定原因码和异常类型。
-- 摘要首先显示固定中文消息；warning/error 在下一行完整显示中文说明。摘要最多追加三个小字字段，只允许状态、
+- 摘要首先显示固定中文消息；warning/error 在下一行完整显示中文说明。IPC 标题已经说明结果时不再重复追加状态。
+  其他摘要最多追加三个小字字段，只允许状态、
   服务、模型、工具、耗时、数据量、数量、进度、分辨率和版本；诊断、事件/错误/原因码、阶段、异常类型、
   代码位置、问题编号、请求和关联编号只能进入展开区。窄窗口可隐藏小字，不得隐藏问题说明。
 - info 保持单行；带详情的条目以摘要行本身作为唯一展开入口，不再附加单独的“查看详情”行。warning 和 info

--- a/plugins/builtin/sakura_gpt_sovits/_runtime_profile.py
+++ b/plugins/builtin/sakura_gpt_sovits/_runtime_profile.py
@@ -264,10 +264,12 @@ def prepare_managed_profile(
     platform: Optional[str] = None,
     runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
 ) -> Optional[Path]:
-    """Return an explicit config path, generating Sakura's profile on Windows.
+    """Return an explicit config path, probing the device only once on Windows.
 
     An arbitrary user-supplied config remains authoritative.  Only an empty
-    path or Sakura's own fixed profile is regenerated.
+    path or Sakura's own fixed profile is managed.  An existing managed profile
+    reuses its device and precision while resetting weights written back by
+    GPT-SoVITS.  Only a missing profile performs the expensive torch/CUDA probe.
     """
 
     platform = platform or sys.platform
@@ -278,6 +280,10 @@ def prepare_managed_profile(
     repair_managed_runtime_paths(work_dir, platform=platform)
     if configured is not None and not is_managed_profile(configured, work_dir):
         return configured
+    generated = managed_profile_path(work_dir)
+    if generated.is_file():
+        reused, _profile = _reuse_existing_profile(work_dir, require_cuda=require_cuda)
+        return reused
     python = Path(runtime_python) if runtime_python is not None else find_runtime_python(work_dir)
     if python is None or not python.is_file():
         raise RuntimeProfileError("TTS_DEVICE_PROBE_FAILED")
@@ -454,6 +460,81 @@ def _validate_tts_config(work_dir: Path, path: Path, profile: DeviceProfile) -> 
         raise RuntimeProfileError("TTS_PROFILE_GENERATION_FAILED")
 
 
+def _write_profile(
+    work_dir: Path,
+    target: Path,
+    payload: Mapping[str, Any],
+    profile: DeviceProfile,
+) -> None:
+    import yaml
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    temporary: Optional[Path] = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            newline="\n",
+            prefix=f".{target.stem}.",
+            suffix=".tmp.yaml",
+            dir=str(target.parent),
+            delete=False,
+        ) as handle:
+            yaml.safe_dump(payload, handle, allow_unicode=True, sort_keys=False)
+            handle.flush()
+            os.fsync(handle.fileno())
+            temporary = Path(handle.name)
+        _validate_tts_config(work_dir, temporary, profile)
+        os.replace(temporary, target)
+        temporary = None
+    except RuntimeProfileError:
+        raise
+    except Exception as error:
+        raise RuntimeProfileError("TTS_PROFILE_GENERATION_FAILED") from error
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+
+
+def _profile_from_existing(payload: Mapping[str, Any], *, require_cuda: bool) -> DeviceProfile:
+    custom = payload.get("custom")
+    candidates = [
+        custom,
+        *(
+            value
+            for key, value in payload.items()
+            if key != "custom" and isinstance(value, Mapping)
+        ),
+    ]
+    for section in candidates:
+        if not isinstance(section, Mapping):
+            continue
+        device = str(section.get("device") or "").strip().lower()
+        is_half = section.get("is_half")
+        if not device or not isinstance(is_half, bool):
+            continue
+        if require_cuda and not device.startswith("cuda:"):
+            raise RuntimeProfileError("TTS_ACCELERATOR_UNAVAILABLE")
+        return DeviceProfile(device, is_half, "Cached device profile")
+    raise RuntimeProfileError("TTS_PROFILE_GENERATION_FAILED")
+
+
+def _reuse_existing_profile(work_dir: Path, *, require_cuda: bool) -> tuple[Path, DeviceProfile]:
+    import yaml
+
+    target = managed_profile_path(work_dir)
+    try:
+        payload = yaml.safe_load(target.read_text(encoding="utf-8"))
+    except Exception as error:
+        raise RuntimeProfileError("TTS_PROFILE_GENERATION_FAILED") from error
+    if not isinstance(payload, Mapping):
+        raise RuntimeProfileError("TTS_PROFILE_GENERATION_FAILED")
+    profile = _profile_from_existing(payload, require_cuda=require_cuda)
+    updated = _update_profile_payload(payload, profile)
+    _write_profile(work_dir, target, updated, profile)
+    return target.resolve(), profile
+
+
 def _generate_profile(work_dir: Path, *, require_cuda: bool) -> tuple[Path, DeviceProfile]:
     import yaml
 
@@ -470,32 +551,7 @@ def _generate_profile(work_dir: Path, *, require_cuda: bool) -> tuple[Path, Devi
         require_cuda=require_cuda or (source == target and _profile_requires_cuda(payload)),
     )
     updated = _update_profile_payload(payload, profile)
-    target.parent.mkdir(parents=True, exist_ok=True)
-    temporary: Optional[Path] = None
-    try:
-        with tempfile.NamedTemporaryFile(
-            mode="w",
-            encoding="utf-8",
-            newline="\n",
-            prefix=f".{target.stem}.",
-            suffix=".tmp.yaml",
-            dir=str(target.parent),
-            delete=False,
-        ) as handle:
-            yaml.safe_dump(updated, handle, allow_unicode=True, sort_keys=False)
-            handle.flush()
-            os.fsync(handle.fileno())
-            temporary = Path(handle.name)
-        _validate_tts_config(work_dir, temporary, profile)
-        os.replace(temporary, target)
-        temporary = None
-    except RuntimeProfileError:
-        raise
-    except Exception as error:
-        raise RuntimeProfileError("TTS_PROFILE_GENERATION_FAILED") from error
-    finally:
-        if temporary is not None:
-            temporary.unlink(missing_ok=True)
+    _write_profile(work_dir, target, updated, profile)
     return target.resolve(), profile
 
 

--- a/plugins/builtin/sakura_gpt_sovits/requirements.txt
+++ b/plugins/builtin/sakura_gpt_sovits/requirements.txt
@@ -1,2 +1,3 @@
 py7zz>=1.1.4
+PyYAML>=6.0,<7
 py7zr

--- a/tests/unit/test_gpt_sovits_runtime_profile.py
+++ b/tests/unit/test_gpt_sovits_runtime_profile.py
@@ -207,6 +207,62 @@ def test_existing_cuda_profile_refuses_silent_cpu_fallback(
     assert target.read_bytes() == before
 
 
+def test_existing_profile_reuses_device_without_torch_probe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    work_dir = tmp_path / "g50"
+    target = _runtime_profile.managed_profile_path(work_dir)
+    target.parent.mkdir(parents=True)
+    target.write_text(
+        yaml.safe_dump(
+            {
+                "custom": {
+                    "device": "cuda:0",
+                    "is_half": True,
+                    "version": "v2ProPlus",
+                    "t2s_weights_path": r"C:\Sakura\characters\A.ckpt",
+                    "vits_weights_path": r"C:\Sakura\characters\A.pth",
+                },
+                "v2ProPlus": {
+                    "device": "cuda:0",
+                    "is_half": True,
+                    "version": "v2ProPlus",
+                    "t2s_weights_path": "GPT_SoVITS/pretrained_models/s1v3.ckpt",
+                    "vits_weights_path": "GPT_SoVITS/pretrained_models/v2Pro/s2Gv2ProPlus.pth",
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        _runtime_profile,
+        "_probe_candidates",
+        lambda: (_ for _ in ()).throw(AssertionError("existing profile must not probe torch/CUDA")),
+    )
+
+    reused, profile = _runtime_profile._reuse_existing_profile(work_dir, require_cuda=True)
+
+    assert reused == target.resolve()
+    assert profile == _runtime_profile.DeviceProfile("cuda:0", True, "Cached device profile")
+    payload = yaml.safe_load(target.read_text(encoding="utf-8"))
+    assert payload["custom"]["t2s_weights_path"] == payload["v2ProPlus"]["t2s_weights_path"]
+    assert payload["custom"]["vits_weights_path"] == payload["v2ProPlus"]["vits_weights_path"]
+    assert not list(target.parent.glob(".*.tmp.yaml"))
+
+    def unexpected_runner(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("existing profile must not start bundled Python")
+
+    assert _runtime_profile.prepare_managed_profile(
+        work_dir,
+        configured_path=target,
+        require_cuda=True,
+        platform="win32",
+        runner=unexpected_runner,
+    ) == target.resolve()
+
+
 def test_user_config_remains_authoritative_without_probe(tmp_path: Path) -> None:
     work_dir = tmp_path / "gpt"
     python = work_dir / "runtime" / "python.exe"
@@ -300,11 +356,14 @@ def test_host_profile_runner_requires_structured_success(tmp_path: Path) -> None
     python.parent.mkdir(parents=True)
     python.write_bytes(b"")
     generated = _runtime_profile.managed_profile_path(work_dir)
-    generated.parent.mkdir(parents=True)
-    generated.write_text("custom: {}", encoding="utf-8")
     line = _runtime_profile._RESULT_PREFIX + json.dumps({"ok": True, "path": str(generated)})
 
-    def runner(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+    calls: list[tuple[list[str], dict[str, object]]] = []
+
+    def runner(command: list[str], **kwargs: object):  # type: ignore[no-untyped-def]
+        calls.append((command, kwargs))
+        generated.parent.mkdir(parents=True)
+        generated.write_text("custom: {}", encoding="utf-8")
         return subprocess.CompletedProcess([], 0, stdout=f"noise\n{line}\n", stderr="")
 
     assert _runtime_profile.prepare_managed_profile(
@@ -313,6 +372,8 @@ def test_host_profile_runner_requires_structured_success(tmp_path: Path) -> None
         platform="win32",
         runner=runner,
     ) == generated.resolve()
+    assert "--worker" in calls[0][0]
+    assert calls[0][1]["timeout"] == 90
 
 
 @pytest.mark.skipif(__import__("sys").platform != "win32", reason="verbatim paths are Windows-only")
@@ -324,8 +385,6 @@ def test_host_profile_runner_accepts_non_verbatim_worker_result(
     python.parent.mkdir(parents=True)
     python.write_bytes(b"")
     generated = _runtime_profile.managed_profile_path(ordinary_work_dir)
-    generated.parent.mkdir(parents=True)
-    generated.write_text("custom: {}", encoding="utf-8")
     verbatim_work_dir = Path("\\\\?\\" + str(ordinary_work_dir))
     line = _runtime_profile._RESULT_PREFIX + json.dumps(
         {"ok": True, "path": str(generated)}
@@ -334,6 +393,8 @@ def test_host_profile_runner_accepts_non_verbatim_worker_result(
 
     def runner(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
         calls.append((command, kwargs))
+        generated.parent.mkdir(parents=True)
+        generated.write_text("custom: {}", encoding="utf-8")
         return subprocess.CompletedProcess(command, 0, stdout=f"{line}\n", stderr="")
 
     assert _runtime_profile.prepare_managed_profile(


### PR DESCRIPTION
## 改动说明

- 启动 GPT-SoVITS 时复用已经生成并验证过的托管设备配置；只有配置缺失时才加载整合包运行时并执行完整设备探测。保留启动前清理角色权重路径的现有行为。
- 补充 GPT-SoVITS 对 PyYAML 的运行依赖和配置复用回归测试。
- 让运行日志按稳定命令显示具体中文动作，并在标题已包含执行结果时省略重复的完成状态。
- 固定运行日志的频道标签列宽，让不同长度标签后的正文保持对齐；过长标签使用省略显示，避免挤压正文。同步更新日志查看器 Spec 和测试。

## 验证

- `runtime\python.exe -m pytest tests\unit\test_gpt_sovits_runtime_profile.py tests\unit\test_gpt_sovits_plugin.py -q`：31 passed
- `runtime\python.exe -m harness run journey-tts`：PASSED 3/3（Python 111、Rust 4、前端 15）
- `node --test desktop/frontend/tests/runtime-log-presentation.test.js`：17 passed
- `runtime\python.exe -m harness run journey-observability`：PASSED 5/5（Python 23、Rust 16、前端 26）