### PR TITLE
移植设置页的语音导入和角色包导出

### DIFF
--- a/app/core_host/character_settings.py
+++ b/app/core_host/character_settings.py
@@ -8,16 +8,27 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
-from app.config.character_archive import CharacterArchiveError, import_character_archive
-from app.config.character_loader import CharacterConfigError, CharacterRegistry
+from app.config.character_archive import (
+    CharacterArchiveError,
+    export_character_archive,
+    export_character_voice_archive,
+    import_character_archive,
+    import_character_voice_archive,
+)
+from app.config.character_loader import (
+    CharacterConfigError,
+    CharacterProfile,
+    CharacterRegistry,
+)
 from app.config.settings_service import AppSettingsService
 from app.core_host.protocol import response
-
 
 CHARACTER_SETTINGS_REQUEST_NAMES = frozenset(
     {
         "characters.settings.get",
         "characters.settings.import",
+        "characters.settings.import_voice",
+        "characters.settings.export",
         "characters.settings.select",
     }
 )
@@ -65,21 +76,49 @@ class CharacterSettingsBoundary:
             name = request.get("name")
             payload = request.get("payload")
             if not isinstance(payload, Mapping):
-                raise CharacterSettingsError("INVALID_REQUEST", "角色设置请求格式无效。")
+                raise CharacterSettingsError(
+                    "INVALID_REQUEST", "角色设置请求格式无效。"
+                )
             if name == "characters.settings.get":
                 if payload:
-                    raise CharacterSettingsError("INVALID_REQUEST", "角色设置读取请求必须为空。")
+                    raise CharacterSettingsError(
+                        "INVALID_REQUEST", "角色设置读取请求必须为空。"
+                    )
                 result = self.snapshot()
             elif name == "characters.settings.import":
                 if set(payload) != {"path"}:
-                    raise CharacterSettingsError("INVALID_REQUEST", "角色导入请求格式无效。")
+                    raise CharacterSettingsError(
+                        "INVALID_REQUEST", "角色导入请求格式无效。"
+                    )
                 result = self.import_archive(payload["path"])
+            elif name == "characters.settings.import_voice":
+                if set(payload) != {"path", "characterId"}:
+                    raise CharacterSettingsError(
+                        "INVALID_REQUEST", "语音包导入请求格式无效。"
+                    )
+                result = self.import_voice_archive(
+                    payload["path"], payload["characterId"]
+                )
+            elif name == "characters.settings.export":
+                if set(payload) != {"path", "characterId", "kind"}:
+                    raise CharacterSettingsError(
+                        "INVALID_REQUEST", "角色包导出请求格式无效。"
+                    )
+                result = self.export_archive(
+                    payload["path"],
+                    payload["characterId"],
+                    payload["kind"],
+                )
             elif name == "characters.settings.select":
                 if set(payload) != {"characterId"}:
-                    raise CharacterSettingsError("INVALID_REQUEST", "角色选择请求格式无效。")
+                    raise CharacterSettingsError(
+                        "INVALID_REQUEST", "角色选择请求格式无效。"
+                    )
                 result = self.select(payload["characterId"])
             else:
-                raise CharacterSettingsError("UNKNOWN_COMMAND", "不支持的角色设置命令。")
+                raise CharacterSettingsError(
+                    "UNKNOWN_COMMAND", "不支持的角色设置命令。"
+                )
             return response(
                 request,
                 generation_id=self._generation_id,
@@ -108,6 +147,7 @@ class CharacterSettingsBoundary:
                     "id": profile.id,
                     "displayName": profile.display_name,
                     "hasVoice": profile.voice is not None,
+                    "hasExportableVoice": self._has_exportable_voice(profile),
                 }
                 for profile in registry.all()
             ],
@@ -138,13 +178,123 @@ class CharacterSettingsBoundary:
                         CharacterRegistry(self._user_root), imported.character_id
                     )
                     change_plan = "core_restart_required"
-            except (OSError, CharacterArchiveError, CharacterConfigError, ValueError) as error:
+            except (
+                OSError,
+                CharacterArchiveError,
+                CharacterConfigError,
+                ValueError,
+            ) as error:
                 raise CharacterSettingsError(
                     "CHARACTER_IMPORT_FAILED",
                     "角色包导入失败，现有角色保持不变。",
                 ) from error
             self._revision += 1
             return self._change_result(change_plan)
+
+    def import_voice_archive(
+        self,
+        raw_path: object,
+        raw_character_id: object,
+    ) -> dict[str, object]:
+        archive = self._import_archive_path(raw_path, suffix=".voice")
+        character_id = self._character_id(raw_character_id)
+        with self._lock:
+            registry = CharacterRegistry(self._user_root)
+            try:
+                registry.get(character_id)
+            except CharacterConfigError as error:
+                raise CharacterSettingsError(
+                    "CHARACTER_NOT_FOUND",
+                    "选择的角色不存在。",
+                    field="characterId",
+                ) from error
+            current = self._settings.load_current_character_id(registry)
+            try:
+                import_character_voice_archive(archive, self._user_root, character_id)
+            except (
+                OSError,
+                CharacterArchiveError,
+                CharacterConfigError,
+                ValueError,
+            ) as error:
+                raise CharacterSettingsError(
+                    "CHARACTER_VOICE_IMPORT_FAILED",
+                    "语音包导入失败。请检查语音包和当前角色的语音文件。",
+                    field="path",
+                ) from error
+            self._revision += 1
+            return self._change_result(
+                "core_restart_required" if current == character_id else "unchanged"
+            )
+
+    def export_archive(
+        self,
+        raw_path: object,
+        raw_character_id: object,
+        raw_kind: object,
+    ) -> dict[str, object]:
+        if not isinstance(raw_kind, str) or raw_kind not in {"full", "card", "voice"}:
+            raise CharacterSettingsError(
+                "CHARACTER_ARCHIVE_KIND_INVALID",
+                "请选择有效的角色包导出类型。",
+                field="kind",
+            )
+        suffix = ".voice" if raw_kind == "voice" else ".char"
+        output = self._export_archive_path(raw_path, suffix=suffix)
+        character_id = self._character_id(raw_character_id)
+        if not output.parent.is_dir():
+            raise CharacterSettingsError(
+                "CHARACTER_ARCHIVE_PATH_INVALID",
+                "请选择有效的导出目录。",
+                field="path",
+            )
+        with self._lock:
+            try:
+                profile = CharacterRegistry(self._user_root).get(character_id)
+            except CharacterConfigError as error:
+                raise CharacterSettingsError(
+                    "CHARACTER_NOT_FOUND",
+                    "选择的角色不存在。",
+                    field="characterId",
+                ) from error
+            if raw_kind in {"full", "voice"} and not self._has_exportable_voice(
+                profile
+            ):
+                message = (
+                    "当前角色没有完整语音模型，请导出单角色包。"
+                    if raw_kind == "full"
+                    else "当前角色没有可导出的语音模型。"
+                )
+                raise CharacterSettingsError(
+                    "CHARACTER_VOICE_NOT_EXPORTABLE",
+                    message,
+                    field="kind",
+                )
+            try:
+                if raw_kind == "voice":
+                    export_character_voice_archive(profile, output)
+                else:
+                    export_character_archive(
+                        profile,
+                        output,
+                        include_voice=raw_kind == "full",
+                    )
+            except (
+                OSError,
+                CharacterArchiveError,
+                CharacterConfigError,
+                ValueError,
+            ) as error:
+                raise CharacterSettingsError(
+                    "CHARACTER_EXPORT_FAILED",
+                    "角色包导出失败，目标文件未被替换。",
+                    field="path",
+                ) from error
+        return {
+            "schemaVersion": 1,
+            "outputPath": str(output),
+            "message": f"角色包已导出到：{output}",
+        }
 
     def select(self, raw_character_id: object) -> dict[str, object]:
         if not isinstance(raw_character_id, str) or not raw_character_id.strip():
@@ -185,6 +335,65 @@ class CharacterSettingsBoundary:
             "snapshot": self.snapshot(),
             "changePlan": change_plan,
         }
+
+    @staticmethod
+    def _character_id(raw_character_id: object) -> str:
+        if not isinstance(raw_character_id, str) or not raw_character_id.strip():
+            raise CharacterSettingsError(
+                "CHARACTER_ID_INVALID",
+                "角色标识无效。",
+                field="characterId",
+            )
+        return raw_character_id.strip()
+
+    @staticmethod
+    def _import_archive_path(raw_path: object, *, suffix: str) -> Path:
+        if not isinstance(raw_path, str) or not raw_path.strip():
+            raise CharacterSettingsError(
+                "CHARACTER_ARCHIVE_PATH_INVALID",
+                f"请选择有效的 Sakura {suffix} 文件用于导入。",
+                field="path",
+            )
+        path = Path(raw_path).expanduser()
+        if (
+            not path.is_absolute()
+            or path.suffix.lower() != suffix
+            or not path.is_file()
+        ):
+            raise CharacterSettingsError(
+                "CHARACTER_ARCHIVE_PATH_INVALID",
+                f"请选择有效的 Sakura {suffix} 文件用于导入。",
+                field="path",
+            )
+        return path
+
+    @staticmethod
+    def _export_archive_path(raw_path: object, *, suffix: str) -> Path:
+        if not isinstance(raw_path, str) or not raw_path.strip():
+            raise CharacterSettingsError(
+                "CHARACTER_ARCHIVE_PATH_INVALID",
+                "请选择有效的角色包导出路径。",
+                field="path",
+            )
+        path = Path(raw_path).expanduser()
+        if not path.is_absolute():
+            raise CharacterSettingsError(
+                "CHARACTER_ARCHIVE_PATH_INVALID",
+                "请选择有效的角色包导出路径。",
+                field="path",
+            )
+        return path if path.suffix.lower() == suffix else path.with_suffix(suffix)
+
+    @staticmethod
+    def _has_exportable_voice(profile: CharacterProfile) -> bool:
+        voice = profile.voice
+        return bool(
+            voice is not None
+            and voice.gpt_model_path is not None
+            and voice.gpt_model_path.is_file()
+            and voice.sovits_model_path is not None
+            and voice.sovits_model_path.is_file()
+        )
 
 
 __all__ = [

--- a/desktop/frontend/settings/root-settings-runtime.js
+++ b/desktop/frontend/settings/root-settings-runtime.js
@@ -1,4 +1,5 @@
 const CHARACTER_ERROR = "CHARACTER_SETTINGS_RESPONSE_INVALID";
+const CHARACTER_EXPORT_ERROR = "CHARACTER_EXPORT_RESPONSE_INVALID";
 const STORAGE_ERROR = "STORAGE_SETTINGS_RESPONSE_INVALID";
 const LEGACY_DATA_ERROR = "LEGACY_DATA_IMPORT_RESPONSE_INVALID";
 const UPDATE_ERROR = "UPDATE_SETTINGS_RESPONSE_INVALID";
@@ -45,14 +46,16 @@ export function normalizeCharacterSettingsSnapshot(snapshot) {
       || !character.displayName
       || character.displayName.length > 128
       || typeof character.hasVoice !== "boolean"
-      || Object.keys(character).length !== 3
+      || typeof character.hasExportableVoice !== "boolean"
+      || (character.hasExportableVoice && !character.hasVoice)
+      || Object.keys(character).length !== 4
     ) fail(CHARACTER_ERROR);
     ids.add(character.id);
     return Object.freeze({
       id: character.id,
       display_name: character.displayName,
       has_voice: character.hasVoice,
-      has_exportable_voice: false,
+      has_exportable_voice: character.hasExportableVoice,
     });
   });
   if (snapshot.currentCharacterId !== null && !ids.has(snapshot.currentCharacterId)) {
@@ -65,6 +68,23 @@ export function normalizeCharacterSettingsSnapshot(snapshot) {
       characters: Object.freeze(characters),
     }),
   });
+}
+
+export function normalizeCharacterExportReceipt(receipt) {
+  const keys = receipt && typeof receipt === "object" ? Object.keys(receipt).sort() : [];
+  const expected = ["message", "outputPath", "schemaVersion"];
+  if (
+    receipt?.schemaVersion !== 1
+    || keys.length !== expected.length
+    || keys.some((key, index) => key !== expected[index])
+    || typeof receipt.outputPath !== "string"
+    || !receipt.outputPath
+    || receipt.outputPath.length > 4096
+    || typeof receipt.message !== "string"
+    || !receipt.message
+    || receipt.message.length > 4608
+  ) fail(CHARACTER_EXPORT_ERROR);
+  return Object.freeze({ ...receipt });
 }
 
 export function normalizeCharacterSwitchReceipt(receipt) {
@@ -280,6 +300,16 @@ export function createRootSettingsClient({ invoke }) {
     },
     async characterImport(path) {
       return normalizeCharacterSwitchReceipt(await invoke("settings_character_import", { path }));
+    },
+    async characterVoiceImport(path, characterId) {
+      return normalizeCharacterSwitchReceipt(
+        await invoke("settings_character_import_voice", { path, characterId }),
+      );
+    },
+    async characterExport(path, characterId, kind) {
+      return normalizeCharacterExportReceipt(
+        await invoke("settings_character_export", { path, characterId, kind }),
+      );
     },
     async characterSelect(characterId) {
       return normalizeCharacterSwitchReceipt(

--- a/desktop/frontend/settings/settings.js
+++ b/desktop/frontend/settings/settings.js
@@ -1713,8 +1713,10 @@ function syncCharacterArchiveState() {
   fields.characterImportButton.disabled = characterArchiveBusy || characterSwitching
     || Boolean(pendingCharacterId);
   if (runtimeSettingsHost) {
-    fields.ttsVoiceImportButton.disabled = true;
-    fields.characterExportButton.disabled = true;
+    fields.ttsVoiceImportButton.disabled = characterArchiveBusy || characterSwitching
+      || !hasCharacter || Boolean(pendingCharacterId) || currentCharacterHasDrafts();
+    fields.characterExportButton.disabled = characterArchiveBusy || characterSwitching
+      || !hasCharacter || Boolean(pendingCharacterId);
     syncCharacterEditorControl(
       fields.characterEditorButton,
       characterArchiveBusy || characterSwitching
@@ -1723,9 +1725,9 @@ function syncCharacterArchiveState() {
     fields.characterArchiveHint.textContent = pendingCharacterId
       ? `已选择 ${character?.display_name || pendingCharacterId}；角色级设置已锁定，点击“应用”或“保存并关闭”后正式切换。`
       : currentCharacterHasDrafts()
-        ? "请先保存或放弃角色相关改动，再打开角色工坊。"
+        ? "当前角色有未保存的改动。保存或放弃后可以导入语音；导出仍使用已保存的角色包。"
         : hasCharacter
-        ? "可以导入角色包，或在角色工坊中编辑当前选择。"
+        ? "可以导入或导出角色包，也可以在角色工坊中编辑当前角色。"
       : "当前没有角色。请导入一个 Sakura .char 角色包。";
     refreshSelect(fields.characterSelect);
     return;
@@ -3364,8 +3366,19 @@ async function importCharacterVoiceArchive() {
       setError("请先选择一个角色。");
       return;
     }
+    if (runtimeSettingsHost && (pendingRuntimeCharacterId() || currentCharacterHasDrafts())) {
+      setError("请先保存或放弃角色相关改动，再导入语音包。");
+      return;
+    }
     const path = String(await chooseArchivePath("voice") || "").trim();
     if (!path) {
+      return;
+    }
+    if (runtimeSettingsHost) {
+      const previousLifecycle = await invoke("runtime_lifecycle_snapshot");
+      const result = await rootSettingsClient.characterVoiceImport(path, character.id);
+      await applyRuntimeCharacterChange(result, previousLifecycle);
+      notify(`已为角色「${character.display_name}」导入 TTS 模型包。`, "success");
       return;
     }
     const result = await hostCall("character.import_voice_archive", {
@@ -3383,12 +3396,21 @@ async function exportCharacterArchive() {
       setError("当前没有可导出的角色。");
       return;
     }
+    if (runtimeSettingsHost && pendingRuntimeCharacterId()) {
+      setError("请先应用或放弃待切换的角色，再导出角色包。");
+      return;
+    }
     const kind = await chooseExportKind();
     if (!kind) {
       return;
     }
     const path = String(await chooseExportPath(kind) || "").trim();
     if (!path) {
+      return;
+    }
+    if (runtimeSettingsHost) {
+      const result = await rootSettingsClient.characterExport(path, character.id, kind);
+      notify(result.message, "success");
       return;
     }
     const result = await hostCall("character.export_archive", {

--- a/desktop/frontend/tests/root-settings-runtime.test.js
+++ b/desktop/frontend/tests/root-settings-runtime.test.js
@@ -6,6 +6,7 @@ import {
   formatSettingsError,
   legacyDataImportPlanHasWork,
   normalizeAboutSettingsSnapshot,
+  normalizeCharacterExportReceipt,
   normalizeCharacterSettingsSnapshot,
   normalizeCharacterSwitchReceipt,
   normalizeLegacyDataImportPlan,
@@ -46,6 +47,12 @@ const unchangedCharacters = Object.freeze({
   targetCharacterId: null,
   previousCoreGenerationId: "generation-a",
   restartState: "not_required",
+});
+
+const characterExport = Object.freeze({
+  schemaVersion: 1,
+  outputPath: "/tmp/role.char",
+  message: "角色包已导出到：/tmp/role.char",
 });
 
 const defaultStorage = Object.freeze({
@@ -144,7 +151,22 @@ test("selected character must be a member and character fields are exact", () =>
   }), /CHARACTER_SETTINGS_RESPONSE_INVALID/);
   assert.throws(() => normalizeCharacterSettingsSnapshot({
     ...emptyCharacters,
-    characters: [{ id: "sakura", displayName: "Sakura", hasVoice: true, path: "/secret" }],
+    characters: [{
+      id: "sakura",
+      displayName: "Sakura",
+      hasVoice: true,
+      hasExportableVoice: true,
+      path: "/secret",
+    }],
+  }), /CHARACTER_SETTINGS_RESPONSE_INVALID/);
+  assert.throws(() => normalizeCharacterSettingsSnapshot({
+    ...emptyCharacters,
+    characters: [{
+      id: "sakura",
+      displayName: "Sakura",
+      hasVoice: false,
+      hasExportableVoice: true,
+    }],
   }), /CHARACTER_SETTINGS_RESPONSE_INVALID/);
 });
 
@@ -153,7 +175,12 @@ test("character switch receipt binds the committed target and previous generatio
     ...emptyCharacters,
     revision: 2,
     currentCharacterId: "sakura",
-    characters: [{ id: "sakura", displayName: "Sakura", hasVoice: true }],
+    characters: [{
+      id: "sakura",
+      displayName: "Sakura",
+      hasVoice: true,
+      hasExportableVoice: true,
+    }],
   };
   const normalized = normalizeCharacterSwitchReceipt({
     ...unchangedCharacters,
@@ -168,6 +195,14 @@ test("character switch receipt binds the committed target and previous generatio
     snapshot: selected,
     targetCharacterId: "other",
   }), /CHARACTER_SETTINGS_RESPONSE_INVALID/);
+});
+
+test("character export receipt exposes only the selected output and public message", () => {
+  assert.deepEqual(normalizeCharacterExportReceipt(characterExport), characterExport);
+  assert.throws(() => normalizeCharacterExportReceipt({
+    ...characterExport,
+    characterCard: "private",
+  }), /CHARACTER_EXPORT_RESPONSE_INVALID/);
 });
 
 test("storage snapshot projects paths, status and reset availability", () => {
@@ -271,6 +306,7 @@ test("typed root settings client uses only frozen character storage, update, and
   const invoke = async (command, args) => {
     calls.push([command, args]);
     if (command === "settings_characters_get") return emptyCharacters;
+    if (command === "settings_character_export") return characterExport;
     if (command.startsWith("settings_character")) return unchangedCharacters;
     if (command === "settings_storage_open_user_root") return null;
     if (command === "settings_update_get") return noUpdate;
@@ -292,6 +328,8 @@ test("typed root settings client uses only frozen character storage, update, and
   const client = createRootSettingsClient({ invoke });
   await client.charactersGet();
   await client.characterImport("/tmp/role.char");
+  await client.characterVoiceImport("/tmp/role.voice", "role");
+  await client.characterExport("/tmp/role.char", "role", "full");
   await client.characterSelect("role");
   await client.storageGet();
   await client.storageOpenUserRoot();
@@ -315,6 +353,8 @@ test("typed root settings client uses only frozen character storage, update, and
   assert.deepEqual(calls, [
     ["settings_characters_get", undefined],
     ["settings_character_import", { path: "/tmp/role.char" }],
+    ["settings_character_import_voice", { path: "/tmp/role.voice", characterId: "role" }],
+    ["settings_character_export", { path: "/tmp/role.char", characterId: "role", kind: "full" }],
     ["settings_character_select", { characterId: "role" }],
     ["settings_storage_get", undefined],
     ["settings_storage_open_user_root", undefined],

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -4971,8 +4971,8 @@ fn validate_character_settings_snapshot(value: &Value) -> Result<(), String> {
         let item = character
             .as_object()
             .ok_or_else(|| "CHARACTER_SETTINGS_RESPONSE_INVALID".to_string())?;
-        if item.len() != 3
-            || !["id", "displayName", "hasVoice"]
+        if item.len() != 4
+            || !["id", "displayName", "hasVoice", "hasExportableVoice"]
                 .iter()
                 .all(|key| item.contains_key(*key))
         {
@@ -4983,11 +4983,15 @@ fn validate_character_settings_snapshot(value: &Value) -> Result<(), String> {
             .get("displayName")
             .and_then(Value::as_str)
             .unwrap_or_default();
+        let has_voice = item.get("hasVoice").and_then(Value::as_bool);
+        let has_exportable_voice = item.get("hasExportableVoice").and_then(Value::as_bool);
         if id.is_empty()
             || id.len() > 128
             || display_name.is_empty()
             || display_name.len() > 128
-            || item.get("hasVoice").and_then(Value::as_bool).is_none()
+            || has_voice.is_none()
+            || has_exportable_voice.is_none()
+            || (has_exportable_voice == Some(true) && has_voice != Some(true))
             || !ids.insert(id)
         {
             return Err("CHARACTER_SETTINGS_RESPONSE_INVALID".to_string());
@@ -4997,6 +5001,32 @@ fn validate_character_settings_snapshot(value: &Value) -> Result<(), String> {
         if !ids.contains(current) {
             return Err("CHARACTER_SETTINGS_RESPONSE_INVALID".to_string());
         }
+    }
+    Ok(())
+}
+
+fn validate_character_export_receipt(value: &Value) -> Result<(), String> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| "CHARACTER_EXPORT_RESPONSE_INVALID".to_string())?;
+    let expected = ["schemaVersion", "outputPath", "message"];
+    let output_path = object
+        .get("outputPath")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let message = object
+        .get("message")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if object.len() != expected.len()
+        || expected.iter().any(|key| !object.contains_key(*key))
+        || object.get("schemaVersion").and_then(Value::as_u64) != Some(1)
+        || output_path.is_empty()
+        || output_path.len() > 4096
+        || message.is_empty()
+        || message.len() > 4608
+    {
+        return Err("CHARACTER_EXPORT_RESPONSE_INVALID".to_string());
     }
     Ok(())
 }
@@ -5168,7 +5198,7 @@ fn observe_studio_character_restart(
         });
 }
 
-async fn character_settings_request(
+async fn character_settings_payload_request(
     window: &WebviewWindow,
     shell: &product_shell::ProductShellState,
     lifecycle: &ShellLifecycleState,
@@ -5188,7 +5218,21 @@ async fn character_settings_request(
         .ok_or_else(|| "SETTINGS_CORE_UNAVAILABLE".to_string())?;
     let response = dispatch_settings_request(handle.clone(), None, name, payload, deadline).await?;
     assert_settings_identity(shell, &handle, window_generation, &core_generation_id)?;
-    let snapshot = settings_response_payload(response)?;
+    let payload = settings_response_payload(response)?;
+    Ok((payload, handle))
+}
+
+async fn character_settings_request(
+    window: &WebviewWindow,
+    shell: &product_shell::ProductShellState,
+    lifecycle: &ShellLifecycleState,
+    name: &'static str,
+    payload: Value,
+    deadline: std::time::Duration,
+) -> Result<(Value, shell_lifecycle::ShellLifecycleHandle), String> {
+    let (snapshot, handle) =
+        character_settings_payload_request(window, shell, lifecycle, name, payload, deadline)
+            .await?;
     validate_character_settings_snapshot(&snapshot)?;
     Ok((snapshot, handle))
 }
@@ -5257,6 +5301,43 @@ fn character_switch_receipt(
         "previousCoreGenerationId": previous_core_generation_id,
         "restartState": restart_state,
     }))
+}
+
+fn finish_character_settings_change(
+    app_handle: tauri::AppHandle,
+    audio_state: &audio::AudioState,
+    snapshot: Value,
+    handle: shell_lifecycle::ShellLifecycleHandle,
+    previous_generation_id: String,
+    previous_generation_number: u64,
+    target_character_id: Option<String>,
+) -> Result<Value, String> {
+    if let Some(target_character_id) = target_character_id {
+        handle
+            .restart()
+            .map_err(|_| "CHARACTER_RESTART_REQUEST_FAILED".to_string())?;
+        audio_state.shutdown();
+        if let Some(history) = app_handle.get_webview_window(history_window::HISTORY_WINDOW_LABEL) {
+            let _ = history.emit(
+                history_window::HISTORY_REFRESH_REQUESTED_EVENT,
+                json!({
+                    "previousGenerationId": previous_generation_id.clone(),
+                    "characterId": target_character_id.clone(),
+                    "reset": true,
+                    "ready": false,
+                }),
+            );
+        }
+        observe_character_restart(
+            app_handle,
+            handle,
+            previous_generation_id.clone(),
+            previous_generation_number,
+            target_character_id,
+        );
+        return character_switch_receipt(snapshot, previous_generation_id, "requested");
+    }
+    character_switch_receipt(snapshot, previous_generation_id, "not_required")
 }
 
 #[tauri::command]
@@ -5366,32 +5447,74 @@ async fn settings_character_import(
         std::time::Duration::from_secs(120),
     )
     .await?;
-    if let Some(target_character_id) = target_character_id {
-        handle
-            .restart()
-            .map_err(|_| "CHARACTER_RESTART_REQUEST_FAILED".to_string())?;
-        audio_state.shutdown();
-        if let Some(history) = app_handle.get_webview_window(history_window::HISTORY_WINDOW_LABEL) {
-            let _ = history.emit(
-                history_window::HISTORY_REFRESH_REQUESTED_EVENT,
-                json!({
-                    "previousGenerationId": previous_generation_id.clone(),
-                    "characterId": target_character_id.clone(),
-                    "reset": true,
-                    "ready": false,
-                }),
-            );
-        }
-        observe_character_restart(
-            app_handle,
-            handle,
-            previous_generation_id.clone(),
-            previous_generation_number,
-            target_character_id,
-        );
-        return character_switch_receipt(snapshot, previous_generation_id, "requested");
-    }
-    character_switch_receipt(snapshot, previous_generation_id, "not_required")
+    finish_character_settings_change(
+        app_handle,
+        &audio_state,
+        snapshot,
+        handle,
+        previous_generation_id,
+        previous_generation_number,
+        target_character_id,
+    )
+}
+
+#[tauri::command]
+async fn settings_character_import_voice(
+    window: WebviewWindow,
+    path: String,
+    character_id: String,
+    app_handle: tauri::AppHandle,
+    shell: State<'_, product_shell::ProductShellState>,
+    lifecycle: State<'_, ShellLifecycleState>,
+    audio_state: State<'_, audio::AudioState>,
+) -> Result<Value, String> {
+    let (
+        snapshot,
+        _change_plan,
+        handle,
+        previous_generation_id,
+        previous_generation_number,
+        target_character_id,
+    ) = character_settings_change_request(
+        &window,
+        &shell,
+        &lifecycle,
+        "characters.settings.import_voice",
+        json!({"path": path, "characterId": character_id}),
+        std::time::Duration::from_secs(120),
+    )
+    .await?;
+    finish_character_settings_change(
+        app_handle,
+        &audio_state,
+        snapshot,
+        handle,
+        previous_generation_id,
+        previous_generation_number,
+        target_character_id,
+    )
+}
+
+#[tauri::command]
+async fn settings_character_export(
+    window: WebviewWindow,
+    path: String,
+    character_id: String,
+    kind: String,
+    shell: State<'_, product_shell::ProductShellState>,
+    lifecycle: State<'_, ShellLifecycleState>,
+) -> Result<Value, String> {
+    let (receipt, _) = character_settings_payload_request(
+        &window,
+        &shell,
+        &lifecycle,
+        "characters.settings.export",
+        json!({"path": path, "characterId": character_id, "kind": kind}),
+        std::time::Duration::from_secs(120),
+    )
+    .await?;
+    validate_character_export_receipt(&receipt)?;
+    Ok(receipt)
 }
 
 #[tauri::command]
@@ -9007,6 +9130,8 @@ fn main() {
             settings_character_choose_import,
             settings_character_choose_export,
             settings_character_import,
+            settings_character_import_voice,
+            settings_character_export,
             settings_character_select,
             open_character_studio,
             studio_bootstrap,
@@ -9154,7 +9279,12 @@ mod tests {
             "schemaVersion": 1,
             "revision": 2,
             "currentCharacterId": "navi",
-            "characters": [{"id": "navi", "displayName": "N.A.V.I.", "hasVoice": false}],
+            "characters": [{
+                "id": "navi",
+                "displayName": "N.A.V.I.",
+                "hasVoice": false,
+                "hasExportableVoice": false,
+            }],
         }))
         .is_ok());
         assert_eq!(
@@ -9162,10 +9292,29 @@ mod tests {
                 "schemaVersion": 1,
                 "revision": 2,
                 "currentCharacterId": "missing",
-                "characters": [{"id": "navi", "displayName": "N.A.V.I.", "hasVoice": false}],
+                "characters": [{
+                    "id": "navi",
+                    "displayName": "N.A.V.I.",
+                    "hasVoice": false,
+                    "hasExportableVoice": false,
+                }],
             }))
             .unwrap_err(),
             "CHARACTER_SETTINGS_RESPONSE_INVALID"
+        );
+        assert_eq!(
+            validate_character_settings_snapshot(&json!({
+                "schemaVersion": 1,
+                "revision": 2,
+                "currentCharacterId": "navi",
+                "characters": [{
+                    "id": "navi",
+                    "displayName": "N.A.V.I.",
+                    "hasVoice": false,
+                    "hasExportableVoice": true,
+                }],
+            })),
+            Err("CHARACTER_SETTINGS_RESPONSE_INVALID".to_string())
         );
     }
 
@@ -9175,7 +9324,12 @@ mod tests {
             "schemaVersion": 1,
             "revision": 2,
             "currentCharacterId": "navi",
-            "characters": [{"id": "navi", "displayName": "N.A.V.I.", "hasVoice": false}],
+            "characters": [{
+                "id": "navi",
+                "displayName": "N.A.V.I.",
+                "hasVoice": false,
+                "hasExportableVoice": false,
+            }],
         });
         let (validated, plan) = validate_character_settings_change(json!({
             "schemaVersion": 1,
@@ -9208,6 +9362,25 @@ mod tests {
         assert_eq!(
             character_restart_target(&empty_snapshot, "unchanged"),
             Ok(None)
+        );
+    }
+
+    #[test]
+    fn character_export_receipt_requires_only_public_output_fields() {
+        assert!(validate_character_export_receipt(&json!({
+            "schemaVersion": 1,
+            "outputPath": "C:\\Users\\test\\navi.char",
+            "message": "角色包已导出。",
+        }))
+        .is_ok());
+        assert_eq!(
+            validate_character_export_receipt(&json!({
+                "schemaVersion": 1,
+                "outputPath": "C:\\Users\\test\\navi.char",
+                "message": "角色包已导出。",
+                "characterCard": "private",
+            })),
+            Err("CHARACTER_EXPORT_RESPONSE_INVALID".to_string())
         );
     }
 

--- a/desktop/src-tauri/src/runtime_log.rs
+++ b/desktop/src-tauri/src/runtime_log.rs
@@ -1171,6 +1171,8 @@ fn viewer_ipc_request_message(record: &RuntimeLogRecord) -> Option<String> {
         "screen_awareness.settings.save" => "保存屏幕感知设置",
         "characters.settings.get" => "读取角色设置",
         "characters.settings.import" => "导入角色",
+        "characters.settings.import_voice" => "导入角色语音",
+        "characters.settings.export" => "导出角色包",
         "characters.settings.select" => "切换角色",
         "storage.settings.get" => "读取存储设置",
         "storage.settings.choose_tts_root" => "更改语音数据目录",

--- a/docs/specs/runtime-v2/WP-5-03-safe-character-switch.md
+++ b/docs/specs/runtime-v2/WP-5-03-safe-character-switch.md
@@ -4,7 +4,7 @@ status: normative
 audience: maintainer
 source_of_truth: self
 status_source: ../../plans/runtime-v2/work-packages.md
-updated: 2026-08-29
+updated: 2026-09-05
 ---
 
 # WP-5-03 安全角色切换、Session 与历史分页
@@ -20,9 +20,14 @@ generation 私有资源完成清理，再启动完整的新 generation。
 同角色选择是无写入、无重启的 `unchanged`。导入角色包只有在首次导入并自动成为当前角色时要求重启；
 导入非当前角色不重启。
 
+设置页可以给当前已提交角色导入 `.voice`，也可以导出完整角色包、单角色包或语音包。给当前角色导入语音后必须
+受控重启 Core，使新的模型和参考语音进入下一 generation；给非当前角色导入时只更新角色包。导出只读取
+已保存的角色数据，不改变当前角色，也不触发重启。完整角色包和语音包要求 GPT 与 SoVITS 模型文件都存在；
+模型不完整时仍可导出不含语音的单角色包。
+
 ## 2. 配置提交与 restart 协议
 
-Python `characters.settings.select/import` 在校验角色包或目标角色后原子保存配置，返回固定 envelope：
+Python `characters.settings.select/import/import_voice` 在校验归档或目标角色后保存数据，返回固定 envelope：
 
 ```json
 {
@@ -37,6 +42,10 @@ restart，并向设置页返回已提交目标、前一 generation 和 `restartS
 `restartState=not_required`。配置保存失败不得 restart；restart 派发失败返回
 `CHARACTER_RESTART_REQUEST_FAILED`。配置可能已经提交，因此失败后禁止第二次写入、自动回滚、自动重试或回退
 旧角色，用户只能按明确错误人工恢复。
+
+`characters.settings.export` 接收角色 ID、导出类型和 Rust 文件对话框选出的绝对路径，成功时只返回
+`schemaVersion`、`outputPath` 和用户提示。Python Core 负责校验角色及语音模型，并通过临时文件替换目标归档；
+Rust 和 WebView 不直接读取角色目录。
 
 设置页的角色下拉不得直接调用 `characters.settings.select`。它可以通过独立的只读视觉预览命令加载目标角色
 已保存的主题、默认立绘和初始问候语，但不得改变 active character、Core generation、Chat reducer、Memory/Timeline、TTS
@@ -85,6 +94,8 @@ generation 隔离，但不视为角色变化。
   collection editor；切换清理会关闭 editor portal、失效在途 collection 查询并清空其分页状态。
 - 收到已提交的 restart receipt 后进入 switching，立即清空并隐藏旧角色 Memory 列表、编辑器、插件
   collection 页面状态和历史内容；切换期间禁用角色导入/选择及角色相关操作，不整页 reload。
+- 当前角色有未保存的外观、语音或 Memory 改动时禁止导入语音，避免受控重启丢失草稿。导出仍可读取已保存
+  的角色包；有待应用的角色切换时，导入语音和导出都保持禁用。
 - Provider、Tools、Plugin 和 Screen Awareness 等全局设置草稿保留，并在新 generation 就绪后重新绑定；
   外观、语音和 Memory 草稿不得迁移到另一角色。
 - 主桌宠只有在角色 ID 变化时替换 Chat Presentation reducer，清除旧回复浏览/打字/TTS 状态并显示新角色

--- a/tests/unit/test_core_host_character_settings.py
+++ b/tests/unit/test_core_host_character_settings.py
@@ -8,7 +8,6 @@ import yaml
 
 from app.core_host.character_settings import CharacterSettingsBoundary
 
-
 GENERATION = "generation-character-settings"
 CREDENTIAL = "0123456789abcdef0123456789abcdef"
 
@@ -46,6 +45,41 @@ def _archive(path: Path, character_id: str = "fixture") -> Path:
     return path
 
 
+def _voice_archive(path: Path, *, complete: bool = True) -> Path:
+    voice = {
+        "tone_refs": "voice/refs/ref.txt",
+        "ref_lang": "ja",
+        "text_lang": "ja",
+    }
+    if complete:
+        voice.update(
+            {
+                "gpt_model": "voice/models/gpt.ckpt",
+                "sovits_model": "voice/models/sovits.pth",
+            }
+        )
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr(
+            "manifest.json",
+            json.dumps(
+                {
+                    "format": "sakura.character.voice",
+                    "version": 1,
+                    "voice": voice,
+                }
+            ),
+        )
+        archive.writestr(
+            "voice/refs/ref.txt",
+            "voice/refs/tone_refs/happy.wav|JA|hello|开心\n",
+        )
+        archive.writestr("voice/refs/tone_refs/happy.wav", b"wav")
+        if complete:
+            archive.writestr("voice/models/gpt.ckpt", b"gpt")
+            archive.writestr("voice/models/sovits.pth", b"sovits")
+    return path
+
+
 def test_empty_snapshot_and_first_import_auto_select(tmp_path: Path) -> None:
     boundary = CharacterSettingsBoundary(GENERATION, CREDENTIAL, tmp_path)
 
@@ -68,13 +102,20 @@ def test_empty_snapshot_and_first_import_auto_select(tmp_path: Path) -> None:
     snapshot = imported["payload"]["snapshot"]
     assert snapshot["currentCharacterId"] == "fixture"
     assert snapshot["characters"] == [
-        {"id": "fixture", "displayName": "Fixture", "hasVoice": False}
+        {
+            "id": "fixture",
+            "displayName": "Fixture",
+            "hasVoice": False,
+            "hasExportableVoice": False,
+        }
     ]
     saved = yaml.safe_load((tmp_path / "config" / "characters.yaml").read_text())
     assert saved == {"current_character_id": "fixture"}
 
 
-def test_select_same_character_is_unchanged_without_rewriting_config(tmp_path: Path) -> None:
+def test_select_same_character_is_unchanged_without_rewriting_config(
+    tmp_path: Path,
+) -> None:
     boundary = CharacterSettingsBoundary(GENERATION, CREDENTIAL, tmp_path)
     boundary.handle(
         _request(
@@ -95,7 +136,135 @@ def test_select_same_character_is_unchanged_without_rewriting_config(tmp_path: P
     assert config.read_bytes() == before
 
 
-def test_select_rejects_unknown_character_without_changing_config(tmp_path: Path) -> None:
+def test_voice_import_restarts_current_character_and_exports_all_package_kinds(
+    tmp_path: Path,
+) -> None:
+    boundary = CharacterSettingsBoundary(GENERATION, CREDENTIAL, tmp_path)
+    boundary.handle(
+        _request(
+            "characters.settings.import",
+            {"path": str(_archive(tmp_path / "fixture.char"))},
+        )
+    )
+
+    imported = boundary.handle(
+        _request(
+            "characters.settings.import_voice",
+            {
+                "path": str(_voice_archive(tmp_path / "fixture.voice")),
+                "characterId": "fixture",
+            },
+        )
+    )
+
+    assert imported["ok"] is True
+    assert imported["payload"]["changePlan"] == "core_restart_required"
+    assert imported["payload"]["snapshot"]["characters"] == [
+        {
+            "id": "fixture",
+            "displayName": "Fixture",
+            "hasVoice": True,
+            "hasExportableVoice": True,
+        }
+    ]
+
+    outputs = {
+        "full": tmp_path / "fixture-full.char",
+        "card": tmp_path / "fixture-card",
+        "voice": tmp_path / "fixture.voice.export.voice",
+    }
+    for kind, output in outputs.items():
+        exported = boundary.handle(
+            _request(
+                "characters.settings.export",
+                {"path": str(output), "characterId": "fixture", "kind": kind},
+            )
+        )
+        assert exported["ok"] is True
+        expected_output = output.with_suffix(".char") if kind == "card" else output
+        assert exported["payload"]["outputPath"] == str(expected_output)
+        assert expected_output.is_file()
+
+    with zipfile.ZipFile(outputs["full"]) as archive:
+        full_manifest = json.loads(archive.read("manifest.json"))
+    with zipfile.ZipFile(outputs["card"].with_suffix(".char")) as archive:
+        card_manifest = json.loads(archive.read("manifest.json"))
+    with zipfile.ZipFile(outputs["voice"]) as archive:
+        voice_manifest = json.loads(archive.read("manifest.json"))
+    assert full_manifest["character"]["voice"]["gpt_model"]
+    assert "voice" not in card_manifest["character"]
+    assert voice_manifest["format"] == "sakura.character.voice"
+
+
+def test_voice_import_for_inactive_character_does_not_restart(tmp_path: Path) -> None:
+    boundary = CharacterSettingsBoundary(GENERATION, CREDENTIAL, tmp_path)
+    boundary.handle(
+        _request(
+            "characters.settings.import",
+            {"path": str(_archive(tmp_path / "alpha.char", "alpha"))},
+        )
+    )
+    boundary.handle(
+        _request(
+            "characters.settings.import",
+            {"path": str(_archive(tmp_path / "beta.char", "beta"))},
+        )
+    )
+
+    result = boundary.handle(
+        _request(
+            "characters.settings.import_voice",
+            {
+                "path": str(_voice_archive(tmp_path / "beta.voice")),
+                "characterId": "beta",
+            },
+        )
+    )
+
+    assert result["ok"] is True
+    assert result["payload"]["changePlan"] == "unchanged"
+    assert result["payload"]["snapshot"]["currentCharacterId"] == "alpha"
+
+
+def test_incomplete_voice_cannot_be_exported_as_full_or_voice_package(
+    tmp_path: Path,
+) -> None:
+    boundary = CharacterSettingsBoundary(GENERATION, CREDENTIAL, tmp_path)
+    boundary.handle(
+        _request(
+            "characters.settings.import",
+            {"path": str(_archive(tmp_path / "fixture.char"))},
+        )
+    )
+    imported = boundary.handle(
+        _request(
+            "characters.settings.import_voice",
+            {
+                "path": str(_voice_archive(tmp_path / "partial.voice", complete=False)),
+                "characterId": "fixture",
+            },
+        )
+    )
+    character = imported["payload"]["snapshot"]["characters"][0]
+    assert character["hasVoice"] is True
+    assert character["hasExportableVoice"] is False
+
+    for kind, suffix in (("full", ".char"), ("voice", ".voice")):
+        output = tmp_path / f"blocked{suffix}"
+        result = boundary.handle(
+            _request(
+                "characters.settings.export",
+                {"path": str(output), "characterId": "fixture", "kind": kind},
+            )
+        )
+        assert result["ok"] is False
+        assert result["error"]["code"] == "CHARACTER_VOICE_NOT_EXPORTABLE"
+        assert not output.exists()
+
+
+def test_select_rejects_unknown_character_without_changing_config(
+    tmp_path: Path,
+) -> None:
     boundary = CharacterSettingsBoundary(GENERATION, CREDENTIAL, tmp_path)
     result = boundary.handle(
         _request("characters.settings.select", {"characterId": "missing"})
@@ -105,7 +274,9 @@ def test_select_rejects_unknown_character_without_changing_config(tmp_path: Path
     assert not (tmp_path / "config" / "characters.yaml").exists()
 
 
-def test_select_save_failure_keeps_existing_character_config(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_select_save_failure_keeps_existing_character_config(
+    tmp_path: Path, monkeypatch
+) -> None:  # type: ignore[no-untyped-def]
     boundary = CharacterSettingsBoundary(GENERATION, CREDENTIAL, tmp_path)
     boundary.handle(
         _request(


### PR DESCRIPTION
## 改动

- 接通 Runtime v2 设置页的 .voice 导入，以及完整角色包、单角色包和语音包导出。
- 导入当前角色语音后执行受控 Core 重启；存在角色级草稿或待应用角色切换时阻止导入。
- 区分“角色有语音配置”和“语音模型可完整导出”，缺少 GPT 或 SoVITS 模型时只允许导出单角色包。
- 保留旧设置宿主兼容分支，并补充 Core、Rust、前端契约和规范说明。

## 验证

- Python 归档与 Core 边界测试：32 passed
- 前端完整测试：267 passed
- Rust 命令编译与响应校验测试：通过
- journey-character-switch：3/3 passed
- docs：1/1 passed
- Ruff、cargo fmt、git diff 检查：通过

## 未验证

未使用真实用户数据手动点击原生文件对话框。