### PR TITLE
修正桌宠缩放位移和动态窗口边界

### DIFF
--- a/desktop/frontend/app.js
+++ b/desktop/frontend/app.js
@@ -59,6 +59,7 @@ import {
   computePetLayout,
   normalizeLayoutAdjustments,
   PRODUCT_LAYOUT_STATE,
+  samePetSurfaceGeometry,
   validateLayoutContract,
 } from "./pet/layout.js";
 import {
@@ -732,9 +733,11 @@ function syncPortraitAppearance(
 }
 
 function commitSurfaceApplication(surface) {
+  const geometryUnchanged = samePetSurfaceGeometry(contentScale, activeBounds, surface);
   contentScale = surface.contentScale;
   activeBounds = surface.activeBounds;
   activeSurfaceRevision = surface.revision;
+  if (geometryUnchanged) return;
   applyPetLayout(stage, productLayout, contentScale, activeBounds);
 }
 
@@ -755,6 +758,45 @@ function waitForPortraitPaint() {
   return new Promise((resolve) => window.requestAnimationFrame(
     () => window.requestAnimationFrame(resolve),
   ));
+}
+
+async function finishPortraitScaleSnapshot(surface, { afterPaint = false } = {}) {
+  if (!Number.isSafeInteger(surface?.snapshotRevision)) return;
+  if (!surface.reveal) {
+    surface.reveal = (async () => {
+      if (afterPaint) await waitForPortraitPaint();
+      await invoke("finish_portrait_scale_preview_snapshot", {
+        revision: surface.snapshotRevision,
+      });
+      surface.snapshotRevision = null;
+    })();
+  }
+  try {
+    await surface.reveal;
+  } catch (error) {
+    surface.reveal = null;
+    throw error;
+  }
+}
+
+async function preparePortraitScaleSnapshot(surface) {
+  if (!surface?.snapshotRequired) return true;
+  if (!surface.prepare) {
+    surface.prepare = (async () => {
+      const installed = await invoke("prepare_portrait_scale_preview_snapshot", {
+        revision: surface.previewRevision,
+      });
+      surface.snapshotRequired = false;
+      if (installed) surface.snapshotRevision = surface.previewRevision;
+      return installed;
+    })();
+  }
+  try {
+    return await surface.prepare;
+  } catch (error) {
+    surface.prepare = null;
+    throw error;
+  }
 }
 
 function activatePortraitHitTest(
@@ -824,11 +866,24 @@ async function previewPortraitScale(key) {
   await runPortraitSurfaceMutation(async () => {
     const revision = ++portraitHitRevision;
     const preview = await invoke("begin_portrait_scale_preview", { revision });
-    if (!preview || revision !== portraitHitRevision) return;
-    if (preview.application) commitSurfaceApplication(preview.application);
-    await activatePortraitHitTest(key, revision);
-    if (revision !== portraitHitRevision) return;
-    syncPortraitAppearance(key);
+    const snapshot = {
+      previewRevision: revision,
+      snapshotRequired: preview?.snapshotRequired === true,
+      snapshotRevision: null,
+      prepare: null,
+      reveal: null,
+    };
+    try {
+      if (!preview || revision !== portraitHitRevision) return;
+      if (!await preparePortraitScaleSnapshot(snapshot)) return;
+      if (preview.application) commitSurfaceApplication(preview.application);
+      await activatePortraitHitTest(key, revision);
+      if (revision !== portraitHitRevision) return;
+      syncPortraitAppearance(key);
+      await finishPortraitScaleSnapshot(snapshot, { afterPaint: true });
+    } finally {
+      await finishPortraitScaleSnapshot(snapshot).catch(() => null);
+    }
   });
 }
 
@@ -1642,6 +1697,7 @@ async function rebindCoreGeneration(generationId) {
 }
 
 await listenAppEvent("sakura://character-visual-preview", async (event) => {
+  let snapshot = null;
   try {
     const publication = event?.payload;
     const previewToken = characterVisualPreviewSessions.begin(publication);
@@ -1672,10 +1728,18 @@ await listenAppEvent("sakura://character-visual-preview", async (event) => {
     const preview = await runPortraitSurfaceMutation(
       () => invoke("begin_portrait_scale_preview", { revision: nativeRevision }),
     );
+    snapshot = {
+      previewRevision: nativeRevision,
+      snapshotRequired: preview?.snapshotRequired === true,
+      snapshotRevision: null,
+      prepare: null,
+      reveal: null,
+    };
     if (
       !characterVisualPreviewSessions.isCurrent(previewToken)
       || nativeRevision !== portraitHitRevision
     ) return;
+    if (!await preparePortraitScaleSnapshot(snapshot)) return;
     const hitRevision = ++portraitHitRevision;
     const previewSurface = await runPortraitSurfaceMutation(
       () => activatePortraitHitTest(key, hitRevision, null, {
@@ -1704,6 +1768,7 @@ await listenAppEvent("sakura://character-visual-preview", async (event) => {
       previewPresentation,
       previewAppearance.portraitScalePercent,
     );
+    await finishPortraitScaleSnapshot(snapshot, { afterPaint: true });
     applyTheme(previewAppearance.themeTokens);
     await applyInputVisualEffect({
       ...activeAppearance,
@@ -1725,6 +1790,8 @@ await listenAppEvent("sakura://character-visual-preview", async (event) => {
     }
   } catch {
     showRecoverableError("角色视觉预览失败；已保留当前角色画面。");
+  } finally {
+    await finishPortraitScaleSnapshot(snapshot).catch(() => null);
   }
 });
 
@@ -1738,7 +1805,7 @@ await listenAppEvent("sakura://control-surface-frame", async (event) => {
   appearanceMutationGuard.supersede();
   surfaceVisibilityController?.previewBubble();
   const deferNative = event.payload.deferNative === true;
-  // Native region relaxation may take longer than a slider frame on a cold WebView2 surface.
+  // A coarse native region update may take longer than a slider frame on a cold WebView2 surface.
   // Paint inside the already-stable backing envelope immediately; the settings session restores
   // one precise region after all slider gestures are finished.
   if (!deferNative) {
@@ -1765,7 +1832,7 @@ await listenAppEvent("sakura://control-surface-gesture", async (event) => {
     surfaceVisibilityController?.previewBubble();
     layoutGestureTrace = sourceTrace;
     layoutGestureActive = true;
-    // The settings appearance session already owns one relaxed Windows region. Keep its revision
+    // The settings appearance session already owns one coarse Windows region. Keep its revision
     // stable across width/height sliders so switching controls cannot trigger a precise-region
     // rebuild between two pointer gestures.
     if (!settingsAppearanceActive || !layoutPreviewSessionActive) {
@@ -1921,7 +1988,59 @@ await listenAppEvent("sakura://portrait-scale-frame", async (event) => {
     ? renderedPortrait
     : characterPresentation.defaultPortraitKey;
   if (preview.deferredNative) {
+    const deferredSurface = preview.deferredSurface;
+    if (deferredSurface) {
+      if (!deferredSurface.ready) {
+        deferredSurface.ready = runPortraitSurfaceMutation(async () => {
+          if (!await preparePortraitScaleSnapshot(deferredSurface)) return null;
+          if (
+            disposed
+            || !portraitScaleGestureActive
+            || ready !== portraitScaleGestureReady
+          ) {
+            await finishPortraitScaleSnapshot(deferredSurface).catch(() => null);
+            return null;
+          }
+          // The snapshot now covers the old compositor surface. Commit the matching stage
+          // origin before AppKit expands the native frame underneath it.
+          commitSurfaceApplication(deferredSurface.application);
+          const revision = ++portraitHitRevision;
+          const nativeFrameTrace = interactionLatencyTrace.atRevision(frameTrace, revision);
+          return activatePortraitHitTest(key, revision, nativeFrameTrace, {
+            portraitScalePercent,
+            reportError: false,
+          });
+        });
+      }
+      try {
+        await deferredSurface.ready;
+      } catch {
+        deferredSurface.ready = null;
+        await finishPortraitScaleSnapshot(deferredSurface).catch(() => null);
+        return;
+      }
+      if (
+        disposed
+        || !portraitScaleGestureActive
+        || ready !== portraitScaleGestureReady
+      ) {
+        await finishPortraitScaleSnapshot(deferredSurface).catch(() => null);
+        return;
+      }
+    }
     syncPortraitAppearance(key, characterPresentation, portraitScalePercent, frameTrace);
+    if (Number.isSafeInteger(deferredSurface?.snapshotRevision)) {
+      try {
+        await finishPortraitScaleSnapshot(deferredSurface, { afterPaint: true });
+      } catch {
+        return;
+      }
+      if (
+        disposed
+        || !portraitScaleGestureActive
+        || ready !== portraitScaleGestureReady
+      ) return;
+    }
     if (!preview.deferredHitRegions) {
       enqueuePortraitScaleHitFrame(key, portraitScalePercent, frameTrace, ready);
     }
@@ -1950,13 +2069,25 @@ await listenAppEvent("sakura://portrait-scale-gesture", async (event) => {
       .then((preview) => {
         if (!preview) return null;
         const surface = preview.application;
-        if (surface && !disposed && revision === portraitHitRevision) {
+        const precommitOnFirstFrame = preview.precommitOnFirstFrame === true;
+        if (surface && !precommitOnFirstFrame && !disposed && revision === portraitHitRevision) {
           commitSurfaceApplication(surface);
         }
         return Object.freeze({
           revision,
           deferredNative: preview.deferredNative === true,
           deferredHitRegions: preview.deferredHitRegions === true,
+          deferredSurface: surface && precommitOnFirstFrame
+            ? {
+                application: surface,
+                previewRevision: revision,
+                snapshotRequired: preview.snapshotRequired === true,
+                snapshotRevision: null,
+                prepare: null,
+                ready: null,
+                reveal: null,
+              }
+            : null,
           trace: beginTrace,
         });
       })
@@ -1979,7 +2110,19 @@ await listenAppEvent("sakura://portrait-scale-gesture", async (event) => {
     // Appearance events are emitted before the gesture-end event. Yield once so their synchronous
     // publication update wins even when both callbacks were released by the same native command.
     await Promise.resolve();
-    if (!preview || disposed || ready !== portraitScaleGestureReady || revision !== portraitHitRevision) return;
+    if (!preview) return;
+    if (disposed || ready !== portraitScaleGestureReady || revision !== portraitHitRevision) {
+      await finishPortraitScaleSnapshot(preview.deferredSurface).catch(() => null);
+      return;
+    }
+    if (preview.deferredSurface?.ready) {
+      await preview.deferredSurface.ready.catch(() => null);
+    }
+    if (disposed || ready !== portraitScaleGestureReady || revision !== portraitHitRevision) return;
+    if (Number.isSafeInteger(preview.deferredSurface?.snapshotRevision)) {
+      await finishPortraitScaleSnapshot(preview.deferredSurface);
+    }
+    if (disposed || ready !== portraitScaleGestureReady || revision !== portraitHitRevision) return;
     const key = renderedPortrait && characterPresentation.portraitMetadata[renderedPortrait]
       ? renderedPortrait
       : characterPresentation.defaultPortraitKey;

--- a/desktop/frontend/pet/layout-controller.js
+++ b/desktop/frontend/pet/layout-controller.js
@@ -73,8 +73,8 @@ export function createLayoutController({
         return;
       }
       // Ordinary adaptive changes remain paired with their precise Win32 clip. During an explicit
-      // settings preview the native region is already relaxed, so stale native acknowledgements
-      // must not paint over the newest immediate WebView frame.
+      // settings preview a coarse native region already follows the latest frame, so stale native
+      // acknowledgements must not paint over the newest immediate WebView frame.
       work.commitVisual?.(work.layout, nativeResult);
       commitLayout(work.layout, nativeResult, { interactionTrace: work.interactionTrace });
       committedLayout = work.layout;

--- a/desktop/frontend/pet/layout.js
+++ b/desktop/frontend/pet/layout.js
@@ -285,6 +285,21 @@ export function applyPetLayout(root, layout, contentScale, activeBounds = null) 
   root.dataset.layoutState = PRODUCT_LAYOUT_STATE;
 }
 
+export function samePetSurfaceGeometry(
+  currentContentScale,
+  currentActiveBounds,
+  nextSurface,
+) {
+  return (
+    currentContentScale === nextSurface?.contentScale
+    && Array.isArray(currentActiveBounds)
+    && Array.isArray(nextSurface?.activeBounds)
+    && currentActiveBounds.length === 4
+    && nextSurface.activeBounds.length === 4
+    && currentActiveBounds.every((value, index) => value === nextSurface.activeBounds[index])
+  );
+}
+
 export function applyBootstrapPetLayout(root, layout, diagnostics) {
   const bootstrap = validateBootstrapSurfaceDiagnostics(diagnostics);
   applyPetLayout(root, layout, bootstrap.contentScale, bootstrap.activeBounds);

--- a/desktop/frontend/tests/layout-bootstrap.test.js
+++ b/desktop/frontend/tests/layout-bootstrap.test.js
@@ -5,6 +5,7 @@ import test from "node:test";
 import {
   applyBootstrapPetLayout,
   computePetLayout,
+  samePetSurfaceGeometry,
   validateBootstrapSurfaceDiagnostics,
   validateLayoutContract,
 } from "../pet/layout.js";
@@ -52,4 +53,18 @@ test("invalid bootstrap diagnostics fail closed", () => {
   ]) {
     assert.throws(() => validateBootstrapSurfaceDiagnostics(value), /bootstrap pet surface/);
   }
+});
+
+test("repeated native surface publications do not invalidate unchanged WebView geometry", () => {
+  const currentBounds = [120, 640, 428, 276];
+  assert.equal(samePetSurfaceGeometry(1, currentBounds, {
+    revision: 9,
+    contentScale: 1,
+    activeBounds: [...currentBounds],
+  }), true);
+  assert.equal(samePetSurfaceGeometry(1, currentBounds, {
+    revision: 10,
+    contentScale: 1,
+    activeBounds: [120, 300, 428, 616],
+  }), false);
 });

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -4032,6 +4032,7 @@ dependencies = [
  "objc2-app-kit",
  "objc2-foundation",
  "objc2-quartz-core",
+ "objc2-web-kit",
  "png 0.18.1",
  "reqwest",
  "rfd",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -46,9 +46,10 @@ windows-version = "=0.1.7"
 [target.'cfg(target_os = "macos")'.dependencies]
 block2 = "=0.6.2"
 objc2 = "=0.6.4"
-objc2-app-kit = { version = "=0.3.2", features = ["block2", "NSAnimation", "NSAnimationContext", "NSEvent", "NSColor", "NSGlassEffectView", "NSGraphics", "NSResponder", "NSView", "NSVisualEffectView", "NSWindow", "objc2-quartz-core"] }
+objc2-app-kit = { version = "=0.3.2", features = ["block2", "NSAnimation", "NSAnimationContext", "NSEvent", "NSColor", "NSControl", "NSGlassEffectView", "NSGraphics", "NSImage", "NSImageView", "NSResponder", "NSView", "NSVisualEffectView", "NSWindow", "objc2-quartz-core"] }
 objc2-foundation = "=0.3.2"
 objc2-quartz-core = { version = "=0.3.2", default-features = false, features = ["CALayer", "objc2-core-foundation"] }
+objc2-web-kit = { version = "=0.3.2", default-features = false, features = ["block2", "WKSnapshotConfiguration", "WKWebView", "objc2-core-foundation"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 cairo-rs = "=0.18.5"

--- a/desktop/src-tauri/src/macos_surface_snapshot.rs
+++ b/desktop/src-tauri/src/macos_surface_snapshot.rs
@@ -1,0 +1,318 @@
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::Duration;
+
+use block2::RcBlock;
+use objc2::{rc::Retained, MainThreadMarker};
+use objc2_app_kit::{
+    NSAutoresizingMaskOptions, NSImage, NSImageView, NSView, NSWindow, NSWindowOrderingMode,
+};
+use objc2_foundation::{NSError, NSRect};
+use objc2_web_kit::{WKSnapshotConfiguration, WKWebView};
+use tokio::sync::oneshot;
+
+const SNAPSHOT_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Clone, Copy)]
+struct SurfaceSnapshot {
+    revision: u64,
+    view: usize,
+    source_window_frame: [f64; 4],
+}
+
+#[derive(Default)]
+struct SurfaceSnapshotState {
+    requested_revision: Option<u64>,
+    overlay: Option<SurfaceSnapshot>,
+}
+
+impl SurfaceSnapshotState {
+    fn begin_request(&mut self, revision: u64) -> Option<SurfaceSnapshot> {
+        self.requested_revision = Some(revision);
+        self.overlay.take()
+    }
+
+    fn accepts(&self, revision: u64) -> bool {
+        self.requested_revision == Some(revision)
+    }
+
+    fn take_revision(&mut self, revision: u64) -> Option<SurfaceSnapshot> {
+        if self.accepts(revision) {
+            self.requested_revision = None;
+        }
+        if self
+            .overlay
+            .is_some_and(|overlay| overlay.revision == revision)
+        {
+            self.overlay.take()
+        } else {
+            None
+        }
+    }
+
+    fn clear(&mut self) -> Option<SurfaceSnapshot> {
+        self.requested_revision = None;
+        self.overlay.take()
+    }
+}
+
+fn snapshot_state() -> &'static Mutex<SurfaceSnapshotState> {
+    static STATE: OnceLock<Mutex<SurfaceSnapshotState>> = OnceLock::new();
+    STATE.get_or_init(|| Mutex::new(SurfaceSnapshotState::default()))
+}
+
+fn trace(phase: &str, detail: impl std::fmt::Display) {
+    if std::env::var_os("SAKURA_TRACE_MACOS_SURFACE").is_some() {
+        eprintln!("[macos-surface-snapshot] phase={phase} {detail}");
+    }
+}
+
+unsafe fn view_from_handle<'a>(handle: usize) -> &'a NSView {
+    unsafe { &*(handle as *mut NSView) }
+}
+
+fn remove_overlay(snapshot: Option<SurfaceSnapshot>) {
+    if let Some(snapshot) = snapshot {
+        unsafe { view_from_handle(snapshot.view) }.removeFromSuperview();
+    }
+}
+
+fn complete(
+    sender: &Arc<Mutex<Option<oneshot::Sender<Result<bool, String>>>>>,
+    result: Result<bool, String>,
+) {
+    if let Ok(mut sender) = sender.lock() {
+        if let Some(sender) = sender.take() {
+            let _ = sender.send(result);
+        }
+    }
+}
+
+fn clear_request(revision: u64) {
+    if let Ok(mut state) = snapshot_state().lock() {
+        if state.accepts(revision) {
+            state.requested_revision = None;
+        }
+    }
+}
+
+pub async fn install(window: &tauri::WebviewWindow, revision: u64) -> Result<bool, String> {
+    let (sender, receiver) = oneshot::channel();
+    let sender = Arc::new(Mutex::new(Some(sender)));
+    let callback_sender = sender.clone();
+    if let Err(error) = window.with_webview(move |webview| {
+        let result = (|| {
+            let mtm = MainThreadMarker::new()
+                .ok_or_else(|| "MACOS_SURFACE_SNAPSHOT_MAIN_THREAD_REQUIRED".to_string())?;
+            let previous = {
+                let mut state = snapshot_state()
+                    .lock()
+                    .map_err(|_| "MACOS_SURFACE_SNAPSHOT_STATE_UNAVAILABLE".to_string())?;
+                state.begin_request(revision)
+            };
+            remove_overlay(previous);
+
+            let native_webview = unsafe {
+                Retained::retain(webview.inner().cast::<WKWebView>())
+                    .ok_or_else(|| "MACOS_SURFACE_SNAPSHOT_WEBVIEW_UNAVAILABLE".to_string())?
+            };
+            let host = unsafe { native_webview.superview() }
+                .ok_or_else(|| "MACOS_SURFACE_SNAPSHOT_HOST_UNAVAILABLE".to_string())?;
+            let ns_window = unsafe { &*webview.ns_window().cast::<NSWindow>() };
+            let source_frame = ns_window.frame();
+            let configuration = unsafe { WKSnapshotConfiguration::new(mtm) };
+            unsafe {
+                configuration.setRect(native_webview.bounds());
+                configuration.setAfterScreenUpdates(false);
+            }
+
+            let completion_webview = native_webview.clone();
+            let completion_host = host.clone();
+            let completion_sender = callback_sender.clone();
+            let completion = RcBlock::new(move |image: *mut NSImage, error: *mut NSError| {
+                let result = (|| {
+                    if image.is_null() {
+                        clear_request(revision);
+                        return Err(if error.is_null() {
+                            "MACOS_SURFACE_SNAPSHOT_EMPTY".to_string()
+                        } else {
+                            "MACOS_SURFACE_SNAPSHOT_CAPTURE_FAILED".to_string()
+                        });
+                    }
+                    let image = unsafe { Retained::retain(image) }
+                        .ok_or_else(|| "MACOS_SURFACE_SNAPSHOT_EMPTY".to_string())?;
+                    let snapshot = NSImageView::imageViewWithImage(&image, mtm);
+                    snapshot.setFrame(completion_webview.frame());
+                    snapshot.setAutoresizingMask(NSAutoresizingMaskOptions::empty());
+
+                    let mut state = snapshot_state()
+                        .lock()
+                        .map_err(|_| "MACOS_SURFACE_SNAPSHOT_STATE_UNAVAILABLE".to_string())?;
+                    if !state.accepts(revision) {
+                        return Ok(false);
+                    }
+                    completion_host.addSubview_positioned_relativeTo(
+                        &snapshot,
+                        NSWindowOrderingMode::Above,
+                        Some(&completion_webview),
+                    );
+                    let handle = Retained::as_ptr(&snapshot) as *mut NSView as usize;
+                    state.overlay = Some(SurfaceSnapshot {
+                        revision,
+                        view: handle,
+                        source_window_frame: [
+                            source_frame.origin.x,
+                            source_frame.origin.y,
+                            source_frame.size.width,
+                            source_frame.size.height,
+                        ],
+                    });
+                    trace(
+                        "installed",
+                        format_args!(
+                            "revision={revision} window=({:.1},{:.1},{:.1},{:.1}) snapshot=({:.1},{:.1},{:.1},{:.1})",
+                            source_frame.origin.x,
+                            source_frame.origin.y,
+                            source_frame.size.width,
+                            source_frame.size.height,
+                            snapshot.frame().origin.x,
+                            snapshot.frame().origin.y,
+                            snapshot.frame().size.width,
+                            snapshot.frame().size.height,
+                        ),
+                    );
+                    Ok(true)
+                })();
+                if result.is_err() {
+                    clear_request(revision);
+                }
+                complete(&completion_sender, result);
+            });
+            unsafe {
+                native_webview.takeSnapshotWithConfiguration_completionHandler(
+                    Some(&configuration),
+                    &completion,
+                );
+            }
+            Ok(())
+        })();
+        if let Err(error) = result {
+            clear_request(revision);
+            complete(&callback_sender, Err(error));
+        }
+    }) {
+        clear_request(revision);
+        return Err(format!("MACOS_SURFACE_SNAPSHOT_DISPATCH_FAILED:{error}"));
+    }
+
+    match tokio::time::timeout(SNAPSHOT_TIMEOUT, receiver).await {
+        Ok(Ok(result)) => result,
+        Ok(Err(_)) => {
+            clear_request(revision);
+            Err("MACOS_SURFACE_SNAPSHOT_CANCELLED".to_string())
+        }
+        Err(_) => {
+            clear_request(revision);
+            Err("MACOS_SURFACE_SNAPSHOT_TIMEOUT".to_string())
+        }
+    }
+}
+
+pub fn reposition_for_window_frame(frame: NSRect) -> Result<(), String> {
+    let snapshot = snapshot_state()
+        .lock()
+        .map_err(|_| "MACOS_SURFACE_SNAPSHOT_STATE_UNAVAILABLE".to_string())?
+        .overlay;
+    let Some(snapshot) = snapshot else {
+        return Ok(());
+    };
+    let view = unsafe { view_from_handle(snapshot.view) };
+    let mut snapshot_frame = view.frame();
+    snapshot_frame.origin.x = snapshot.source_window_frame[0] - frame.origin.x;
+    snapshot_frame.origin.y = snapshot.source_window_frame[1] - frame.origin.y;
+    view.setFrame(snapshot_frame);
+    trace(
+        "repositioned",
+        format_args!(
+            "revision={} window=({:.1},{:.1},{:.1},{:.1}) snapshot=({:.1},{:.1},{:.1},{:.1})",
+            snapshot.revision,
+            frame.origin.x,
+            frame.origin.y,
+            frame.size.width,
+            frame.size.height,
+            snapshot_frame.origin.x,
+            snapshot_frame.origin.y,
+            snapshot_frame.size.width,
+            snapshot_frame.size.height,
+        ),
+    );
+    Ok(())
+}
+
+pub async fn finish(window: &tauri::WebviewWindow, revision: u64) -> Result<(), String> {
+    let (sender, receiver) = oneshot::channel();
+    window
+        .with_webview(move |_| {
+            let result: Result<(), String> = (|| {
+                let overlay = {
+                    let mut state = snapshot_state()
+                        .lock()
+                        .map_err(|_| "MACOS_SURFACE_SNAPSHOT_STATE_UNAVAILABLE".to_string())?;
+                    state.take_revision(revision)
+                };
+                remove_overlay(overlay);
+                Ok(())
+            })();
+            let _ = sender.send(result);
+        })
+        .map_err(|error| format!("MACOS_SURFACE_SNAPSHOT_DISPATCH_FAILED:{error}"))?;
+    tokio::time::timeout(SNAPSHOT_TIMEOUT, receiver)
+        .await
+        .map_err(|_| "MACOS_SURFACE_SNAPSHOT_TIMEOUT".to_string())?
+        .map_err(|_| "MACOS_SURFACE_SNAPSHOT_CANCELLED".to_string())??;
+    trace("finished", format_args!("revision={revision}"));
+    Ok(())
+}
+
+pub fn clear(window: &tauri::WebviewWindow) -> Result<(), String> {
+    window
+        .with_webview(move |_| {
+            let overlay = snapshot_state()
+                .lock()
+                .ok()
+                .and_then(|mut state| state.clear());
+            remove_overlay(overlay);
+            trace("cleared", "all");
+        })
+        .map_err(|error| format!("MACOS_SURFACE_SNAPSHOT_DISPATCH_FAILED:{error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SurfaceSnapshot, SurfaceSnapshotState};
+
+    fn snapshot(revision: u64) -> SurfaceSnapshot {
+        SurfaceSnapshot {
+            revision,
+            view: revision as usize,
+            source_window_frame: [0.0; 4],
+        }
+    }
+
+    #[test]
+    fn stale_completion_and_cleanup_cannot_remove_a_newer_snapshot() {
+        let mut state = SurfaceSnapshotState::default();
+        assert!(state.begin_request(10).is_none());
+        assert!(state.accepts(10));
+
+        state.overlay = Some(snapshot(10));
+        assert_eq!(state.begin_request(11).unwrap().revision, 10);
+        state.overlay = Some(snapshot(11));
+
+        assert!(!state.accepts(10));
+        assert!(state.take_revision(10).is_none());
+        assert_eq!(state.overlay.unwrap().revision, 11);
+        assert_eq!(state.take_revision(11).unwrap().revision, 11);
+        assert!(state.overlay.is_none());
+        assert!(state.requested_revision.is_none());
+    }
+}

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -6615,7 +6615,10 @@ fn begin_portrait_scale_preview(
             // application again would make the WebView rewrite every stage offset and layout variable
             // on a no-op pointer press, which can invalidate the whole transparent layer on macOS.
             let mut preview_application = None;
+            #[cfg(target_os = "macos")]
             let mut snapshot_required = false;
+            #[cfg(not(target_os = "macos"))]
+            let snapshot_required = false;
             #[cfg(windows)]
             if !geometry.portrait_scale_preview_active {
                 let state = geometry
@@ -7255,6 +7258,8 @@ async fn finish_portrait_scale_preview_snapshot(
         }
         macos_surface_snapshot::finish(&window, revision).await?;
     }
+    #[cfg(not(target_os = "macos"))]
+    let _ = revision;
     Ok(())
 }
 

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -23,6 +23,8 @@ mod interaction_latency;
 mod legacy_import;
 #[cfg(target_os = "macos")]
 mod macos_input_glass;
+#[cfg(target_os = "macos")]
+mod macos_surface_snapshot;
 #[allow(dead_code)] // Consumed by the serial Supervisor beginning in WP-1B-02.
 mod managed_process_tree;
 #[allow(dead_code)] // Compile-only platform contracts are wired by WP-1P-02 through WP-1P-05.
@@ -60,7 +62,8 @@ use serde_json::{json, Value};
 use shared_instance::NativeInstanceLockBackend;
 use tauri::{Emitter, Manager, State, WebviewWindow};
 use window_geometry::{
-    apply_window_layout, apply_window_layout_with_fit_bounds, AnchorPolicy, ControlSurfaceLayout,
+    apply_window_layout, apply_window_layout_with_fit_bounds,
+    clip_expanded_surface_bounds_to_work_area, AnchorPolicy, ControlSurfaceLayout,
     InputSurfaceTransition, LayoutApplication, LayoutContract, LayoutRevisionGuard,
     MonitorDescriptor, PhysicalRect, PresentationState,
 };
@@ -394,6 +397,8 @@ struct PortraitScalePreview {
     application: Option<LayoutApplication>,
     deferred_native: bool,
     deferred_hit_regions: bool,
+    precommit_on_first_frame: bool,
+    snapshot_required: bool,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -800,6 +805,17 @@ fn uses_resident_stable_surface_bounds(
         && (portrait_alpha_mask_available || control_surface_available)
 }
 
+fn uses_bubble_expansion_stable_surface_bounds(bubble_auto_expand: bool) -> bool {
+    cfg!(windows) && bubble_auto_expand
+}
+
+fn preserves_portrait_anchor_for_scale_settlement(
+    preview_active: bool,
+    gesture_active: bool,
+) -> bool {
+    preview_active && !gesture_active
+}
+
 fn compute_pet_window_layout(
     contract: &LayoutContract,
     state: PresentationState,
@@ -943,6 +959,34 @@ fn compute_pet_window_layout_with_surface_policy(
     )
 }
 
+fn clip_portrait_scale_preview_application_to_work_area(
+    contract: &LayoutContract,
+    monitor: &MonitorDescriptor,
+    current: &LayoutApplication,
+    stable: LayoutApplication,
+) -> Result<LayoutApplication, String> {
+    let expanded_bounds =
+        window_interaction::union_surface_bounds(current.active_bounds, stable.active_bounds);
+    let preview_bounds = clip_expanded_surface_bounds_to_work_area(
+        current,
+        expanded_bounds,
+        contract.viewport.portrait_anchor,
+    )?;
+    if preview_bounds == stable.active_bounds {
+        return Ok(stable);
+    }
+    apply_window_layout_with_fit_bounds(
+        contract,
+        stable.state,
+        stable.revision,
+        monitor,
+        Some(current.portrait_anchor),
+        AnchorPolicy::UserPositioned,
+        stable.visible_fit_bounds,
+        preview_bounds,
+    )
+}
+
 #[tauri::command]
 fn current_pet_layout_revision(
     window: WebviewWindow,
@@ -1080,7 +1124,7 @@ fn apply_pet_layout(
             control_surface.as_ref(),
             session.portrait_alpha_mask.as_ref(),
             false,
-            bubble_auto_expand,
+            uses_bubble_expansion_stable_surface_bounds(bubble_auto_expand),
         )?;
         let previous_application = session.application.clone();
         let previous_control_surface = session.control_surface.clone();
@@ -1622,6 +1666,24 @@ fn build_native_interaction_regions(
     physical.portrait_alpha_mask = native_portrait_alpha_mask;
     interaction_latency::stage_elapsed("interaction-regions-build-return", started);
     Ok(physical)
+}
+
+#[cfg(any(windows, test))]
+fn build_coarse_native_interaction_regions(
+    contract: &LayoutContract,
+    application: &LayoutApplication,
+    control_surface: Option<&ControlSurfaceLayout>,
+    portrait_alpha_mask: Option<&character_presentation::PortraitAlphaMask>,
+    portrait_scale_percent: u16,
+) -> Result<window_interaction::PhysicalHitRegions, String> {
+    let precise = build_native_interaction_regions(
+        contract,
+        application,
+        control_surface,
+        portrait_alpha_mask,
+        portrait_scale_percent,
+    )?;
+    Ok(window_interaction::coarse_preview_hit_regions(&precise))
 }
 
 struct ContextMenuSurfaceGeometry {
@@ -2225,7 +2287,7 @@ fn commit_dragged_window_position(
         session.portrait_scale_percent,
         session.control_surface.as_ref(),
         session.portrait_alpha_mask.as_ref(),
-        session.bubble_auto_expand,
+        uses_bubble_expansion_stable_surface_bounds(session.bubble_auto_expand),
     )?;
     let previous_application = session.application.clone();
     let previous_regions = session.hit_regions.clone();
@@ -4479,6 +4541,9 @@ fn settings_character_appearance_scale_gesture(
 ) -> Result<(), String> {
     let publication_trace = trace.clone();
     interaction_latency::command("settings.portrait-scale-gesture", trace, || {
+        if std::env::var_os("SAKURA_TRACE_MACOS_SURFACE").is_some() {
+            eprintln!("[macos-surface-snapshot] phase=settings-gesture active={active}");
+        }
         product_shell::validate_settings_window(&window)?;
         interaction_latency::lock(
             geometry_state.inner(),
@@ -4511,6 +4576,11 @@ fn settings_character_appearance_scale_frame(
 ) -> Result<(), String> {
     let publication_trace = trace.clone();
     interaction_latency::command("settings.portrait-scale-frame", trace, || {
+        if std::env::var_os("SAKURA_TRACE_MACOS_SURFACE").is_some() {
+            eprintln!(
+                "[macos-surface-snapshot] phase=settings-frame scale={portrait_scale_percent}"
+            );
+        }
         product_shell::validate_settings_window(&window)?;
         if !(window_interaction::PORTRAIT_SCALE_MIN_PERCENT
             ..=window_interaction::PORTRAIT_SCALE_MAX_PERCENT)
@@ -6186,10 +6256,14 @@ fn begin_control_surface_preview(
         if !geometry.request_control_surface_preview(revision) {
             return Ok(());
         }
-        if cfg!(windows) {
-            NativeWindowInteractionBackend
-                .relax_hit_regions(&window)
-                .map_err(|error| error.to_string())?;
+        #[cfg(windows)]
+        {
+            let current = geometry
+                .hit_regions
+                .as_ref()
+                .ok_or_else(|| "PET_HIT_REGIONS_NOT_READY".to_string())?;
+            let coarse = window_interaction::coarse_preview_hit_regions(current);
+            apply_precise_hit_regions(&window, &coarse)?;
         }
         geometry.activate_control_surface_preview(revision);
         Ok(())
@@ -6223,6 +6297,20 @@ fn preview_pet_control_surface(
         previous.input_rect != control_surface.input_rect
             || previous.input_visible != control_surface.input_visible
     });
+    #[cfg(windows)]
+    {
+        let contract = layout_contract()?;
+        let coarse = build_coarse_native_interaction_regions(
+            &contract,
+            &application,
+            Some(&control_surface),
+            geometry.portrait_alpha_mask.as_ref(),
+            geometry.portrait_scale_percent,
+        )?;
+        // Keep the resident HWND stable, but never expose its transparent remainder as input.
+        // This region has only component rectangles, so it is cheap enough for latest-wins frames.
+        apply_precise_hit_regions(&window, &coarse)?;
+    }
     // Deferred settings frames still own the latest logical geometry. Portrait-scale settlement
     // and drag authorization must not fall back to the control surface from before the slider
     // session merely because the expensive precise native region is intentionally postponed.
@@ -6258,20 +6346,27 @@ fn end_control_surface_preview(
         if !geometry.can_end_control_surface_preview(revision) {
             return Ok(());
         }
-        geometry.control_surface_preview_active = false;
         if geometry.context_menu_open || geometry.portrait_hit_relaxed {
+            geometry.control_surface_preview_active = false;
             return Ok(());
         }
-        let hit_regions = geometry
-            .hit_regions
+        let application = geometry
+            .application
             .clone()
-            .ok_or_else(|| "PET_HIT_REGIONS_NOT_READY".to_string())?;
+            .ok_or_else(|| "PET_LAYOUT_NOT_READY".to_string())?;
+        let hit_regions = build_native_interaction_regions(
+            &layout_contract()?,
+            &application,
+            geometry.control_surface.as_ref(),
+            geometry.portrait_alpha_mask.as_ref(),
+            geometry.portrait_scale_percent,
+        )?;
         if let Err(error) = apply_precise_hit_regions_with_synchronous_redraw(&window, &hit_regions)
         {
-            // Keep the preview flag retryable so a later settle can restore the precise mask.
-            geometry.control_surface_preview_active = true;
             return Err(error);
         }
+        geometry.hit_regions = Some(hit_regions);
+        geometry.control_surface_preview_active = false;
         Ok(())
     })
 }
@@ -6318,32 +6413,61 @@ fn prepare_portrait_transition(
             .clone()
             .ok_or_else(|| "PET_LAYOUT_NOT_READY".to_string())?
     } else {
-        // macOS/Linux do not retain the Windows all-layout envelope. Keep their native frame
-        // stable for the duration of the cross-fade across just the two involved portraits.
-        let old_bounds =
-            window_interaction::logical_scale_stable_surface_bounds_with_control_surface(
+        let current_application = geometry
+            .application
+            .clone()
+            .ok_or_else(|| "PET_LAYOUT_NOT_READY".to_string())?;
+        let old_visible_bounds =
+            window_interaction::logical_visible_surface_bounds_with_control_surface(
                 &contract,
                 state,
                 geometry.portrait_scale_percent,
                 geometry.control_surface.as_ref(),
                 geometry.portrait_alpha_mask.as_ref(),
             )?;
-        let new_bounds =
-            window_interaction::logical_scale_stable_surface_bounds_with_control_surface(
+        let new_visible_bounds =
+            window_interaction::logical_visible_surface_bounds_with_control_surface(
                 &contract,
                 state,
                 geometry.portrait_scale_percent,
                 geometry.control_surface.as_ref(),
                 Some(&next_mask),
             )?;
-        apply_window_layout(
-            &contract,
-            state,
-            geometry.applied_revision,
-            &monitor,
-            geometry.portrait_anchor,
-            window_interaction::union_surface_bounds(old_bounds, new_bounds),
-        )?
+        let visible_transition_bounds =
+            window_interaction::union_surface_bounds(old_visible_bounds, new_visible_bounds);
+        if window_interaction::logical_surface_contains(
+            current_application.active_bounds,
+            visible_transition_bounds,
+        ) {
+            current_application
+        } else {
+            // macOS/Linux do not retain the Windows all-layout envelope. Keep their native frame
+            // stable for the duration of the cross-fade across just the two involved portraits.
+            let old_bounds =
+                window_interaction::logical_scale_stable_surface_bounds_with_control_surface(
+                    &contract,
+                    state,
+                    geometry.portrait_scale_percent,
+                    geometry.control_surface.as_ref(),
+                    geometry.portrait_alpha_mask.as_ref(),
+                )?;
+            let new_bounds =
+                window_interaction::logical_scale_stable_surface_bounds_with_control_surface(
+                    &contract,
+                    state,
+                    geometry.portrait_scale_percent,
+                    geometry.control_surface.as_ref(),
+                    Some(&next_mask),
+                )?;
+            apply_window_layout(
+                &contract,
+                state,
+                geometry.applied_revision,
+                &monitor,
+                geometry.portrait_anchor,
+                window_interaction::union_surface_bounds(old_bounds, new_bounds),
+            )?
+        }
     };
     let mut combined = build_native_interaction_regions(
         &contract,
@@ -6450,211 +6574,294 @@ fn begin_portrait_scale_preview(
     trace: Option<interaction_latency::InteractionTraceContext>,
     lifecycle: State<'_, ShellLifecycleState>,
     geometry_state: State<'_, Mutex<WindowGeometrySession>>,
-    glass: State<'_, input_visual_effect::InputVisualEffectState>,
+    _glass: State<'_, input_visual_effect::InputVisualEffectState>,
 ) -> Result<Option<PortraitScalePreview>, String> {
-    interaction_latency::command("main.begin-portrait-scale-preview", trace, || {
-        if window.label() != "main" {
-            return Err("PET_WINDOW_REQUIRED".to_string());
-        }
-        let available_generation = lifecycle
-            .handle
-            .as_ref()
-            .ok_or_else(|| "CHARACTER_PRESENTATION_UNAVAILABLE".to_string())?
-            .available_generation_id()
-            .map_err(str::to_string)?;
-        let mut geometry = interaction_latency::lock(
-            geometry_state.inner(),
-            "geometry-mutex-wait-start",
-            "geometry-mutex-acquired",
-        )?;
-        let generation_id = resolve_portrait_hit_generation(
-            available_generation,
-            geometry.portrait_hit_generation.as_deref(),
-        )?;
-        let same_generation =
-            geometry.portrait_hit_generation.as_deref() == Some(generation_id.as_str());
-        if same_generation && revision <= geometry.portrait_hit_revision {
-            return Ok(None);
-        }
-        geometry.require_context_menu_closed()?;
-        // A scale gesture owns the native surface transaction. If it starts while
-        // a portrait cross-fade is waiting for its final commit, discard that
-        // stale transition rather than letting it resize the window later.
-        geometry.portrait_transition_pending = None;
-        geometry.portrait_transition_active = false;
-        geometry.portrait_transition_drag = None;
-
-        let mut preview_application = if defers_native_portrait_scale_frames() {
-            geometry.application.clone()
-        } else {
-            None
-        };
-        if cfg!(windows) && !geometry.portrait_scale_preview_active {
-            let state = geometry
-                .state
-                .ok_or_else(|| "PET_LAYOUT_NOT_READY".to_string())?;
-            let contract = layout_contract()?;
-            let monitor = target_monitor(&window, geometry.portrait_anchor)?;
-            let application = compute_pet_window_layout(
-                &contract,
-                state,
-                geometry.applied_revision,
-                &monitor,
-                geometry.portrait_anchor,
-                if geometry.anchor_user_positioned {
-                    AnchorPolicy::UserPositioned
-                } else {
-                    AnchorPolicy::Automatic
-                },
-                geometry.portrait_scale_percent,
-                geometry.control_surface.as_ref(),
-                geometry.portrait_alpha_mask.as_ref(),
-                true,
-                geometry.bubble_auto_expand,
-            )?;
-            let hit_regions = build_native_interaction_regions(
-                &contract,
-                &application,
-                geometry.control_surface.as_ref(),
-                geometry.portrait_alpha_mask.as_ref(),
-                geometry.portrait_scale_percent,
-            )?;
-            let previous_application = geometry.application.clone();
-            let previous_regions = geometry.hit_regions.clone();
-            NativeWindowInteractionBackend
-                .relax_hit_regions(&window)
-                .map_err(|error| error.to_string())?;
-            apply_native_pet_surface_bounds_transaction(
-                &window,
-                &application,
-                previous_application.as_ref(),
-                previous_regions.as_ref(),
-            )?;
-            if let Some(surface) = geometry.control_surface.as_ref() {
-                glass.update_control_surface(&window, surface, &application, None, None)?;
+    interaction_latency::command(
+        "main.begin-portrait-scale-preview",
+        trace,
+        || {
+            if window.label() != "main" {
+                return Err("PET_WINDOW_REQUIRED".to_string());
             }
-            geometry.portrait_anchor = Some(application.portrait_anchor);
-            geometry.physical_local_anchor = Some(application.physical_local_anchor);
-            geometry.active_bounds = Some(application.active_bounds);
-            geometry.surface_scale = application.scale_factor * application.content_scale;
-            geometry.application = Some(application.clone());
-            geometry.hit_regions = Some(hit_regions);
-            preview_application = Some(application);
-        }
+            let available_generation = lifecycle
+                .handle
+                .as_ref()
+                .ok_or_else(|| "CHARACTER_PRESENTATION_UNAVAILABLE".to_string())?
+                .available_generation_id()
+                .map_err(str::to_string)?;
+            let mut geometry = interaction_latency::lock(
+                geometry_state.inner(),
+                "geometry-mutex-wait-start",
+                "geometry-mutex-acquired",
+            )?;
+            let generation_id = resolve_portrait_hit_generation(
+                available_generation,
+                geometry.portrait_hit_generation.as_deref(),
+            )?;
+            let same_generation =
+                geometry.portrait_hit_generation.as_deref() == Some(generation_id.as_str());
+            if same_generation && revision <= geometry.portrait_hit_revision {
+                return Ok((None, false));
+            }
+            geometry.require_context_menu_closed()?;
+            // A scale gesture owns the native surface transaction. If it starts while
+            // a portrait cross-fade is waiting for its final commit, discard that
+            // stale transition rather than letting it resize the window later.
+            geometry.portrait_transition_pending = None;
+            geometry.portrait_transition_active = false;
+            geometry.portrait_transition_drag = None;
 
-        // Keep this as an explicit platform branch instead of folding it into the Windows path:
-        // Win32 retains its stable HWND/all-layout envelope and SetWindowRgn transaction unchanged.
-        if cfg!(target_os = "macos") && !geometry.portrait_scale_preview_active {
-            let state = geometry
-                .state
-                .ok_or_else(|| "PET_LAYOUT_NOT_READY".to_string())?;
-            let contract = layout_contract()?;
-            let monitor = target_monitor(&window, geometry.portrait_anchor)?;
-            let application = compute_pet_window_layout(
-                &contract,
-                state,
-                geometry.applied_revision,
-                &monitor,
-                geometry.portrait_anchor,
-                if geometry.anchor_user_positioned {
-                    AnchorPolicy::UserPositioned
-                } else {
-                    AnchorPolicy::Automatic
-                },
-                geometry.portrait_scale_percent,
-                geometry.control_surface.as_ref(),
-                geometry.portrait_alpha_mask.as_ref(),
-                true,
-                geometry.bubble_auto_expand,
-            )?;
-            let previous_application = geometry.application.clone();
-            let previous_regions = geometry.hit_regions.clone();
-            let hit_regions = apply_native_pet_surface_transaction(
-                &window,
-                &contract,
-                &application,
-                geometry.control_surface.as_ref(),
-                geometry.portrait_alpha_mask.as_ref(),
-                geometry.portrait_scale_percent,
-                previous_application.as_ref(),
-                previous_regions.as_ref(),
-                geometry.portrait_hit_relaxed,
-            )?;
-            geometry.portrait_anchor = Some(application.portrait_anchor);
-            geometry.physical_local_anchor = Some(application.physical_local_anchor);
-            geometry.active_bounds = Some(application.active_bounds);
-            geometry.surface_scale = application.scale_factor * application.content_scale;
-            geometry.application = Some(application.clone());
-            geometry.hit_regions = Some(hit_regions);
-            preview_application = Some(application);
-        }
+            // Beginning a gesture does not itself change the native surface. Publishing the current
+            // application again would make the WebView rewrite every stage offset and layout variable
+            // on a no-op pointer press, which can invalidate the whole transparent layer on macOS.
+            let mut preview_application = None;
+            let mut snapshot_required = false;
+            #[cfg(windows)]
+            if !geometry.portrait_scale_preview_active {
+                let state = geometry
+                    .state
+                    .ok_or_else(|| "PET_LAYOUT_NOT_READY".to_string())?;
+                let contract = layout_contract()?;
+                let monitor = target_monitor(&window, geometry.portrait_anchor)?;
+                let application = compute_pet_window_layout(
+                    &contract,
+                    state,
+                    geometry.applied_revision,
+                    &monitor,
+                    geometry.portrait_anchor,
+                    if geometry.anchor_user_positioned {
+                        AnchorPolicy::UserPositioned
+                    } else {
+                        AnchorPolicy::Automatic
+                    },
+                    geometry.portrait_scale_percent,
+                    geometry.control_surface.as_ref(),
+                    geometry.portrait_alpha_mask.as_ref(),
+                    true,
+                    uses_bubble_expansion_stable_surface_bounds(geometry.bubble_auto_expand),
+                )?;
+                let hit_regions = build_native_interaction_regions(
+                    &contract,
+                    &application,
+                    geometry.control_surface.as_ref(),
+                    geometry.portrait_alpha_mask.as_ref(),
+                    geometry.portrait_scale_percent,
+                )?;
+                let coarse_preview_regions = build_coarse_native_interaction_regions(
+                    &contract,
+                    &application,
+                    geometry.control_surface.as_ref(),
+                    geometry.portrait_alpha_mask.as_ref(),
+                    window_interaction::PORTRAIT_SCALE_MAX_PERCENT,
+                )?;
+                let previous_application = geometry.application.clone();
+                let previous_regions = geometry.hit_regions.clone();
+                let geometry_changed = previous_application
+                    .as_ref()
+                    .is_none_or(|previous| !same_surface_geometry(previous, &application));
+                // A one-time relaxation is needed only if this older session has not entered the
+                // resident Windows envelope yet. The steady-state settings session keeps a coarse
+                // maximum-scale portrait/control region instead of making the whole HWND clickable.
+                if geometry_changed {
+                    NativeWindowInteractionBackend
+                        .relax_hit_regions(&window)
+                        .map_err(|error| error.to_string())?;
+                }
+                apply_native_pet_surface_bounds_transaction(
+                    &window,
+                    &application,
+                    previous_application.as_ref(),
+                    previous_regions.as_ref(),
+                )?;
+                if let Err(error) = apply_precise_hit_regions(&window, &coarse_preview_regions) {
+                    if geometry_changed {
+                        return match rollback_pet_surface(
+                        &window,
+                        previous_application.as_ref(),
+                        previous_regions.as_ref(),
+                    ) {
+                        Ok(()) => Err(format!(
+                            "PET_SCALE_PREVIEW_REGION_FAILED_PREVIOUS_RESTORED: {error}"
+                        )),
+                        Err(rollback_error) => Err(format!(
+                            "PET_SCALE_PREVIEW_REGION_FAILED: {error}; PET_SURFACE_ROLLBACK_FAILED: {rollback_error}"
+                        )),
+                    };
+                    }
+                    return Err(error);
+                }
+                if let Some(surface) = geometry.control_surface.as_ref() {
+                    _glass.update_control_surface(&window, surface, &application, None, None)?;
+                }
+                geometry.portrait_anchor = Some(application.portrait_anchor);
+                geometry.physical_local_anchor = Some(application.physical_local_anchor);
+                geometry.active_bounds = Some(application.active_bounds);
+                geometry.surface_scale = application.scale_factor * application.content_scale;
+                geometry.application = Some(application.clone());
+                geometry.hit_regions = Some(hit_regions);
+                preview_application = Some(application);
+            }
 
-        // GTK/GDK owns a separate Linux transaction. X11/XWayland can atomically move+resize;
-        // native Wayland receives only the compositor-owned resize request. Both use the same
-        // precommitted 150% surface snapshot and retain precise surface-local input routing.
-        if cfg!(target_os = "linux")
-            && geometry.portrait_scale_gesture_active
-            && !geometry.portrait_scale_preview_active
-        {
-            let state = geometry
-                .state
-                .ok_or_else(|| "PET_LAYOUT_NOT_READY".to_string())?;
-            let contract = layout_contract()?;
-            let monitor = target_monitor(&window, geometry.portrait_anchor)?;
-            let application = compute_pet_window_layout(
-                &contract,
-                state,
-                geometry.applied_revision,
-                &monitor,
-                geometry.portrait_anchor,
-                if geometry.anchor_user_positioned {
-                    AnchorPolicy::UserPositioned
-                } else {
-                    AnchorPolicy::Automatic
-                },
-                geometry.portrait_scale_percent,
-                geometry.control_surface.as_ref(),
-                geometry.portrait_alpha_mask.as_ref(),
-                true,
-                geometry.bubble_auto_expand,
-            )?;
-            let previous_application = geometry.application.clone();
-            let previous_regions = geometry.hit_regions.clone();
-            let hit_regions = apply_native_pet_surface_transaction(
-                &window,
-                &contract,
-                &application,
-                geometry.control_surface.as_ref(),
-                geometry.portrait_alpha_mask.as_ref(),
-                geometry.portrait_scale_percent,
-                previous_application.as_ref(),
-                previous_regions.as_ref(),
-                geometry.portrait_hit_relaxed,
-            )?;
-            geometry.portrait_anchor = Some(application.portrait_anchor);
-            geometry.physical_local_anchor = Some(application.physical_local_anchor);
-            geometry.active_bounds = Some(application.active_bounds);
-            geometry.surface_scale = application.scale_factor * application.content_scale;
-            geometry.application = Some(application.clone());
-            geometry.hit_regions = Some(hit_regions);
-            preview_application = Some(application);
-        }
+            #[cfg(target_os = "macos")]
+            if !geometry.portrait_scale_preview_active {
+                let state = geometry
+                    .state
+                    .ok_or_else(|| "PET_LAYOUT_NOT_READY".to_string())?;
+                let contract = layout_contract()?;
+                let monitor = target_monitor(&window, geometry.portrait_anchor)?;
+                let current_application = geometry
+                    .application
+                    .as_ref()
+                    .ok_or_else(|| "PET_LAYOUT_NOT_READY".to_string())?;
+                let stable_application = compute_pet_window_layout(
+                    &contract,
+                    state,
+                    geometry.applied_revision,
+                    &monitor,
+                    geometry.portrait_anchor,
+                    if geometry.anchor_user_positioned {
+                        AnchorPolicy::UserPositioned
+                    } else {
+                        AnchorPolicy::Automatic
+                    },
+                    geometry.portrait_scale_percent,
+                    geometry.control_surface.as_ref(),
+                    geometry.portrait_alpha_mask.as_ref(),
+                    true,
+                    uses_bubble_expansion_stable_surface_bounds(geometry.bubble_auto_expand),
+                )?;
+                let preview = clip_portrait_scale_preview_application_to_work_area(
+                    &contract,
+                    &monitor,
+                    current_application,
+                    stable_application,
+                )?;
+                if !same_surface_geometry(current_application, &preview) {
+                    snapshot_required = true;
+                }
+                preview_application = Some(preview);
+            }
 
-        if !same_generation {
-            geometry.portrait_alpha_mask = None;
-            geometry.portrait_hit_key = None;
-            geometry.portrait_hit_resource_id = None;
+            // GTK/GDK owns a separate Linux transaction. X11/XWayland can atomically move+resize;
+            // native Wayland receives only the compositor-owned resize request. Both use the same
+            // precommitted 150% surface snapshot and retain precise surface-local input routing.
+            if cfg!(target_os = "linux")
+                && geometry.portrait_scale_gesture_active
+                && !geometry.portrait_scale_preview_active
+            {
+                let state = geometry
+                    .state
+                    .ok_or_else(|| "PET_LAYOUT_NOT_READY".to_string())?;
+                let contract = layout_contract()?;
+                let monitor = target_monitor(&window, geometry.portrait_anchor)?;
+                let application = compute_pet_window_layout(
+                    &contract,
+                    state,
+                    geometry.applied_revision,
+                    &monitor,
+                    geometry.portrait_anchor,
+                    if geometry.anchor_user_positioned {
+                        AnchorPolicy::UserPositioned
+                    } else {
+                        AnchorPolicy::Automatic
+                    },
+                    geometry.portrait_scale_percent,
+                    geometry.control_surface.as_ref(),
+                    geometry.portrait_alpha_mask.as_ref(),
+                    true,
+                    uses_bubble_expansion_stable_surface_bounds(geometry.bubble_auto_expand),
+                )?;
+                let previous_application = geometry.application.clone();
+                let previous_regions = geometry.hit_regions.clone();
+                let hit_regions = apply_native_pet_surface_transaction(
+                    &window,
+                    &contract,
+                    &application,
+                    geometry.control_surface.as_ref(),
+                    geometry.portrait_alpha_mask.as_ref(),
+                    geometry.portrait_scale_percent,
+                    previous_application.as_ref(),
+                    previous_regions.as_ref(),
+                    geometry.portrait_hit_relaxed,
+                )?;
+                geometry.portrait_anchor = Some(application.portrait_anchor);
+                geometry.physical_local_anchor = Some(application.physical_local_anchor);
+                geometry.active_bounds = Some(application.active_bounds);
+                geometry.surface_scale = application.scale_factor * application.content_scale;
+                geometry.application = Some(application.clone());
+                geometry.hit_regions = Some(hit_regions);
+                preview_application = Some(application);
+            }
+
+            if !same_generation {
+                geometry.portrait_alpha_mask = None;
+                geometry.portrait_hit_key = None;
+                geometry.portrait_hit_resource_id = None;
+            }
+            geometry.portrait_hit_generation = Some(generation_id);
+            geometry.portrait_hit_revision = revision;
+            geometry.portrait_hit_relaxed = defers_portrait_scale_hit_region_frames();
+            geometry.portrait_scale_preview_active = true;
+            Ok((
+                Some(PortraitScalePreview {
+                    application: preview_application,
+                    deferred_native: defers_native_portrait_scale_frames(),
+                    deferred_hit_regions: defers_portrait_scale_hit_region_frames(),
+                    precommit_on_first_frame: cfg!(target_os = "macos"),
+                    snapshot_required,
+                }),
+                snapshot_required,
+            ))
+        },
+    )
+    .map(|(preview, _)| preview)
+}
+
+#[tauri::command]
+async fn prepare_portrait_scale_preview_snapshot(
+    window: WebviewWindow,
+    revision: u64,
+    geometry_state: State<'_, Mutex<WindowGeometrySession>>,
+) -> Result<bool, String> {
+    if window.label() != "main" {
+        return Err("PET_WINDOW_REQUIRED".to_string());
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let ready = {
+            let geometry = geometry_state
+                .lock()
+                .map_err(|_| "window geometry state is unavailable".to_string())?;
+            geometry.portrait_scale_preview_active && geometry.portrait_hit_revision == revision
+        };
+        if !ready {
+            return Ok(false);
         }
-        geometry.portrait_hit_generation = Some(generation_id);
-        geometry.portrait_hit_revision = revision;
-        geometry.portrait_hit_relaxed = defers_portrait_scale_hit_region_frames();
-        geometry.portrait_scale_preview_active = true;
-        Ok(Some(PortraitScalePreview {
-            application: preview_application,
-            deferred_native: defers_native_portrait_scale_frames(),
-            deferred_hit_regions: defers_portrait_scale_hit_region_frames(),
-        }))
-    })
+        let installed = macos_surface_snapshot::install(&window, revision).await?;
+        let still_current = {
+            let geometry = geometry_state
+                .lock()
+                .map_err(|_| "window geometry state is unavailable".to_string())?;
+            installed
+                && geometry.portrait_scale_preview_active
+                && geometry.portrait_hit_revision == revision
+        };
+        if !still_current {
+            macos_surface_snapshot::finish(&window, revision).await?;
+            return Ok(false);
+        }
+        if std::env::var_os("SAKURA_TRACE_MACOS_SURFACE").is_some() {
+            eprintln!(
+                "[macos-surface-snapshot] phase=prepare-return revision={revision} snapshot=true"
+            );
+        }
+        return Ok(true);
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (revision, geometry_state);
+        Ok(false)
+    }
 }
 
 #[tauri::command]
@@ -6755,6 +6962,10 @@ fn activate_portrait_hit_test(
         let contract = layout_contract()?;
         let monitor = target_monitor(&window, geometry.portrait_anchor)?;
         let stabilize_portrait_scale = geometry.stabilizes_portrait_scale_bounds();
+        let preserve_portrait_scale_anchor = preserves_portrait_anchor_for_scale_settlement(
+            geometry.portrait_scale_preview_active,
+            geometry.portrait_scale_gesture_active,
+        );
         let defer_portrait_hit_regions = geometry.defers_precise_portrait_scale_hit_regions();
         let defer_precise_hit_regions = geometry.defers_precise_surface_hit_regions();
         let defer_portrait_transition_native =
@@ -6779,7 +6990,7 @@ fn activate_portrait_hit_test(
                 geometry.applied_revision,
                 &monitor,
                 geometry.portrait_anchor,
-                if geometry.anchor_user_positioned {
+                if geometry.anchor_user_positioned || preserve_portrait_scale_anchor {
                     AnchorPolicy::UserPositioned
                 } else {
                     AnchorPolicy::Automatic
@@ -6788,8 +6999,22 @@ fn activate_portrait_hit_test(
                 geometry.control_surface.as_ref(),
                 portrait_alpha_mask,
                 stabilize_portrait_scale,
-                geometry.bubble_auto_expand,
+                uses_bubble_expansion_stable_surface_bounds(geometry.bubble_auto_expand),
             )?,
+        };
+        let application = if cfg!(target_os = "macos") && stabilize_portrait_scale {
+            let current_application = geometry
+                .application
+                .as_ref()
+                .ok_or_else(|| "PET_LAYOUT_NOT_READY".to_string())?;
+            clip_portrait_scale_preview_application_to_work_area(
+                &contract,
+                &monitor,
+                current_application,
+                application,
+            )?
+        } else {
+            application
         };
         let previous_application = geometry.application.clone();
         let previous_regions = geometry.hit_regions.clone();
@@ -6860,7 +7085,7 @@ fn activate_portrait_hit_test(
         geometry.portrait_hit_key = Some(portrait_key);
         geometry.portrait_hit_resource_id = portrait_resource_id;
         geometry.portrait_hit_revision = revision;
-        // A concurrent control-surface preview keeps the HWND relaxed, but it must not masquerade
+        // A concurrent control-surface preview keeps a coarse HWND region, but it must not masquerade
         // as an unfinished portrait gesture. end_control_surface_preview owns the final precise
         // region once both previews have actually ended.
         geometry.portrait_hit_relaxed = defer_portrait_hit_regions;
@@ -6986,7 +7211,7 @@ fn settle_portrait_scale_surface(
         geometry.control_surface.as_ref(),
         geometry.portrait_alpha_mask.as_ref(),
         false,
-        geometry.bubble_auto_expand,
+        uses_bubble_expansion_stable_surface_bounds(geometry.bubble_auto_expand),
     )?;
     let previous_application = geometry.application.clone();
     let previous_regions = geometry.hit_regions.clone();
@@ -7013,6 +7238,24 @@ fn settle_portrait_scale_surface(
     geometry.application = Some(application.clone());
     geometry.hit_regions = Some(hit_regions);
     Ok(Some(application))
+}
+
+#[tauri::command]
+async fn finish_portrait_scale_preview_snapshot(
+    window: WebviewWindow,
+    revision: u64,
+) -> Result<(), String> {
+    if window.label() != "main" {
+        return Err("PET_WINDOW_REQUIRED".to_string());
+    }
+    #[cfg(target_os = "macos")]
+    {
+        if std::env::var_os("SAKURA_TRACE_MACOS_SURFACE").is_some() {
+            eprintln!("[macos-surface-snapshot] phase=finish-command");
+        }
+        macos_surface_snapshot::finish(&window, revision).await?;
+    }
+    Ok(())
 }
 
 #[tauri::command]
@@ -7909,6 +8152,10 @@ fn main() {
                     }
                 }
                 tauri::WindowEvent::Destroyed => {
+                    #[cfg(target_os = "macos")]
+                    if let Some(main_window) = window.app_handle().get_webview_window("main") {
+                        let _ = macos_surface_snapshot::clear(&main_window);
+                    }
                     let geometry = window.state::<Mutex<WindowGeometrySession>>();
                     if let Ok(mut geometry) = geometry.lock() {
                         if geometry.portrait_scale_gesture_active {
@@ -8014,6 +8261,8 @@ fn main() {
             activate_portrait_hit_test,
             commit_portrait_transition,
             settle_portrait_scale_surface,
+            prepare_portrait_scale_preview_snapshot,
+            finish_portrait_scale_preview_snapshot,
             interaction_latency_diagnostics_enabled,
             input_visual_effect_status,
             record_interaction_latency_trace,
@@ -8462,6 +8711,80 @@ mod tests {
     }
 
     #[test]
+    fn automatic_bubble_expansion_reserves_a_maximum_surface_only_on_windows() {
+        assert!(!uses_bubble_expansion_stable_surface_bounds(false));
+        assert_eq!(
+            uses_bubble_expansion_stable_surface_bounds(true),
+            cfg!(windows)
+        );
+    }
+
+    #[test]
+    fn portrait_scale_settlement_keeps_the_existing_physical_anchor_at_screen_edges() {
+        let contract = layout_contract().unwrap();
+        let monitor = MonitorDescriptor {
+            name: None,
+            work_area: PhysicalRect {
+                x: 0,
+                y: 0,
+                width: 1_920,
+                height: 1_080,
+            },
+            scale_factor: 1.0,
+        };
+        let initial = compute_pet_window_layout(
+            &contract,
+            PresentationState::Product,
+            1,
+            &monitor,
+            None,
+            AnchorPolicy::Automatic,
+            100,
+            None,
+            None,
+            true,
+            false,
+        )
+        .unwrap();
+        let automatically_refitted = compute_pet_window_layout(
+            &contract,
+            PresentationState::Product,
+            2,
+            &monitor,
+            Some(initial.portrait_anchor),
+            AnchorPolicy::Automatic,
+            150,
+            None,
+            None,
+            false,
+            false,
+        )
+        .unwrap();
+        let settled = compute_pet_window_layout(
+            &contract,
+            PresentationState::Product,
+            2,
+            &monitor,
+            Some(initial.portrait_anchor),
+            AnchorPolicy::UserPositioned,
+            150,
+            None,
+            None,
+            false,
+            false,
+        )
+        .unwrap();
+
+        assert!(preserves_portrait_anchor_for_scale_settlement(true, false));
+        assert!(!preserves_portrait_anchor_for_scale_settlement(true, true));
+        assert_ne!(
+            automatically_refitted.portrait_anchor,
+            initial.portrait_anchor
+        );
+        assert_eq!(settled.portrait_anchor, initial.portrait_anchor);
+    }
+
+    #[test]
     fn message_expansion_keeps_the_native_window_and_input_anchor_stable() {
         let contract = layout_contract().unwrap();
         let monitor = MonitorDescriptor {
@@ -8522,6 +8845,87 @@ mod tests {
             compact.physical_local_anchor,
             expanded.physical_local_anchor
         );
+    }
+
+    #[test]
+    fn control_surface_preview_region_stays_coarse_and_follows_the_latest_frame() {
+        let contract = layout_contract().unwrap();
+        let monitor = MonitorDescriptor {
+            name: None,
+            work_area: PhysicalRect {
+                x: 0,
+                y: 0,
+                width: 2_560,
+                height: 1_440,
+            },
+            scale_factor: 1.0,
+        };
+        let first = ControlSurfaceLayout {
+            bubble_rect: [130, 600, 640, 128],
+            input_rect: [130, 738, 640, 52],
+            controls_rect: [730, 610, 30, 30],
+            bubble_visible: true,
+            input_visible: true,
+        };
+        let application = compute_pet_window_layout(
+            &contract,
+            PresentationState::Product,
+            1,
+            &monitor,
+            None,
+            AnchorPolicy::Automatic,
+            100,
+            Some(&first),
+            None,
+            true,
+            false,
+        )
+        .unwrap();
+        let mask = character_presentation::PortraitAlphaMask::new(4, 4, vec![255; 16]);
+        let first_regions = build_coarse_native_interaction_regions(
+            &contract,
+            &application,
+            Some(&first),
+            Some(&mask),
+            100,
+        )
+        .unwrap();
+        let second = ControlSurfaceLayout {
+            bubble_rect: [70, 520, 760, 208],
+            input_rect: [70, 738, 760, 52],
+            controls_rect: [790, 530, 30, 30],
+            ..first
+        };
+        let second_regions = build_coarse_native_interaction_regions(
+            &contract,
+            &application,
+            Some(&second),
+            Some(&mask),
+            100,
+        )
+        .unwrap();
+        let maximum_scale_regions = build_coarse_native_interaction_regions(
+            &contract,
+            &application,
+            Some(&second),
+            Some(&mask),
+            window_interaction::PORTRAIT_SCALE_MAX_PERCENT,
+        )
+        .unwrap();
+
+        assert!(first_regions.portrait_alpha_mask.is_none());
+        assert!(second_regions.portrait_alpha_mask.is_none());
+        assert!(maximum_scale_regions.portrait_alpha_mask.is_none());
+        assert_ne!(first_regions.interactive, second_regions.interactive);
+        assert_ne!(first_regions.drag, second_regions.drag);
+        assert!(maximum_scale_regions.drag[0].width >= second_regions.drag[0].width);
+        assert!(maximum_scale_regions.drag[0].height >= second_regions.drag[0].height);
+        assert!(second_regions
+            .interactive
+            .iter()
+            .chain(second_regions.drag.iter())
+            .all(|rect| rect.width < second_regions.envelope[0]
+                || rect.height < second_regions.envelope[1]));
     }
 
     #[test]

--- a/desktop/src-tauri/src/platform/window_backend.rs
+++ b/desktop/src-tauri/src/platform/window_backend.rs
@@ -122,9 +122,8 @@ fn macos_atomic_frame(
             backing_scale,
         )?;
         let frame = NSRect::new(NSPoint::new(x, y), NSSize::new(width, height));
-        // `display=true` forces AppKit to paint the resized surface before WebKit has consumed
-        // the precommitted stage offset, exposing one stale frame at gesture begin/end.
         ns_window.setFrame_display(frame, false);
+        crate::macos_surface_snapshot::reposition_for_window_frame(frame)?;
         Ok(())
     }
 

--- a/desktop/src-tauri/src/window_geometry.rs
+++ b/desktop/src-tauri/src/window_geometry.rs
@@ -592,6 +592,86 @@ pub fn apply_window_layout_with_fit_bounds(
     })
 }
 
+/// Limits a gesture-only backing envelope to the pixels that can appear inside the monitor work
+/// area while keeping the already committed surface available. This matters on macOS because
+/// AppKit moves an oversized borderless window back below the menu bar when its requested top
+/// edge is off-screen, which would move every visible child even though the portrait anchor did
+/// not change.
+pub fn clip_expanded_surface_bounds_to_work_area(
+    application: &LayoutApplication,
+    expanded_bounds: [u32; 4],
+    viewport_anchor: [u32; 2],
+) -> Result<[u32; 4], String> {
+    let [base_x, base_y, base_width, base_height] = application.active_bounds;
+    let [expanded_x, expanded_y, expanded_width, expanded_height] = expanded_bounds;
+    let base_right = base_x
+        .checked_add(base_width)
+        .ok_or_else(|| "base pet surface right edge overflow".to_string())?;
+    let base_bottom = base_y
+        .checked_add(base_height)
+        .ok_or_else(|| "base pet surface bottom edge overflow".to_string())?;
+    let expanded_right = expanded_x
+        .checked_add(expanded_width)
+        .ok_or_else(|| "expanded pet surface right edge overflow".to_string())?;
+    let expanded_bottom = expanded_y
+        .checked_add(expanded_height)
+        .ok_or_else(|| "expanded pet surface bottom edge overflow".to_string())?;
+    if expanded_x > base_x
+        || expanded_y > base_y
+        || expanded_right < base_right
+        || expanded_bottom < base_bottom
+    {
+        return Err("expanded pet surface must contain the committed bounds".to_string());
+    }
+
+    let scale = application.scale_factor * application.content_scale;
+    if !scale.is_finite() || scale <= 0.0 {
+        return Err("pet surface scale must be positive and finite".to_string());
+    }
+    let [anchor_x, anchor_y] = viewport_anchor;
+    let physical_edge =
+        |value: u32, canonical_anchor: u32, global_anchor: i32, round_up: bool| -> i64 {
+            let relative = (f64::from(value) - f64::from(canonical_anchor)) * scale;
+            i64::from(global_anchor)
+                + if round_up {
+                    relative.ceil() as i64
+                } else {
+                    relative.floor() as i64
+                }
+        };
+
+    let mut left = expanded_x;
+    while left < base_x
+        && physical_edge(left, anchor_x, application.portrait_anchor.x, false)
+            < i64::from(application.work_area.x)
+    {
+        left += 1;
+    }
+    let mut top = expanded_y;
+    while top < base_y
+        && physical_edge(top, anchor_y, application.portrait_anchor.y, false)
+            < i64::from(application.work_area.y)
+    {
+        top += 1;
+    }
+    let mut right = expanded_right;
+    while right > base_right
+        && physical_edge(right, anchor_x, application.portrait_anchor.x, true)
+            > application.work_area.right()
+    {
+        right -= 1;
+    }
+    let mut bottom = expanded_bottom;
+    while bottom > base_bottom
+        && physical_edge(bottom, anchor_y, application.portrait_anchor.y, true)
+            > application.work_area.bottom()
+    {
+        bottom -= 1;
+    }
+
+    Ok([left, top, right - left, bottom - top])
+}
+
 /// Expands an already committed surface without recalculating its monitor fit or anchor.
 ///
 /// Context menus are painted inside the existing WebView coordinate space, so opening one must
@@ -1887,6 +1967,84 @@ mod tests {
                 anchor
             );
         }
+    }
+
+    #[test]
+    fn window_surface_regression_scale_preview_keeps_visible_surface_at_macos_top_edge() {
+        let contract = contract();
+        let monitor = monitor(
+            PhysicalRect {
+                x: 0,
+                y: 30,
+                width: 1_920,
+                height: 1_050,
+            },
+            1.0,
+        );
+        let anchor = PhysicalPoint { x: 1_000, y: 214 };
+        let current_bounds = [300, 800, 300, 300];
+        let stable_bounds = [0, 0, 900, 1_500];
+        let current = apply_window_layout_with_fit_bounds(
+            &contract,
+            PresentationState::Product,
+            1,
+            &monitor,
+            Some(anchor),
+            AnchorPolicy::UserPositioned,
+            current_bounds,
+            current_bounds,
+        )
+        .unwrap();
+        let unconstrained = apply_window_layout_with_fit_bounds(
+            &contract,
+            PresentationState::Product,
+            1,
+            &monitor,
+            Some(anchor),
+            AnchorPolicy::UserPositioned,
+            current_bounds,
+            stable_bounds,
+        )
+        .unwrap();
+        assert_eq!(current.physical_placement.y, monitor.work_area.y);
+        assert!(unconstrained.physical_placement.y < monitor.work_area.y);
+
+        let clipped_bounds = clip_expanded_surface_bounds_to_work_area(
+            &current,
+            stable_bounds,
+            contract.viewport.portrait_anchor,
+        )
+        .unwrap();
+        let clipped = apply_window_layout_with_fit_bounds(
+            &contract,
+            PresentationState::Product,
+            1,
+            &monitor,
+            Some(anchor),
+            AnchorPolicy::UserPositioned,
+            current_bounds,
+            clipped_bounds,
+        )
+        .unwrap();
+
+        assert_eq!(clipped_bounds[1], current_bounds[1]);
+        assert_eq!(clipped.physical_placement.y, monitor.work_area.y);
+        let current_visible_top = i64::from(clipped.portrait_anchor.y)
+            + ((f64::from(current_bounds[1]) - f64::from(contract.viewport.portrait_anchor[1]))
+                * clipped.scale_factor
+                * clipped.content_scale)
+                .floor() as i64;
+        assert_eq!(current_visible_top, i64::from(monitor.work_area.y));
+        assert_eq!(clipped.portrait_anchor, current.portrait_anchor);
+        assert_eq!(
+            clipped.physical_local_anchor[1],
+            current.physical_local_anchor[1]
+        );
+        assert_eq!(
+            i64::from(clipped.physical_placement.x) + i64::from(clipped.physical_local_anchor[0]),
+            i64::from(anchor.x)
+        );
+        assert!(clipped.physical_placement.height > current.physical_placement.height);
     }
 
     #[test]

--- a/desktop/src-tauri/src/window_interaction.rs
+++ b/desktop/src-tauri/src/window_interaction.rs
@@ -698,6 +698,19 @@ pub fn union_surface_bounds(first: [u32; 4], second: [u32; 4]) -> [u32; 4] {
     ]
 }
 
+pub fn logical_surface_contains(container: [u32; 4], candidate: [u32; 4]) -> bool {
+    let container_right = u64::from(container[0]) + u64::from(container[2]);
+    let container_bottom = u64::from(container[1]) + u64::from(container[3]);
+    let candidate_right = u64::from(candidate[0]) + u64::from(candidate[2]);
+    let candidate_bottom = u64::from(candidate[1]) + u64::from(candidate[3]);
+    candidate[2] > 0
+        && candidate[3] > 0
+        && candidate[0] >= container[0]
+        && candidate[1] >= container[1]
+        && candidate_right <= container_right
+        && candidate_bottom <= container_bottom
+}
+
 /// Extends a committed surface for an overlay that is positioned inside its
 /// current top-left origin. The WebView keeps that origin while the native
 /// window grows, so the overlay can be painted without changing the canonical
@@ -1526,9 +1539,14 @@ fn dpi_region_scale(old_dpi: u32, new_dpi: u32) -> Option<f32> {
 #[cfg(any(windows, test))]
 fn coarse_drag_hit_regions(model: &PhysicalHitRegions) -> Option<PhysicalHitRegions> {
     model.portrait_alpha_mask.as_ref()?;
+    Some(coarse_preview_hit_regions(model))
+}
+
+#[cfg(any(windows, test))]
+pub(crate) fn coarse_preview_hit_regions(model: &PhysicalHitRegions) -> PhysicalHitRegions {
     let mut coarse = model.clone();
     coarse.portrait_alpha_mask = None;
-    Some(coarse)
+    coarse
 }
 
 #[cfg(windows)]
@@ -2822,6 +2840,43 @@ mod tests {
     }
 
     #[test]
+    fn window_surface_regression_same_silhouette_transition_reuses_current_surface() {
+        let contract = contract();
+        let surface = extreme_control_surface(&contract, 640, 122, 0, 0, 52).unwrap();
+        let mask = PortraitAlphaMask::new(4, 4, vec![255; 16]);
+        let current = logical_bubble_expansion_stable_surface_bounds(
+            &contract,
+            PresentationState::Product,
+            100,
+            &surface,
+            Some(&mask),
+        )
+        .unwrap();
+        let visible = logical_visible_surface_bounds_with_control_surface(
+            &contract,
+            PresentationState::Product,
+            100,
+            Some(&surface),
+            Some(&mask),
+        )
+        .unwrap();
+        let old_scale_stable = logical_scale_stable_surface_bounds_with_control_surface(
+            &contract,
+            PresentationState::Product,
+            100,
+            Some(&surface),
+            Some(&mask),
+        )
+        .unwrap();
+
+        assert!(logical_surface_contains(
+            current,
+            union_surface_bounds(visible, visible)
+        ));
+        assert!(!logical_surface_contains(current, old_scale_stable));
+    }
+
+    #[test]
     fn window_surface_regression_context_menu_expands_and_restores_dynamic_bounds() {
         let base = [126, 678, 648, 196];
         let menu = [146, 698, 226, 273];
@@ -2957,6 +3012,11 @@ mod tests {
         };
 
         assert!(coarse_drag_hit_regions(&model).is_none());
+        assert_eq!(
+            coarse_preview_hit_regions(&model).drag,
+            model.drag,
+            "preview still keeps the visible drag rectangle without an alpha mask"
+        );
     }
 
     #[test]

--- a/docs/adr/0010-cross-platform-pet-surface.md
+++ b/docs/adr/0010-cross-platform-pet-surface.md
@@ -4,7 +4,7 @@ status: proposed
 audience: maintainer
 source_of_truth: self
 status_source: ../plans/runtime-v2/work-packages.md
-updated: 2026-09-01
+updated: 2026-09-03
 ---
 
 # ADR-0010：跨平台桌宠动态表面与精确命中
@@ -33,10 +33,11 @@ Runtime v2 把 900×996 规范舞台直接作为原生透明窗口。Windows 另
   切换只替换精确 region；原生 frame 未变化时不得重复提交 bounds 或 WebView surface offset。
   Windows 用“当前倍率下的完整规范立绘槽 + 当前控件与工具坞”计算工作区适配；alpha mask 不得改变
   `content_scale`、anchor、`active_bounds`、physical placement 或 WebView offset。静止态仍
-  用当前 mask 的精确 region 表达真实轮廓和点击穿透。缩放开始只清除一次复杂 region，数值刻度经专用
+  用当前 mask 的精确 region 表达真实轮廓和点击穿透。缩放开始只把复杂 alpha region 换成“150% 立绘
+  外接矩形 + 当前可见控件”的粗 region，数值刻度经专用
   轻量事件直接更新 WebView 合成 transform，不进入完整外观预览、bounds、surface offset 或 alpha 模型。
   显式手势结束后，最新 revision 只提交一次当前倍率精确 region，不再改变窗口 placement；
-  从放宽状态恢复时跳过旧新 region 桥接，避免连续两次 GDI 裁剪。放宽 region 不能成为常驻状态，也
+  从粗 region 恢复时跳过旧新 region 桥接，避免连续两次 GDI 裁剪。粗 region 不能成为常驻状态，也
   不能用相邻刻度的时间间隔推断手势已经结束。轻量帧采用 latest-wins 和内部有界追赶，单帧失败不作为
   设置连接故障；最终完整外观 publication 仍是可靠状态提交。
 - macOS 只在缩放手势活跃期间临时使用“当前控件布局与 150% 立绘”的稳定包络；静止态必须收紧到
@@ -60,8 +61,10 @@ Runtime v2 把 900×996 规范舞台直接作为原生透明窗口。Windows 另
   逐帧 resize/reposition 原生窗口。
   Windows 稳定 HWND/WebView 包络扩大为完整规范立绘槽在 50%–150% 倍率下与全部合法控制面板布局
   极值的并集。四个布局滑块与立绘倍率一样采用两端事务：刻度用 RAF/latest-wins 轻量事件直接绘制，
-  结束时只做一次原生提交
-  和精确 region 恢复。Windows 视觉帧不等待 region 放宽完成；立绘图层在首次交互前预先提升为
+  同时用少量矩形更新当前控件的粗 region；结束时只做一次原生布局提交和精确 region 恢复。粗 region
+  去掉昂贵的立绘 alpha 行段，但必须保留立绘外接矩形、气泡、输入框和其他可见控件，禁止清空
+  `SetWindowRgn` 让整个稳定 HWND 接收点击。Windows 视觉帧不等待粗 region 更新完成；更新失败时保留
+  上一版有效 region。立绘图层在首次交互前预先提升为
   transform 合成层。macOS 不复用 Windows 的全部布局极值包络；macOS/Linux 的布局手势也不复用
   立绘缩放专用的 150% 临时包络，两者收到布局轻量事件时仍逐帧提交对应命中模型，真实控件布局超出
   当前包络时仍更新原生表面。
@@ -77,8 +80,8 @@ Runtime v2 把 900×996 规范舞台直接作为原生透明窗口。Windows 另
 - 立绘有效 alpha 像素与气泡的非交互空白可拖动。气泡中的实际回复文字、滚动条、输入框、菜单及
   其他控件保持交互优先；WebView 在调用拖动命令前按 DOM 目标拦截这些交互点，Rust 再按同 revision
   的逻辑命中模型复核立绘或可见气泡起点。
-- bounds、命中与 DOM 布局按同一 revision 提交；失败保留上一版有效快照。除 Windows 缩放预览
-  期间的短暂放宽外，不得恢复整窗命中。过期立绘 revision 返回空结果，不得把旧 `active_bounds`
+- bounds、命中与 DOM 布局按同一 revision 提交；失败保留上一版有效快照。设置外观或缩放预览不得
+  恢复整窗命中。过期立绘 revision 返回空结果，不得把旧 `active_bounds`
   重新提交给前端。
 - textarea 内容扩展固定输入栏顶部并只向下增加高度，气泡矩形不参与该变化。扩展时原生层先提交最终
   bounds/命中，WebView 再用无持久尾帧的 FLIP 动画呈现内容位移。Windows 收缩时若先提交较小
@@ -103,7 +106,8 @@ Runtime v2 把 900×996 规范舞台直接作为原生透明窗口。Windows 另
 Windows 静止态继续使用窗口 region 同时裁剪可见和输入区域，复杂 alpha 不得静默退化成外接矩形；
 跨 silhouette 的稳定 HWND 包络会比当前可见 alpha 占用更大的透明 backing surface，但换来表情与角色
 切换时不再重建 HWND/WebView frame。当前 mask 的精确 region 让透明余量既不绘制也不接收点击。缩放
-手势期的临时放宽是有明确开始、结束和最新 revision 恢复的视觉性能事务，不是降级兜底。
+和布局手势期只允许使用覆盖当前视觉的粗矩形 region，并由最新 revision 恢复精确 region；稳定 HWND
+剩余的透明空间不会因此拦截桌面点击。
 Tauri 2.11.3/WRY 0.55.1 在 macOS 根 `WebviewWindow` 上会忽略独立 WebView bounds，远程 WebKit
 图层也不服从父 `NSView` 的几何平移；而 WebView eval 与窗口 placement 排队也不能证明没有可见
 中间帧。因此本决策不把根 WebView 伪装成可负偏移子视口，也不把消息顺序作为缩放稳定性的保证：

--- a/docs/adr/0025-macos-dynamic-surface-envelope.md
+++ b/docs/adr/0025-macos-dynamic-surface-envelope.md
@@ -3,7 +3,7 @@ kind: adr
 status: accepted
 audience: maintainer
 source_of_truth: self
-updated: 2026-08-18
+updated: 2026-09-03
 ---
 
 # ADR-0025：macOS 桌宠静止态动态包络与过渡稳定包络边界

--- a/docs/records/incidents/MACOS_PET_TOP_EDGE_DRAG_REGRESSION.md
+++ b/docs/records/incidents/MACOS_PET_TOP_EDGE_DRAG_REGRESSION.md
@@ -1,0 +1,106 @@
+---
+kind: record
+status: recorded
+audience: maintainer
+source_of_truth: self
+priority: P1
+resolution: awaiting-live-validation
+updated: 2026-09-04
+---
+
+# macOS 桌宠无法拖到工作区顶端回归
+
+> 当前结论：问题来自缩放手势使用的临时最大包络，而不是拖动事件本身。当前工作树会在 macOS 上裁掉超出工作区的临时透明 backing，并在手势结束后恢复当前倍率的真实包络。自动测试已锁定几何不变量；macOS 原生窗口的最终行为仍需每次相关改动后做实机验收。
+
+## 影响与回归特征
+
+- 有可见立绘的角色无法继续向上拖到菜单栏下方，立绘顶部会留下明显空位。
+- 问题多次在“修复缩放抖动或闪烁”之后重新出现，因此不能只检查拖动监听器。
+- 全透明角色不容易暴露这类问题。它可以检查气泡、输入栏和命中区域，但不能证明可见立绘已经贴顶。
+- 问题曾与调整立绘大小时的下跳、闪烁同时出现，但两者不是同一个验收项。
+
+## 根因
+
+macOS 的静止态曾常驻立绘最大倍率包络，或在缩放预览开始后保留了向当前可见内容上方扩展的透明区域。用户向上拖动时，AppKit 约束的是整个无边框 `NSWindow`，不是其中可见立绘的 alpha 顶边。透明 backing 先碰到工作区顶边后，AppKit 不再允许窗口继续向上，所以立绘顶部仍离工作区顶边一段距离。
+
+这类回归容易反复出现，原因是两个目标互相牵制：
+
+- 稳定的大包络可以减少缩放过程中频繁 resize 带来的抖动和错位。
+- 大包络如果在静止态长期保留，或在屏幕边缘不裁剪，就会改变拖动边界并扩大透明窗口。
+
+因此，“不抖”不能靠 macOS 常驻 150% 包络解决。设置页打开时取消整个窗口的遮罩也不是可接受方案：在 Windows 的稳定大窗口中，这会让大块透明区域吞掉其他窗口的点击。
+
+## 当前修正
+
+相关实现位于：
+
+- `desktop/src-tauri/src/main.rs`：`clip_portrait_scale_preview_application_to_work_area()` 在缩放预览开始时合并当前表面和稳定包络，再调用几何裁剪。
+- `desktop/src-tauri/src/window_geometry.rs`：`clip_expanded_surface_bounds_to_work_area()` 只裁掉工作区外的手势临时 backing，不能裁掉已经提交的可见表面。
+- `desktop/src-tauri/src/window_interaction.rs`：计算当前倍率真实包络和手势期间的稳定包络。
+
+当前策略如下：
+
+1. macOS 静止态只保留当前倍率立绘、气泡、输入栏和其他可见控件的真实并集。
+2. 调整立绘大小时允许临时扩大包络，但先按当前显示器工作区裁掉不可见的外围 backing。
+3. 扩大和裁剪前后保持同一个全局物理立绘锚点；不能通过移动整个窗口来容纳透明区域。
+4. 手势结束后恢复最终倍率的精确动态包络，不留下最大倍率的顶部空位。
+5. Windows 继续使用稳定 HWND/WebView 包络，并以粗粒度 region 覆盖立绘与可见控件；稳定包络中的其他透明区域必须穿透。
+
+## 自动回归门
+
+Rust 测试 `window_surface_regression_scale_preview_keeps_visible_surface_at_macos_top_edge` 模拟以下场景：
+
+1. 工作区从菜单栏下方开始，当前可见桌宠已经贴住工作区顶边。
+2. 缩放手势请求一个向上扩展的 150% 临时包络；未裁剪时，其原生窗口顶边会越过工作区。
+3. 应用裁剪后，原生窗口顶边不能低于或越过工作区顶边，当前可见表面的全局顶边仍保持贴顶。
+4. 裁剪前后的全局物理立绘锚点必须完全一致，窗口仍可向下扩展容纳手势预览。
+
+测试名带 `window_surface_regression` 前缀，因此会进入 `runtime-v2-window-surface` Harness profile。运行方式：
+
+```bash
+./runtime/bin/python -m harness run runtime-v2-window-surface
+```
+
+需要只跑这条测试时：
+
+```bash
+cargo test --manifest-path desktop/src-tauri/Cargo.toml --locked \
+  window_surface_regression_scale_preview_keeps_visible_surface_at_macos_top_edge \
+  -- --nocapture
+```
+
+该测试能防止几何算法再次把可见内容向下推，但无法观察 AppKit、WKWebView 和 WindowServer 的真实合成帧。不要用它证明实机拖动、透明穿透或缩放无闪烁。
+
+2026-09-04 的自动验证结果：
+
+- 定向 Rust 测试：1 passed，0 failed。
+- `runtime-v2-window-surface`：4/4 cases 通过。其中前端 249 项、表面回归 14 项、窗口几何 29 项、窗口交互 37 项全部通过。
+- `git diff --check`：通过。
+- `tools/check_docs.py`：仍被仓库原有的 `docs/.DS_Store` 拒绝；没有新增文档错误，也没有为本次记录清理该文件。
+
+## macOS 实机验收
+
+每次修改动态包络、缩放预览、原生 frame、stage offset 或透明命中后，至少执行一次：
+
+1. 使用有可见立绘的 N.A.V.I.，先关闭气泡和输入栏干扰，将桌宠拖到菜单栏下方。
+2. 确认可见立绘顶部距工作区顶部不超过 2 个逻辑像素，松手后不会被弹回。
+3. 打开设置，把立绘大小连续拖动 `50% → 150% → 50%`，再松手并重新拖到顶边。
+4. 重复 20 轮，确认拖动中立绘不裁剪，气泡和输入栏不抖，松手后顶部空位不残留。
+5. 点击立绘外围和内部透明洞，确认点击到达背景窗口；可见立绘、气泡和输入栏仍能正常交互。
+6. 在 Windows 上复查设置页打开及滑条操作期间的大块透明区域可以点击穿透，不能用取消 region 的方式换取稳定。
+
+若第 2 或第 3 步失败，即使所有自动测试通过，也应重新打开本事件。验收视频或结果应记录构建 SHA；不要只写“新版”或引用本机对话链接。
+
+## 不得恢复的方案
+
+- macOS 静止态常驻 150% 最大包络。
+- 为了避免滑条抖动，在设置页打开期间取消 Windows 整个窗口的 region。
+- 分别调用窗口 `set_size` 和 `set_position` 来补偿位置；两步之间可能暴露错位帧。
+- 用全透明角色作为“可见立绘已经贴顶”的验收证据。
+
+## 关闭条件
+
+- 上述 Rust 回归测试进入 `runtime-v2-window-surface` 并通过。
+- macOS 有可见立绘的角色完成 20 轮顶边拖动和缩放实机验收。
+- Windows 完成透明区域穿透与立绘、气泡尺寸和位置滑条稳定性复查。
+- 故障记录中保存构建 SHA、日期和结果；不依赖 Codex 深度链接或某台电脑的本地会话。

--- a/docs/records/incidents/MACOS_PORTRAIT_SCALE_WINDOW_FLICKER.md
+++ b/docs/records/incidents/MACOS_PORTRAIT_SCALE_WINDOW_FLICKER.md
@@ -1,0 +1,265 @@
+---
+kind: record
+status: recorded
+audience: maintainer
+source_of_truth: self
+priority: P1
+resolution: unresolved
+updated: 2026-09-04
+---
+
+# macOS 调整立绘大小时整窗概率闪烁（未解决）
+
+> 当前结论：问题仍可在 macOS 实机复现。2026-09-04 的最新实现已经消除了窗口下跳、左上角闪现和同步快照死锁，但调整立绘大小时仍有概率发生整窗闪烁。本记录不能作为修复或验收证据。
+
+## 优先级和影响
+
+- 优先级：P1，由项目所有者在 2026-09-04 确认。
+- 处理安排：暂缓，之后单独继续。
+- 直接影响：设置页调整立绘大小时，桌宠窗口可能闪一下。闪烁通常出现在第一次真实数值变化或一次缩放手势的早期。
+- 当前没有观察到进程崩溃、配置丢失或角色数据损坏。立绘缩放仍能完成，因此它不是当前发布工作的阻断项。
+- 已知主要发生在 macOS。Windows 需要保留本文列出的输入穿透和稳定窗口约束，但尚无证据表明 Windows 存在同一种 WKWebView 闪烁。
+
+## 最终用户反馈
+
+最新开发版包含异步 `WKWebView` 快照遮挡，并把快照捕获推迟到第一次真实数值变化。原生日志能完整走完捕获、扩窗、重定位和移除，用户连续实机拖动后仍确认“还是会闪”。
+
+因此，下面两条都不成立：
+
+1. 日志完整不代表画面没有中间帧。
+2. 前端和 Rust 测试通过不代表透明原生窗口没有闪烁。
+
+此前同一问题还出现过更明显的表现：
+
+- 仅按下立绘大小滑条，桌宠整体向下移动；松手后恢复。
+- 第一次改变数值时，整个桌宠向左上方闪现一下。
+- 位置问题修正后，窗口仍会在原地闪一下。
+- 一版按下即预扩 WebView 的实现会立刻闪，输入栏还会瞬间出现在立绘顶部；开始拖动时再次闪烁。该方案已撤回。
+- N.A.V.I. 能复现位移和闪烁；全透明的 N.A.V.I.-Test 不容易表现同一视觉问题。N.A.V.I.-Test 只能检查气泡、输入栏和命中区域，不能作为立绘无闪烁的反证。
+
+## 与早期立绘切换双闪的关系
+
+早期问题发生在切换立绘或表情时，与本次缩放滑条闪烁共享原生窗口、WebView 和透明表面链路，但触发动作不同。以下历史直接保存在仓库中，不依赖某台电脑上的 Codex 对话：
+
+- 版本核对时，`v1.0.3` 与当时的 `origin/main` 都指向 `d5ce4253c1129e329debd46ef61ee6d5b2fd833c`，该版本已经存在立绘切换双闪。
+- 当时的前端先调用 `prepare_portrait_transition`。Rust 计算新旧立绘 alpha bounds 的并集，并提交一次原生窗口 frame；前端执行交叉淡入淡出、等待两个绘制帧后，又调用 `commit_portrait_transition` 提交最终 frame。两次 AppKit 窗口事务与“整窗闪两次”的现象吻合。
+- 那次排查曾建立独立修复工作树，但实际改动偏到了缩放结算和物理立绘锚点保持。`portrait_scale` Rust 测试虽为 3/3 通过，实机也只操作了缩放滑条，没有完成真实立绘切换的无闪验收；当时没有提交、推送或创建 PR。
+- 后续处理同类问题时，必须沿实际 `portrait-key` 切换链路记录原生 frame 提交次数，并在 macOS 实机观察淡入和整窗表面。缩放测试、日志完整或几何单测都不能替代这项证据。
+
+这段历史用于提醒后续维护者区分“立绘切换”和“立绘缩放”两条事务。不能因为其中一条路径恢复正常，就推断另一条也不会闪。
+
+## 复现步骤
+
+### 环境
+
+- 平台：macOS 实机。
+- 当前代码位置：仓库主工作区。
+- 记录时分支：`fix/telemetry-diagnostics-quality`。
+- 记录时 HEAD：`e654348c41a7`。
+- 修复尝试全部位于未提交工作树。当前分支名称与本缺陷无关，后续不得把整份工作树直接提交到该分支。
+
+开启原生表面诊断：
+
+```bash
+SAKURA_TRACE_MACOS_SURFACE=1 ./scripts/start.sh
+```
+
+不要读取、修改或清理仓库 `data/` 及外部用户数据。复现不需要碰这些目录。
+
+### 操作
+
+1. 打开“设置 → 角色与布局”。
+2. 选择有可见立绘的 N.A.V.I.。
+3. 先单击或按住“立绘大小”滑条，不改变数值，然后松手。
+4. 再进行一次只跨越 1～2 个刻度的拖动，观察第一次数值变化。
+5. 连续执行 `50% → 150% → 50%`，分别观察开始拖动、连续变化和松手。
+6. 重复短拖动至少 20 次。该问题有概率性，一次没有出现不能判定通过。
+7. 将桌宠拖到屏幕顶部附近后重复上述步骤，并确认松手后仍能继续向上拖动。
+8. 切换一次立绘或角色，检查原先修好的立绘淡入和双闪问题是否回归。
+
+最好录制 60 fps 以上的视频，并同时保存带 revision 和单调时钟的原生日志。静态截图很难捕获一帧闪烁。
+
+## 目标行为
+
+macOS 实机需要同时满足以下条件：
+
+- 按下滑条但不改变数值时，原生窗口、WebView 和 DOM 均不发生视觉变化。
+- 第一次数值变化不闪、不跳，也不能短暂显示错误位置的气泡或输入栏。
+- 连续拖动期间立绘平滑缩放，气泡和输入栏的全局位置保持不变。
+- 松手不闪、不跳，最终精确命中区域与显示倍率一致。
+- 桌宠仍可拖到工作区顶部，不能因临时最大包络被 AppKit 向下钳回。
+- 立绘/角色切换保留淡入效果，不能恢复整窗双闪。
+
+跨平台还要守住两项约束：
+
+- Windows 可以常驻稳定 HWND/WebView 包络，但设置页打开和滑条操作期间只能使用覆盖可见组件的粗 region。巨大透明区域必须穿透，不能吞掉半个屏幕的点击。
+- 调整气泡宽度、高度、位置和输入栏位置时，不能因为原生包络或精确 region 重建而抖动。
+
+## 当前调用链
+
+### 设置页
+
+`desktop/frontend/settings/appearance-runtime.js` 在真实 pointer/key 手势开始和结束时发布：
+
+- `settings_character_appearance_scale_gesture(active=true/false)`
+- `settings_character_appearance_scale_frame(portrait_scale_percent)`
+
+数值帧采用 RAF 和 latest-wins 队列。单纯按下而没有 `input` 事件时，不应发布 scale frame。
+
+### 主窗口前端
+
+`desktop/frontend/app.js` 负责：
+
+1. `begin_portrait_scale_preview` 登记预览并取得最大倍率临时包络。
+2. 第一个真实数值帧调用 `prepare_portrait_scale_preview_snapshot`。
+3. 快照安装成功后，先提交新的 WebView stage offset，再调用 `activate_portrait_hit_test` 扩大原生窗口。
+4. 新倍率画面经过两个 `requestAnimationFrame` 后调用 `finish_portrait_scale_preview_snapshot`。
+5. 手势结束后提交最终精确表面。
+
+`samePetSurfaceGeometry()` 会跳过相同 `contentScale + activeBounds` 的重复 CSS 写入。这个优化能减少无效重绘，但没有消除本次实机闪烁。
+
+### Rust 与 AppKit
+
+- `desktop/src-tauri/src/main.rs`
+  - `begin_portrait_scale_preview()` 计算临时 50%～150% 包络。
+  - `prepare_portrait_scale_preview_snapshot()` 在不持有 `WindowGeometrySession` 锁时异步等待快照。
+  - `activate_portrait_hit_test()` 提交本轮原生表面。
+  - `finish_portrait_scale_preview_snapshot()` 按 revision 移除快照。
+  - `settle_portrait_scale_surface()` 恢复静止态动态包络。
+- `desktop/src-tauri/src/macos_surface_snapshot.rs`
+  - 使用 `WKWebView.takeSnapshotWithConfiguration` 捕获当前 WebView。
+  - 以 `NSImageView` 把快照放在 WKWebView 上方。
+  - 使用 `tokio::sync::oneshot` 等待回调，避免堵塞 Tauri/AppKit 主线程。
+  - 快照和清理均带 revision；旧回调不能移除新手势的快照。
+- `desktop/src-tauri/src/platform/window_backend.rs`
+  - `macos_atomic_frame()` 使用 `setFrame_display(frame, false)`。
+  - 原生 frame 改变后重定位快照，使它在屏幕上的全局位置保持不变。
+- `desktop/src-tauri/src/window_geometry.rs`
+  - `clip_expanded_surface_bounds_to_work_area()` 把临时包络裁到工作区，避免越过屏幕顶部时被 AppKit 整窗向下钳制。
+
+### Windows 保护措施
+
+Windows 路径保留稳定最大包络，并用 `coarse_preview_hit_regions()` 生成“立绘外接矩形 + 可见控件”的临时 region。不能重新采用清空 `SetWindowRgn` 的做法，否则稳定 HWND 的巨大透明余量会拦截其他窗口。
+
+## 已确认和仍未确认的归因
+
+### 已确认
+
+- 窗口下跳来自临时大窗口越过工作区顶部后被 AppKit 调整；工作区裁剪已经消除该位移。
+- 左上角闪现来自原生 frame 与前端 stage offset 在不同时间生效；按相同几何提交后，该错误位置不再是当前主要表现。
+- 早期同步快照实现会在 Tauri command 内等待 WKWebView 异步回调，同时占有几何锁。日志只有 `installed`，没有 command return；后续 frame 和 gesture-end 全部等待该锁。该死锁已改为异步等待。
+- 按下即预扩 WKWebView 会暴露错误切片，输入栏曾瞬间出现在立绘顶部。当前实现不在 pointerdown 时捕获快照或改变原生 frame。
+- 最新实机日志中，快照事务能正常完成；用户仍看到概率闪烁。
+
+### 高概率原因，但尚未证明
+
+第一次扩展 `NSWindow/WKWebView` 仍会重建 backing/compositor surface。现有 `NSImageView` 是同一个窗口内容树中的兄弟/覆盖视图，它可能与 WKWebView 一起参与窗口表面重建，所以不能保证每一帧都遮住底层变化。
+
+另一个可疑点是快照移除时机。两个 RAF 只能证明 JavaScript 获得了两次绘制机会，不能证明 WebKit 远程图层已经由 WindowServer 合成到屏幕。日志中的 `finished` 也只代表 `NSImageView` 已移除，不代表替换后的 WKWebView 帧已显示。
+
+当前没有高帧率视频与原生时间戳的逐帧对应关系，无法确认闪烁发生在：
+
+- 快照安装时；
+- `setFrame_display(false)` 扩窗时；
+- 快照移除时；
+- 手势结束后从最大包络收回静止态包络时。
+
+下次继续前先定位到其中一个阶段，不要再同时调整多个时序参数。
+
+## 已尝试方案
+
+### 保留的改动
+
+- macOS 静止态使用动态包络，设置缩放时才计算临时最大包络。
+- 临时包络按工作区裁剪，防止顶部钳制造成窗口下跳。
+- 缩放结算保持全局物理立绘锚点。
+- 相同原生表面和相同前端几何不重复提交。
+- Windows 设置预览使用 coarse region，透明余量不接收点击。
+- 快照捕获和移除不再同步阻塞 AppKit 主线程，并加入 revision 隔离和设置窗口关闭清理。
+
+这些改动分别解决了真实回归。后续若撤回当前快照实验，应按 hunk 区分，不能整体回退工作树。
+
+### 已撤回或判定不足的方案
+
+- macOS 常驻 150% 最大窗口：缩放稳定一些，但窗口过高，桌宠无法继续向上拖动；静止态也不应长期保留大包络。
+- 设置页打开时直接关闭 Windows 遮罩/region：大半屏幕变成不可点击区域，不可接受。
+- pointerdown 时直接预扩 WKWebView、保持旧 `NSWindow`：按下即闪，并显示错误 WebView 切片，已撤回。
+- AppKit 原生窗口 class swapping：启动阶段触发 KVO crash，已撤回，禁止恢复。
+- 仅使用 `setFrame_display(false)`、去重 frame 或提前提交 stage offset：能消除部分错位，不能遮住 backing surface 首次重建。
+- 当前同窗 `NSImageView` 快照：解决了同步死锁，日志顺序正确，但未通过用户实机视觉验收。
+
+## 2026-09-04 日志证据
+
+一次典型首帧事务：
+
+```text
+phase=settings-gesture active=true
+phase=settings-frame scale=62
+phase=installed revision=2 window=(2022,108,428,605) snapshot=(0,0,428,605)
+phase=prepare-return revision=2 snapshot=true
+phase=repositioned revision=2 window=(1823,108,707,1186) snapshot=(199,0,428,605)
+phase=finish-command
+phase=finished revision=2
+phase=settings-gesture active=false
+```
+
+连续多轮拖动中，每个 revision 都能看到 `installed`、`prepare-return`、`repositioned` 和 `finished`。没有再次出现早期实现缺少 `begin-return` 的阻塞表现，也没有捕获到 Rust panic。用户在这组日志对应的实机运行中仍看到了闪烁。
+
+这段日志只能证明控制流完成，不能证明 WindowServer 没有显示过空白帧或旧帧。
+
+## 自动验证状态
+
+2026-09-04 当前未提交代码完成：
+
+- `cargo check --manifest-path desktop/src-tauri/Cargo.toml -j 2`：通过。
+- `cargo test --manifest-path desktop/src-tauri/Cargo.toml -j 2 portrait_scale -- --nocapture`：3 passed。
+- 快照 revision 竞态测试：1 passed。
+- `desktop/frontend`：249 passed。
+
+这些测试覆盖几何、revision 和前端状态流，不覆盖 macOS WindowServer 的实际合成结果。实机视觉验收失败，所以 `resolution` 仍为 `unresolved`。
+
+## 当前工作树边界
+
+记录时共有 13 个相关修改文件和 1 个新增文件，约 `1062 insertions / 262 deletions`。主要路径：
+
+```text
+desktop/frontend/app.js
+desktop/frontend/pet/layout-controller.js
+desktop/frontend/pet/layout.js
+desktop/frontend/tests/layout-bootstrap.test.js
+desktop/src-tauri/Cargo.toml
+desktop/src-tauri/Cargo.lock
+desktop/src-tauri/src/main.rs
+desktop/src-tauri/src/macos_surface_snapshot.rs
+desktop/src-tauri/src/platform/window_backend.rs
+desktop/src-tauri/src/window_geometry.rs
+desktop/src-tauri/src/window_interaction.rs
+docs/adr/0010-cross-platform-pet-surface.md
+docs/adr/0025-macos-dynamic-surface-envelope.md
+docs/specs/runtime-v2/WP-3-03A-cross-platform-pet-surface.md
+```
+
+其中 `macos_surface_snapshot.rs`、`objc2-web-kit` 依赖和三个相关 command 属于仍未通过验收的实验。几何裁剪、锚点保持、相同表面去重和 Windows coarse region 是此前回归的有效修复。下次接手应先保存当前 diff，再按这条边界拆分。
+
+带 `SAKURA_TRACE_MACOS_SURFACE=1` 的开发进程已在本记录完成前停止。下次复现需要重新运行 `scripts/start.sh`，不能假定屏幕上残留的 Sakura 就是这份工作树构建出的版本。
+
+## 下次调查建议
+
+1. 先录制高帧率视频，在 `installed`、`repositioned`、`finished` 和最终收缩各写一个单调时钟时间戳，确认闪烁属于哪一阶段。
+2. 临时延长快照保留时间，只用于诊断。如果闪烁随移除时间后移，问题在 reveal gate；如果仍发生在扩窗瞬间，同窗快照没有隔离 backing 重建。
+3. 若确认同窗快照无效，优先做一个独立无交互透明覆盖窗口的最小 PoC。覆盖窗口必须固定在旧画面的屏幕坐标，并在主窗口扩容完成后移除。不要先引入双窗口常驻架构。
+4. 若闪烁发生在最终收缩，保持手势期间最大包络不是问题根源；应单独处理 settle transaction，避免把首帧和松手问题混在一起。
+5. 每次实验只修改一个原生阶段，并用 N.A.V.I. 重复至少 20 次。N.A.V.I.-Test 只用于穿透和控件位置检查。
+6. macOS 通过后再到 Windows 实机检查透明区域点击穿透、四个布局滑条和立绘缩放。不要用 macOS 结果代替 Windows 验收。
+
+## 关闭条件
+
+只有满足以下条件后才能把本记录改为 resolved：
+
+- N.A.V.I. 在 macOS 实机连续完成 20 轮短拖动和 10 轮 `50% → 150% → 50%`，没有整窗闪烁、错位或下跳。
+- 单击/按住滑条但不改值无闪烁，第一次真实数值变化也无闪烁。
+- 屏幕顶部拖动、立绘切换淡入、气泡和输入栏位置全部通过回归检查。
+- Windows 实机确认稳定 HWND 的透明余量仍可点击穿透，立绘与四个布局滑条无抖动。
+- 自动测试继续通过，并保留至少一个覆盖过期 revision 不能清理新快照的回归测试。
+
+在达到这些条件前，不要在提交、PR 或发布说明中写“macOS 立绘缩放闪烁已修复”。

--- a/docs/records/incidents/README.md
+++ b/docs/records/incidents/README.md
@@ -3,9 +3,11 @@ kind: index
 status: current
 audience: maintainer
 source_of_truth: self
-updated: 2026-07-31
+updated: 2026-09-04
 ---
 
 # Incidents
 
+- [macOS 调整立绘大小时整窗概率闪烁（未解决）](MACOS_PORTRAIT_SCALE_WINDOW_FLICKER.md)
+- [macOS 桌宠无法拖到工作区顶端回归](MACOS_PET_TOP_EDGE_DRAG_REGRESSION.md)
 - [TTS 退出竞态与 native crash](TTS_SHUTDOWN_NATIVE_CRASH.md)

--- a/docs/specs/runtime-v2/WP-3-03A-cross-platform-pet-surface.md
+++ b/docs/specs/runtime-v2/WP-3-03A-cross-platform-pet-surface.md
@@ -4,7 +4,7 @@ status: normative
 audience: maintainer
 source_of_truth: self
 status_source: ../../plans/runtime-v2/work-packages.md
-updated: 2026-09-02
+updated: 2026-09-03
 ---
 
 # WP-3-03A：跨平台桌宠动态表面与精确命中规范
@@ -15,7 +15,7 @@ updated: 2026-09-02
   0.9.10 合法布局极值与三行输入框。原生窗口必须取立绘可见 alpha、可见气泡、输入框、菜单和其他可见
   控件的动态视觉外接矩形。全局安全边距为 2 逻辑像素，外部 focus outline 额外预留 4 像素。
 - 隐藏组件不得占用视觉包络或输入区域。alpha 值大于零的立绘像素参与命中，透明洞和外围必须穿透；
-  仅 Windows 缩放预览活跃期间允许按下述性能事务短暂放宽，预览结束后必须恢复精确穿透。全透明
+  Windows 设置预览只允许按下述性能事务短暂使用粗 region，预览结束后必须恢复精确穿透。全透明
   立绘是合法资源，对视觉包络和立绘拖动区域的贡献为零，但当前可见气泡、输入框和控件仍必须参与。
 - 动态控制面提交保留气泡和输入栏的规范矩形，并分别携带 `bubbleVisible`、`inputVisible`。矩形用于恢复
   位置和后续测量；逻辑包络、命中区域、菜单入口及原生视觉层只消费可见组件。共享契约不得包含 HWND、
@@ -46,10 +46,11 @@ updated: 2026-09-02
   包络。Windows 一旦取得有效立绘资源，底层 HWND/WebView 必须常驻覆盖完整规范立绘槽、全部合法缩放和
   控件布局极值的稳定包络；该矩形不得依赖当前表情或角色的 alpha 外接范围。表情淡入和角色切换只允许
   更新精确 window region，不得 resize/reposition HWND 或改变 WebView surface offset。静止态仍由当前倍率精确 window region
-  裁出真实视觉和点击范围。手势开始只允许清除一次旧复杂 region，不得 resize/reposition HWND 或改变
+  裁出真实视觉和点击范围。手势开始只允许把旧复杂 region 换成覆盖 150% 立绘外接矩形和当前可见控件
+  的粗 region，不得清空 region、resize/reposition HWND 或改变
   WebView surface offset。手势期每个数值刻度必须经独立轻量帧通道直接更新 WebView 合成 transform，
   不得进入完整外观预览、原生 bounds、alpha 行段构建或 `SetWindowRgn`。手势活跃期间任何精确 region
-  提交都必须被拒绝。松手、取消或失焦后，最新 revision 只恢复一次当前倍率的精确 region；从放宽状态
+  提交都必须被拒绝。松手、取消或失焦后，最新 revision 只恢复一次当前倍率的精确 region；从粗 region
   恢复时不得先提交过渡桥接 region，也不得改变稳定 HWND placement。旧 revision 不得生效。若下一轮
   pointer/key 手势在上一轮预览队列排空前开始，两轮必须共享已开启的原生 guard，不得在中间发布
   `active=false` 或产生无 guard 刻度。轻量帧允许丢弃旧值并有界追赶最新值，单帧失败不得显示连接报警；
@@ -92,8 +93,10 @@ updated: 2026-09-02
   `controlPanelWidth`、`bubbleMaxHeight`、`controlPanelVerticalOffset` 或
   `inputBarOffset` 时，沿用 0.9.10 的调整范围：控制组宽度 420–860、气泡固定/最低高度 96–260、控制组
   垂直偏移 -200–200、输入栏偏移 0–200。Windows 的底层 HWND/WebView 包络必须同时覆盖这些布局极值与
-  50%–150% 立绘倍率。Windows 每个数值帧必须立即更新 WebView 布局，不得等待 region 放宽、完整 appearance
-  publication 或原生布局回包。每轮手势只允许一次最终原生布局提交和一次精确 region 恢复。
+  50%–150% 立绘倍率。设置外观页打开期间，Windows 必须持续保留轻量粗 region；每个布局数值帧按
+  latest-wins 更新气泡、输入框、控件和立绘外接矩形，不得清空 `SetWindowRgn`。粗 region 更新失败时
+  保留上一版有效 region。WebView 布局不得等待 region 更新、完整 appearance publication 或原生布局
+  回包。每轮手势只允许一次最终原生布局提交和一次精确 region 恢复。
   每个合法偏移值必须产生对应的真实控件位移；不得因为三行输入框预留或规范 viewport 底边而在
   -27 等中间值提前钳住气泡位置。输入框需要的额外底部空间应由动态原生包络承担。
   macOS 不具备 Windows 的全部布局极值包络；macOS/Linux 的布局手势不使用立绘缩放专用的稳定包络，
@@ -118,9 +121,9 @@ updated: 2026-09-02
 
 ## 平台契约
 
-- Windows 静止态和非缩放预览使用精确 Win32 window region，不得把复杂 alpha 退成 bbox。只有受
-  revision 和显式手势约束的缩放预览，以及右键自绘菜单从打开到关闭的完整 resize 事务，可以临时
-  清除 region。缩放预览必须由最新 revision 在手势结束时恢复；菜单必须在恢复打开前 HWND placement
+- Windows 静止态使用精确 Win32 window region，不得把复杂 alpha 退成 bbox。设置布局和立绘缩放预览
+  只能临时改用受 revision 约束的粗 region，不得让整个稳定 HWND 可点击。右键自绘菜单从打开到关闭的
+  完整 resize 事务仍可临时清除 region。预览必须由最新 revision 在手势结束时恢复；菜单必须在恢复打开前 HWND placement
   后恢复打开前的精确 region，恢复失败则保留整窗可交互安全回退并显式报错。桌宠在混合 DPI 显示器
   之间实时拖动时，`WM_DPICHANGED` 必须在 WebView/窗口按新 DPI 调整的同一消息链中同步变换当前精确
   region；不得保留旧物理坐标裁剪到松手后的最终布局提交。松手提交必须使用目标 DPI 下的本地锚点
@@ -143,12 +146,15 @@ updated: 2026-09-02
 - 冷启动的首次 bounds 提交不得阻塞窗口事件循环；主窗口必须在 15 秒内可见并保持响应。
 - 有效 alpha 与气泡非交互空白可拖动，实际回复文字、滚动条、输入框和控件不能拖动；可见立绘顶部
   可距工作区顶部不超过 2 逻辑像素。
+- macOS 静止态不得保留气泡扩展或立绘缩放使用的临时最大包络。当前可见表面的顶边必须能拖到工作区
+  顶边，鼠标释放后窗口位置和物理立绘锚点必须一致。
 - 拖动立绘或气泡空白不得出现矩形选择层或图片拖拽预览；气泡实际回复文字和输入框文本仍可选择、
   复制且高亮跟随主题。
 - 连续拖动缩放滑块 50%→150%→50%，气泡与输入框的全局物理坐标必须保持不变且无中间错位帧。
 - 对话回复从空文本增长到超过可视范围时，对话框外框高度必须保持设置值；连续拖动四个布局滑块时
   第一帧即可见、高频刻度不闪回，最终 DOM、原生表面和精确命中均等于最后一个值。Windows 首次拖动
-  与后续拖动的事件路径相同，不得要求重复拖动后才响应。
+  与后续拖动的事件路径相同，不得要求重复拖动后才响应。设置页打开及滑条操作期间，稳定 HWND 中未被
+  粗 region 覆盖的透明区域必须继续穿透到其他窗口。
 - 以超过 120ms 的慢速刻度间隔往返拖动 50%↔55% 时，手势中途不得误恢复精确 region 或向上闪动；
   只在真实 pointer/key 手势结束后恢复一次。
 - 上述缩放循环的活动预览中 `active_bounds`、物理窗口 placement、本地立绘锚点和 `content_scale`

--- a/harness/suites.json
+++ b/harness/suites.json
@@ -886,7 +886,7 @@
     },
     {
       "id": "runtime-v2-window-surface-regression-tests",
-      "description": "锁定 macOS 临时稳定包络、全透明立绘、右键菜单临时包络和过渡包络回归",
+      "description": "锁定 macOS 顶边裁剪与临时稳定包络、全透明立绘、右键菜单临时包络和过渡包络回归",
       "argv": [
         "cargo",
         "test",


### PR DESCRIPTION
## 改动

- macOS 静止时只保留当前可见内容的原生包络；缩放预览使用临时包络，并按工作区裁剪，避免桌宠被透明窗口向下顶回。
- 缩放结算保留原有物理锚点；相同表面不重复提交，过期 revision 也不能清理较新的快照。
- Windows 缩放预览继续使用覆盖可见区域的粗粒度 region，避免透明窗口拦截背景点击。
- 增加窗口几何、命中区域和快照竞态回归测试，并记录 macOS 顶边拖动与缩放闪烁的调查结果。

## 验证

- `git diff --check origin/main...HEAD`
- `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml --all -- --check`
- `node --test desktop/frontend/tests/layout-bootstrap.test.js`：3 passed
- Rust 定向测试：`macos_surface_snapshot` 1 项、`window_geometry` 29 项、`window_interaction` 37 项及 3 项主模块回归测试，共 70 passed

全量 `cargo test` 已尝试运行。编译成功，但临时 worktree 中的 Core Runtime、进程树、Runtime Log 和共享实例等非本次模块用例出现失败或长超时，因此中止；这些失败没有作为本 PR 的通过证据，也尚未单独调查。

## 已知限制

macOS 调整立绘大小时的整窗概率闪烁仍能在实机复现。本 PR 修复缩放下跳、顶边拖动和动态包络回归，不宣称已经解决该闪烁。顶边连续拖动、Windows 透明区域穿透等实机验收仍需按事件记录执行。