### PR TITLE
修复 Windows 冷启动被握手期限误判失败

### DIFF
--- a/desktop/src-tauri/src/shell_lifecycle.rs
+++ b/desktop/src-tauri/src/shell_lifecycle.rs
@@ -26,7 +26,7 @@ use crate::{
     update_settings::UpdateCoordinator,
 };
 
-const HELLO_DEADLINE: Duration = Duration::from_secs(3);
+const HELLO_DEADLINE: Duration = Duration::from_secs(10);
 const INITIALIZE_DEADLINE: Duration = Duration::from_secs(5);
 const SNAPSHOT_DEADLINE: Duration = Duration::from_secs(3);
 const READINESS_DEADLINE: Duration = Duration::from_secs(30);
@@ -1078,6 +1078,14 @@ fn is_safe_version(value: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn hello_deadline_matches_the_validated_cold_start_budget() {
+        // A Windows 10 release report observed the Core process reaching its
+        // first fixed log event after 5.2 seconds. Keep enough headroom for
+        // Python startup and real-time antivirus scanning on a cold cache.
+        assert_eq!(HELLO_DEADLINE, Duration::from_secs(10));
+    }
 
     fn copy_fixture_tree(source: &std::path::Path, target: &std::path::Path) {
         std::fs::create_dir_all(target).expect("temporary fixture directory");

--- a/desktop/src-tauri/src/telemetry.rs
+++ b/desktop/src-tauri/src/telemetry.rs
@@ -1111,7 +1111,12 @@ fn validate_error_candidate(candidate: &TelemetryErrorCandidateV1) -> Result<(),
             candidate.code == "LEGACY_IMPORT_RECOVERY_FAILED"
         }
         ("rust", "first_run.state.failed") => candidate.code == "FIRST_RUN_STATE_FAILED",
-        ("rust", "core.spawn.failed") => candidate.code == "CORE_UNEXPECTED_EXIT",
+        ("rust", "core.spawn.failed") => {
+            matches!(
+                candidate.code.as_str(),
+                "CORE_UNEXPECTED_EXIT" | "CORE_HELLO_TIMEOUT"
+            )
+        }
         (
             "rust",
             "legacy_import.failed"
@@ -1370,11 +1375,17 @@ fn allowlisted_runtime_error(
         "legacy_import.result_invalid" => {
             stable_attribute(attributes, "code").map(|code| ("rust", code))
         }
-        "core.spawn.failed"
-            if token_attribute(attributes, "category", &["unexpected_exit"]).is_some() =>
+        "core.spawn.failed" if source == "rust" => match token_attribute(
+            attributes,
+            "category",
+            &["unexpected_exit", "hello_timeout"],
+        )
+        .as_deref()
         {
-            Some(("rust", "CORE_UNEXPECTED_EXIT".to_string()))
-        }
+            Some("unexpected_exit") => Some(("rust", "CORE_UNEXPECTED_EXIT".to_string())),
+            Some("hello_timeout") => Some(("rust", "CORE_HELLO_TIMEOUT".to_string())),
+            _ => None,
+        },
         "tts.service.failed"
         | "tts.service.warmup_failed"
         | "tts.process.cleanup.failed"
@@ -1998,6 +2009,45 @@ mod tests {
         assert!(validate_core_error_candidate(&spoofed).is_err());
         service.shutdown();
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn core_hello_timeout_is_reported_with_a_specific_safe_code() {
+        assert_eq!(
+            allowlisted_runtime_error(
+                "rust",
+                "core.spawn.failed",
+                Some(&json!({"category": "hello_timeout"})),
+            ),
+            Some(("rust", "CORE_HELLO_TIMEOUT".to_string()))
+        );
+        assert_eq!(
+            allowlisted_runtime_error(
+                "rust",
+                "core.spawn.failed",
+                Some(&json!({"category": "unexpected_exit"})),
+            ),
+            Some(("rust", "CORE_UNEXPECTED_EXIT".to_string()))
+        );
+        assert_eq!(
+            allowlisted_runtime_error(
+                "webview",
+                "core.spawn.failed",
+                Some(&json!({"category": "hello_timeout"})),
+            ),
+            None
+        );
+
+        let candidate = TelemetryErrorCandidateV1 {
+            schema: 1,
+            component: "rust".to_string(),
+            event: "core.spawn.failed".to_string(),
+            code: "CORE_HELLO_TIMEOUT".to_string(),
+            operation_id: None,
+            exception_type: None,
+            stack: Vec::new(),
+        };
+        assert!(validate_error_candidate(&candidate).is_ok());
     }
 
     #[test]

--- a/docs/adr/0001-runtime-v2-process-supervision.md
+++ b/docs/adr/0001-runtime-v2-process-supervision.md
@@ -103,19 +103,21 @@ SupervisorState = stopping
 
 shutdown、health 和 cancel 不得排在普通长任务之后。
 
-### 初始 lifecycle deadline 建议
+### Lifecycle deadline
 
-以下数值是 Phase 1B/1C 的首轮故障测试输入，不代表已经 `Technically Validated`；技术门可以基于分布数据调整，但必须同时更新 ADR、测试 fixture 和诊断文案：
+以下数值是当前生命周期合同。技术门可以根据真实运行数据调整，但必须同时更新 ADR、测试和诊断文案：
 
-| 生命周期动作 | 初始 deadline | 超时后的动作 |
+| 生命周期动作 | deadline | 超时后的动作 |
 |---|---:|---|
-| `system.hello` | 3,000 ms | 当前 generation 启动失败；在 restart budget 内可按暂时性启动失败重试 |
+| `system.hello` | 10,000 ms | 当前 generation 启动失败；在 restart budget 内可按暂时性启动失败重试 |
 | `core.initialize` 响应/接受 | 5,000 ms | 当前 generation 初始化协议失败；清理旧树后可在 budget 内重试 |
 | readiness watchdog | 30,000 ms | 与 initialize 请求 deadline 分离；进入 diagnostics/restarting，不阻塞 health/shutdown |
 | `system.shutdown` 协议优雅期 | 3,000 ms | 到期立即 `terminate_tree`，不继续等待领域任务 |
 | 完整停止并验证进程树退出 | 从 shutdown 意图起 5,000 ms | 超过即为 P1；Shell 记录强杀/残留证据并禁止新 generation |
 
 deadline 从 Rust 侧发出对应意图并成功写入当前 generation transport 时计时；WebView 不能覆盖这些 lifecycle 值。调试器附加、首轮依赖下载或人工断点不能改变正式验收 deadline。
+
+2026-09-03 的 Windows 10 稳定版报告显示，Core 冷启动在 5.2 秒后才发出首条固定日志，原 3 秒期限会先结束握手并回收仍在启动的进程。`system.hello` 因此调整为 10 秒；initialize、readiness 和 shutdown 的期限不变。
 
 ## 竞态与幂等规则
 

--- a/docs/adr/0002-runtime-v2-ipc.md
+++ b/docs/adr/0002-runtime-v2-ipc.md
@@ -85,7 +85,7 @@ Python 进程启动
 
 hello 前不得导入或初始化 Assistant、Memory、MCP、插件和 TTS 重型模块。
 
-初始 lifecycle deadline 统一采用 ADR-0001 的建议值：`system.hello` 3,000 ms、`core.initialize` 接受响应 5,000 ms、readiness watchdog 30,000 ms、`system.shutdown` 协议优雅期 3,000 ms，完整进程树停止从 shutdown 意图起不超过 5,000 ms。这些是待 Phase 1B/1C 验证的初值，不是已验证性能承诺。`core.initialize` 必须先快速返回接受/拒绝结果，不能把 30 秒 readiness watchdog 当成同步 request deadline。
+生命周期期限采用 ADR-0001 的当前值：`system.hello` 10,000 ms、`core.initialize` 接受响应 5,000 ms、readiness watchdog 30,000 ms、`system.shutdown` 协议优雅期 3,000 ms，完整进程树停止从 shutdown 意图起不超过 5,000 ms。hello 期限已根据 Windows 10 稳定版的冷启动报告调整；`core.initialize` 必须先快速返回接受或拒绝结果，不能把 30 秒 readiness watchdog 当成同步 request deadline。
 
 ### 协议版本与能力协商
 

--- a/docs/specs/runtime-v2/remote-diagnostics-telemetry.md
+++ b/docs/specs/runtime-v2/remote-diagnostics-telemetry.md
@@ -223,6 +223,9 @@ Payload schema 1 固定为：
 `stable/prerelease/development`，`platform` 只接受
 `windows/macos/linux`，`installKind` 只接受 `fresh/upgrade/legacy_import/unknown`。
 
+Core 进程意外退出使用 `CORE_UNEXPECTED_EXIT`，首次握手超时使用 `CORE_HELLO_TIMEOUT`。两者都由 Rust 的
+`core.spawn.failed` 事件产生，不上传底层异常正文。
+
 `stack` 最多 16 个 frame，`breadcrumbs` 最多 40 条。单个 stack frame 只允许 `module/function/file/line`。`file` 必须是
 repo-relative 或 module-relative 路径；不得包含绝对路径、源码文本、locals、参数或异常 message。无法可靠规范化的 frame
 直接丢弃。Fingerprint 只由稳定错误分类和规范化 frame 计算。

--- a/tests/unit/test_core_host_tts.py
+++ b/tests/unit/test_core_host_tts.py
@@ -1028,7 +1028,6 @@ class InstantTTSPlugin:
         GENERATION,
         ToolRegistry(),
         PluginInventory(roots).scan().runtime_specs,
-        call_timeout=0.1,
     )
     session = SimpleNamespace(plugin_application=worker, character=SimpleNamespace(id="sakura"))
     boundary = TTSBoundary(


### PR DESCRIPTION
## 问题

Windows 10 稳定版的一次冷启动中，`core.spawn.completed` 到 `core.spawn.failed` 相隔约 3011 ms，正好触发原有的 3 秒 `system.hello` 期限。Core 在失败后约 2.1 秒才发出 `core.process.started`，说明进程仍在启动，却已被 Shell 回收。随后设置页只能收到 `SETTINGS_CORE_UNAVAILABLE`。

## 修改

- 将 `system.hello` 期限从 3 秒调整为 10 秒，为托管 Python 冷启动和实时防病毒扫描留出余量；initialize、readiness 和 shutdown 期限保持不变。
- 将 `hello_timeout` 映射为独立的 `CORE_HELLO_TIMEOUT` 错误报告，后续可以直接识别同类启动失败。
- 更新进程监督、IPC 和远程诊断文档，并加入对应回归测试。

## 验证

- `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml -- --check`
- `git diff --check`
- `cargo test --locked --manifest-path desktop/src-tauri/Cargo.toml shell_lifecycle::tests -- --nocapture`：12 passed
- `cargo test --locked --manifest-path desktop/src-tauri/Cargo.toml telemetry::tests -- --nocapture`：18 passed
- `cargo test --locked --manifest-path desktop/src-tauri/Cargo.toml`：427 passed，18 ignored，0 failed