### PR TITLE
fix: 限制角色工坊备份并完善模型展示与编辑入口

### DIFF
--- a/app/config/character_studio.py
+++ b/app/config/character_studio.py
@@ -21,6 +21,7 @@ from app.config.character_loader import (
     character_theme_to_mapping,
 )
 from app.config.character_packages import allocate_character_installation
+from app.core.runtime_log import diagnostic_attributes, log_event
 from app.storage.atomic import atomic_write_text, rename_with_retry, replace_with_retry
 from app.storage.paths import StoragePaths, sanitize_directory_component
 from app.config.models import DEFAULT_THEME_SETTINGS, ThemeSettings, theme_from_mapping, theme_to_mapping
@@ -34,6 +35,7 @@ DRAFT_SCHEMA_VERSION = 1
 PUBLISH_JOURNAL_VERSION = 2
 PUBLISH_JOURNAL_FILENAME = "publish-journal.json"
 PUBLISH_TRANSACTIONS_DIRNAME = ".studio-transactions"
+PUBLISH_BACKUP_LIMIT = 2
 PORTRAIT_DESCRIPTION_FILENAME = "立绘说明.txt"
 _CHARACTER_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 _PORTRAIT_SUFFIXES = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
@@ -393,6 +395,7 @@ class CharacterStudioService:
             "doc": doc.to_payload(),
             "is_dirty": True,
             "saved_at": int(time.time()),
+            "model_files": self._workspace_model_files(self._draft_package_dir(safe_id)),
         }
 
     def save_draft(self, doc_payload: dict[str, Any], package_dir: Path | str) -> dict[str, Any]:
@@ -470,6 +473,17 @@ class CharacterStudioService:
             )
             if allocated_id != profile.id:
                 raise ValueError(f"角色 ID 已存在：{profile.id}。请直接打开该角色进行编辑。")
+        if existing_profile is not None and _package_trees_equal(
+            draft_dir, target_dir, cancel_check=cancel_check
+        ):
+            _operation_checkpoint(cancel_check)
+            if commit_started is not None:
+                commit_started()
+            result = self._complete_publish(
+                draft_dir, existing_profile, current_character_id, changed=False
+            )
+            self._cleanup_publish_backups(target_dir, profile.id, result)
+            return result
         transaction_id = uuid.uuid4().hex
         transaction_root = self._publish_transactions_root / transaction_id
         staging_dir = transaction_root / "staging"
@@ -485,15 +499,12 @@ class CharacterStudioService:
             "target_existed": target_existed,
             "workspace_id": workspace_id,
         }
-        state = self._read_state(workspace_id)
-        was_installed = state is not None and str(state.get("origin")) == "installed"
         journal_written = False
         committed = False
         try:
             transaction_root.mkdir(parents=True, exist_ok=False)
             _copytree_cancellable(draft_dir, staging_dir, cancel_check=cancel_check)
             _operation_checkpoint(cancel_check)
-            saved_doc = CharacterStudioDoc.from_package_dir(staging_dir)
             self._write_publish_journal(journal)
             journal_written = True
             if commit_started is not None:
@@ -506,33 +517,16 @@ class CharacterStudioService:
             if target_existed:
                 rename_with_retry(rollback_dir, backup_dir)
             saved_profile = _load_profile(target_dir / "character.json")
-            if state is not None:
-                self._write_state(
-                    workspace_id,
-                    saved_doc,
-                    origin="installed",
-                    dirty=False,
-                    imported_assets=[str(item) for item in state.get("imported_assets", [])],
-                )
-            result = {
-                "saved_character_id": profile.id,
-                "current_character_id": str(current_character_id or ""),
-                "characters": self.list_characters(
-                    current_character_id=str(current_character_id or "")
-                ),
-                "doc": saved_doc.to_payload(),
-                "package_dir": str(draft_dir),
-                "workspace_id": workspace_id,
-                "is_dirty": False,
-                "message": (
-                    f"已保存角色「{saved_profile.display_name}」。"
-                    if was_installed
-                    else f"已发布角色「{saved_profile.display_name}」。"
-                ),
-            }
+            result = self._complete_publish(
+                draft_dir, saved_profile, current_character_id, changed=True
+            )
             self._clear_publish_journal()
             journal_written = False
             committed = True
+            self._cleanup_publish_backups(
+                target_dir, profile.id, result,
+                newest=backup_dir if target_existed else None,
+            )
             return result
         except Exception:
             if journal_written:
@@ -541,6 +535,42 @@ class CharacterStudioService:
         finally:
             if committed or not journal_written:
                 shutil.rmtree(transaction_root, ignore_errors=True)
+
+    def _complete_publish(
+        self,
+        draft_dir: Path,
+        profile: CharacterProfile,
+        current_character_id: str,
+        *,
+        changed: bool,
+    ) -> dict[str, Any]:
+        workspace_id = self._workspace_id_for_package(draft_dir)
+        state = self._read_state(workspace_id)
+        was_installed = state is not None and state.get("origin") == "installed"
+        doc = CharacterStudioDoc.from_package_dir(profile.package_dir)
+        if state is not None:
+            self._write_state(
+                workspace_id, doc, origin="installed", dirty=False,
+                imported_assets=[str(item) for item in state.get("imported_assets", [])],
+            )
+        return {
+            "saved_character_id": profile.id,
+            "current_character_id": str(current_character_id or ""),
+            "characters": self.list_characters(current_character_id=str(current_character_id or "")),
+            "doc": doc.to_payload(),
+            "package_dir": str(draft_dir),
+            "workspace_id": workspace_id,
+            "is_dirty": False,
+            "changed": changed,
+            "model_files": self._workspace_model_files(draft_dir),
+            "message": (
+                f"角色「{profile.display_name}」内容未变化。"
+                if not changed else
+                f"已保存角色「{profile.display_name}」。"
+                if was_installed else
+                f"已发布角色「{profile.display_name}」。"
+            ),
+        }
 
     def import_portrait(
         self,
@@ -801,6 +831,32 @@ class CharacterStudioService:
     def _state_path(self, character_id: str) -> Path:
         return self._draft_root(character_id) / "draft.json"
 
+    def _workspace_model_files(self, package_dir: Path) -> list[dict[str, Any]]:
+        """List model metadata independently of the selected or enabled provider."""
+        models: list[dict[str, Any]] = []
+        if package_dir.is_symlink() or package_dir.is_junction():
+            return models
+        for directory, subdirs, filenames in os.walk(package_dir, followlinks=False):
+            root = Path(directory)
+            subdirs[:] = [name for name in subdirs
+                          if not (root / name).is_symlink() and not (root / name).is_junction()]
+            for name in filenames:
+                path = root / name
+                if path.suffix.lower() not in {*_VOICE_MODEL_SUFFIXES.values(), ".onnx"}:
+                    continue
+                try:
+                    if path.is_symlink() or not path.is_file():
+                        continue
+                    models.append({
+                        "relative_path": path.relative_to(package_dir).as_posix(),
+                        "byte_length": path.stat().st_size,
+                    })
+                except OSError:
+                    # An unreadable metadata entry must not turn a completed draft
+                    # save into a failure. No model contents are read here.
+                    continue
+        return sorted(models, key=lambda item: item["relative_path"].casefold())
+
     def _opened_payload(
         self,
         package_dir: Path,
@@ -819,6 +875,7 @@ class CharacterStudioService:
             "is_dirty": bool(state.get("dirty")) if state is not None else source == "draft",
             "doc": doc.to_payload(),
             "characters": self.list_characters(current_character_id=doc.id),
+            "model_files": self._workspace_model_files(package_dir),
         }
 
     def _summary_from_profile(self, profile: CharacterProfile, current_character_id: str) -> dict[str, Any]:
@@ -1012,6 +1069,68 @@ class CharacterStudioService:
         if backup_dir.exists():
             backup_dir = self.backup_root / f"{backup_dir.name}-{uuid.uuid4().hex[:8]}"
         return backup_dir
+
+    def _cleanup_publish_backups(
+        self,
+        target_dir: Path,
+        character_id: str,
+        result: dict[str, Any],
+        *,
+        newest: Path | None = None,
+    ) -> None:
+        # Only run after commit (also on a no-op save). Never remove recovery input.
+        if self._publish_journal_path.exists():
+            return
+        try:
+            if self.backup_root.is_symlink() or self.backup_root.is_junction():
+                raise ValueError("角色备份目录不能经过符号链接或目录联接。")
+            if newest is not None:
+                # copytree preserves mtimes. Use the manifest as the backup clock:
+                # partial cleanup changes directory mtimes, but not this file.
+                os.utime(newest / "character.json", None)
+            pattern = re.compile(
+                rf"{re.escape(target_dir.name)}-(\d{{8}}-\d{{6}})(?:-[0-9a-f]{{8}})?"
+            )
+            candidates: list[tuple[bool, str, int, Path]] = []
+            for path in self.backup_root.iterdir():
+                match = pattern.fullmatch(path.name)
+                if match is None or path.is_symlink() or path.is_junction() or not path.is_dir():
+                    continue
+                manifest = path / "character.json"
+                try:
+                    _direct_child_path(self.backup_root, path.name, "角色备份目录")
+                    if manifest.is_symlink():
+                        continue
+                    raw = json.loads(manifest.read_text(encoding="utf-8"))
+                    if not isinstance(raw, dict) or raw.get("id") != character_id:
+                        continue
+                    candidates.append((path == newest, match[1], manifest.stat().st_mtime_ns, path))
+                except (OSError, ValueError):
+                    # Unknown or damaged directories may contain the only copy
+                    # of user data. Leave them for manual inspection.
+                    continue
+            candidates.sort(reverse=True)
+            for _, _, _, path in candidates[PUBLISH_BACKUP_LIMIT:]:
+                _direct_child_path(self.backup_root, path.name, "角色备份目录")
+                # Keep the identity until all assets are removed. A locked model
+                # must not leave a large, unrecognizable directory on the next save.
+                for entry in path.iterdir():
+                    if entry.name == "character.json":
+                        continue
+                    if entry.is_dir() and not entry.is_symlink():
+                        shutil.rmtree(entry)
+                    else:
+                        entry.unlink()
+                (path / "character.json").unlink()
+                path.rmdir()
+        except (OSError, ValueError) as exc:
+            log_event("CharacterStudio", "角色已保存，旧备份清理失败", {
+                "character_id": character_id,
+                **diagnostic_attributes(
+                    exc, reason_code="STUDIO_BACKUP_CLEANUP_FAILED", stage="backup_cleanup"
+                ),
+            })
+            result["message"] += "部分旧备份未能清理，下次保存时会重试。"
 
     @property
     def _publish_journal_path(self) -> Path:
@@ -1301,6 +1420,36 @@ def _files_equal_cancellable(
                 return False
             if not source_chunk:
                 return True
+
+
+def _package_trees_equal(
+    source: Path,
+    target: Path,
+    *,
+    cancel_check: Callable[[], None] | None,
+) -> bool:
+    for root in (source, target):
+        if root.is_symlink() or root.is_junction() or not root.is_dir():
+            raise ValueError("角色包目录无效或包含符号链接。")
+    source_items = {item.name: item for item in source.iterdir()}
+    target_items = {item.name: item for item in target.iterdir()}
+    if source_items.keys() != target_items.keys():
+        return False
+    # Text files sort ahead of large asset folders, so ordinary edits exit early.
+    for name, item in sorted(source_items.items()):
+        _operation_checkpoint(cancel_check)
+        other = target_items[name]
+        if item.is_symlink() or other.is_symlink() or item.is_junction() or other.is_junction():
+            raise ValueError("角色包不能包含符号链接。")
+        if item.is_dir() and other.is_dir():
+            if not _package_trees_equal(item, other, cancel_check=cancel_check):
+                return False
+        elif item.is_file() and other.is_file():
+            if not _files_equal_cancellable(item, other, cancel_check=cancel_check):
+                return False
+        else:
+            return False
+    return True
 
 
 def _cleanup_created_assets(package_dir: Path, copied_assets: list[dict[str, Any]]) -> None:

--- a/app/core_host/character_studio.py
+++ b/app/core_host/character_studio.py
@@ -262,7 +262,7 @@ class CharacterStudioBoundary:
                     "currentCharacterId": current or None,
                     "changePlan": (
                         "core_restart_required"
-                        if result.get("saved_character_id") == current
+                        if result.get("changed") and result.get("saved_character_id") == current
                         else "unchanged"
                     ),
                     "message": str(result.get("message") or ""),
@@ -570,6 +570,7 @@ def _opened_to_public(value: Mapping[str, Any], current: str) -> dict[str, Any]:
         "resumed": bool(value.get("resumed")),
         "isDirty": bool(value.get("is_dirty")),
         "doc": _keys_to_camel(value.get("doc") or {}),
+        "modelFiles": _keys_to_camel(value.get("model_files") or []),
         "characters": characters,
         "currentCharacterId": current or None,
     }
@@ -582,6 +583,7 @@ def _draft_to_public(value: Mapping[str, Any]) -> dict[str, Any]:
         "doc": _keys_to_camel(value.get("doc") or {}),
         "isDirty": bool(value.get("is_dirty")),
         "savedAt": int(value.get("saved_at") or 0),
+        "modelFiles": _keys_to_camel(value.get("model_files") or []),
     }
 
 

--- a/desktop/frontend/settings/appearance-runtime.js
+++ b/desktop/frontend/settings/appearance-runtime.js
@@ -579,13 +579,27 @@ export function createRuntimeAppearanceController({
   function applySnapshot(input, { preserveDraft = false } = {}) {
     const next = validateAppearanceSnapshot(input);
     const previousDraft = draft ? clone(draft) : null;
+    const previousBaseline = baseline;
     const previousCharacterId = snapshot?.presentation?.characterId || "";
     snapshot = next;
     baseline = clone(snapshot.appearance.values);
     draft = clone(baseline);
-    if (preserveDraft && previousDraft && previousCharacterId === snapshot.presentation.characterId) {
+    if (preserveDraft && previousDraft && previousBaseline
+        && previousCharacterId === snapshot.presentation.characterId) {
       try {
-        draft = clone(validateAppearanceValues(previousDraft, snapshot.limits));
+        // Keep edits made in Settings, while accepting untouched values published by Studio.
+        for (const key of Object.keys(draft)) {
+          if (key === "themeTokens") {
+            for (const token of Object.keys(draft.themeTokens)) {
+              if (previousDraft.themeTokens[token] !== previousBaseline.themeTokens[token]) {
+                draft.themeTokens[token] = previousDraft.themeTokens[token];
+              }
+            }
+          } else if (previousDraft[key] !== previousBaseline[key]) {
+            draft[key] = previousDraft[key];
+          }
+        }
+        draft = clone(validateAppearanceValues(draft, snapshot.limits));
       } catch {
         draft = clone(baseline);
       }

--- a/desktop/frontend/settings/settings.js
+++ b/desktop/frontend/settings/settings.js
@@ -447,6 +447,7 @@ function refreshDirty() {
   const dirty = computeDirty();
   document.body.classList.toggle("is-dirty", dirty);
   fields.saveButton.classList.toggle("has-changes", dirty);
+  if (runtimeSettingsHost) syncCharacterArchiveState();
 }
 
 let dirtyTimer = null;
@@ -1398,12 +1399,14 @@ function renderCharacters() {
   syncCharacterArchiveState();
 }
 
-function applyRuntimeCharacterSnapshot(snapshot) {
+function applyRuntimeCharacterSnapshot(snapshot, { preserveSelection = false } = {}) {
   const normalized = snapshot?.snapshot && snapshot?.character
     ? snapshot
     : normalizeCharacterSettingsSnapshot(snapshot);
+  const pendingSelection = preserveSelection ? pendingRuntimeCharacterId() : null;
   runtimeCharacterSnapshot = normalized.snapshot;
-  runtimeCharacterDraftId = normalized.character.current_character_id;
+  runtimeCharacterDraftId = normalized.character.characters.some((item) => item.id === pendingSelection)
+    ? pendingSelection : normalized.character.current_character_id;
   request = request || {};
   request.character = normalized.character;
   renderCharacters();
@@ -1719,8 +1722,7 @@ function syncCharacterArchiveState() {
       || !hasCharacter || Boolean(pendingCharacterId);
     syncCharacterEditorControl(
       fields.characterEditorButton,
-      characterArchiveBusy || characterSwitching
-        || !hasCharacter || Boolean(pendingCharacterId) || currentCharacterHasDrafts(),
+      characterArchiveBusy || characterSwitching || !hasCharacter,
     );
     fields.characterArchiveHint.textContent = pendingCharacterId
       ? `已选择 ${character?.display_name || pendingCharacterId}；角色级设置已锁定，点击“应用”或“保存并关闭”后正式切换。`
@@ -1849,8 +1851,8 @@ async function rebindSettingsAfterCharacterSwitch(lifecycle) {
   await runtimeAppearanceController?.rebindGeneration(generationId);
   await runtimeToolsController?.refreshCurrent();
   await runtimePluginController?.refreshCurrent();
-  await runtimeVoiceController?.refreshCurrent();
-  applyRuntimeCharacterSnapshot(await rootSettingsClient.charactersGet());
+  await runtimeVoiceController?.refreshCurrent({ preserveDraft: true });
+  applyRuntimeCharacterSnapshot(await rootSettingsClient.charactersGet(), { preserveSelection: true });
   memoryState.rebinding = false;
   if (fields.pages.memory.classList.contains("is-active")) {
     await loadMemories();
@@ -1876,7 +1878,7 @@ async function refreshRuntimeCharacterCatalog(payload) {
       generationId,
       readLifecycle: () => invoke("runtime_lifecycle_snapshot"),
       readCatalog: () => rootSettingsClient.charactersGet(),
-      applyCatalog: applyRuntimeCharacterSnapshot,
+      applyCatalog: (snapshot) => applyRuntimeCharacterSnapshot(snapshot, { preserveSelection: true }),
       rebindSettings: rebindSettingsAfterCharacterSwitch,
     });
     if (applied && revision === characterCatalogRefreshRevision) setError("");
@@ -1888,6 +1890,7 @@ async function refreshRuntimeCharacterCatalog(payload) {
     if (rebinding && revision === characterCatalogRefreshRevision) {
       characterSwitching = false;
       memoryState.rebinding = false;
+      renderMemorySurface();
       syncCharacterArchiveState();
     }
   }
@@ -3429,10 +3432,6 @@ async function launchCharacterStudio() {
       setError("请先选择一个角色。");
       return;
     }
-    if (pendingRuntimeCharacterId() || currentCharacterHasDrafts()) {
-      setError("请先保存或放弃角色相关改动，再打开角色工坊。");
-      return;
-    }
     await invoke("open_character_studio", { characterId: character.id });
   });
 }
@@ -4589,6 +4588,7 @@ async function queryPluginCollection(
   collection,
   { append = false, render = true } = {},
 ) {
+  if (!request?.plugins?.items.includes(plugin)) return;
   if (section.surface === "memory" && (
     memoryState.rebinding || characterSwitching || pendingRuntimeCharacterId()
   )) return;
@@ -4621,6 +4621,7 @@ async function queryPluginCollection(
       search: querySearch,
       filters: queryFilters,
     });
+    if (pluginCollectionState.get(collectionKey) !== state) return;
     if (section.surface === "memory" && (memoryState.rebinding || characterSwitching)) return;
     if (queryRevision !== state.queryRevision) {
       state.queryPending = true;
@@ -4631,9 +4632,11 @@ async function queryPluginCollection(
     state.total = result.total;
     state.loaded = true;
   } catch (error) {
+    if (pluginCollectionState.get(collectionKey) !== state) return;
     if (queryRevision === state.queryRevision) state.error = String(error);
     else state.queryPending = true;
   } finally {
+    if (pluginCollectionState.get(collectionKey) !== state) return;
     state.loading = false;
     if (section.surface === "memory" && (memoryState.rebinding || characterSwitching)) {
       state.queryPending = false;
@@ -6148,7 +6151,27 @@ function applyRuntimePluginSnapshot(snapshot, { preserveDraft = false, draft = n
       })),
     })),
   };
+  const previousCollections = new Map(pluginCollectionState);
+  previousCollections.forEach((state) => window.clearTimeout(state.searchTimer));
   pluginCollectionState.clear();
+  if (preserveDraft) {
+    for (const plugin of request.plugins.items) {
+      for (const section of plugin.settings) {
+        for (const collection of section.collections) {
+          const key = pluginCollectionKey(plugin, section, collection);
+          const previous = previousCollections.get(key);
+          if (!previous) continue;
+          // A new state object detaches old queries while keeping the editor and filters.
+          const current = pluginCollectionRuntimeState(plugin, section, collection);
+          current.editor = previous.editor ? clonePlain(previous.editor) : null;
+          current.editorError = previous.editorError;
+          current.selectedItemId = previous.selectedItemId;
+          current.search = previous.search;
+          current.filters = clonePlain(previous.filters);
+        }
+      }
+    }
+  }
   initializePluginState();
   if (preserveDraft && draft) {
     Object.entries(draft.enabledById || {}).forEach(([id, enabled]) => {
@@ -6496,7 +6519,7 @@ function applyRuntimeProviderModelSnapshot(snapshot) {
 
 async function refreshRuntimeVoiceCurrent() {
   if (!runtimeVoiceController) return;
-  await runtimeVoiceController.refreshCurrent();
+  await runtimeVoiceController.refreshCurrent({ preserveDraft: true });
 }
 
 async function saveRuntimeSettings() {

--- a/desktop/frontend/settings/voice-runtime.js
+++ b/desktop/frontend/settings/voice-runtime.js
@@ -230,10 +230,12 @@ export function createVoiceController({
     }
   }
 
-  function renderSections() {
+  function renderSections(drafts = []) {
     sectionInputs.clear();
     fields.sections.textContent = "";
     for (const section of snapshot.sections) {
+      const draftValues = drafts.find((item) => item.pluginId === section.pluginId
+        && item.sectionId === section.sectionId)?.values || {};
       const group = document.createElement("fieldset");
       group.className = "settings-group plugin-voice-section";
       group.voiceProviderId = section.pluginId;
@@ -296,7 +298,8 @@ export function createVoiceController({
           if (field.step !== null) input.step = String(field.step);
         }
         if (!field.readonly && !["readonly", "status", "resource"].includes(field.type)) {
-          setInputValue(field, input);
+          setInputValue(Object.hasOwn(draftValues, field.key)
+            ? { ...field, value: draftValues[field.key] } : field, input);
           const handleInput = () => { syncFieldAvailability(); markDirty(); };
           input.addEventListener("input", handleInput);
           input.addEventListener("change", handleInput);
@@ -412,9 +415,14 @@ export function createVoiceController({
     onDirty();
   }
 
-  function initialize(value) {
+  function initialize(value, { preserveDraft = false } = {}) {
     const next = exactVoiceSnapshot(value);
+    const previousDraft = preserveDraft ? currentDraft() : null;
+    const previousBaseline = baseline ? JSON.parse(baseline) : null;
     if (!next.providers.length) {
+      if (previousDraft && draftSignature(previousDraft) !== baseline) {
+        throw new Error("语音引擎暂不可用，未保存的语音改动已保留，请稍后重新检查。");
+      }
       renderUnavailable();
       return;
     }
@@ -443,23 +451,49 @@ export function createVoiceController({
     refreshSelect(fields.provider);
     renderSections();
     baseline = draftSignature(currentDraft());
+    if (previousDraft && previousBaseline
+        && previousDraft.characterId === (snapshot.character?.characterId || null)) {
+      if (previousDraft.enabled !== previousBaseline.enabled) fields.enabled.checked = previousDraft.enabled;
+      if (previousDraft.providerId !== previousBaseline.providerId && previousDraft.providerId) {
+        if (!Array.from(fields.provider.children).some((item) => item.value === previousDraft.providerId)) {
+          const option = document.createElement("option");
+          option.value = previousDraft.providerId;
+          option.textContent = `${previousDraft.providerId}（未加载）`;
+          fields.provider.append(option);
+        }
+        fields.provider.value = previousDraft.providerId;
+      }
+      const edits = previousDraft.sections.map((section) => {
+        const oldValues = previousBaseline.sections.find((item) => item.pluginId === section.pluginId
+          && item.sectionId === section.sectionId)?.values || {};
+        return { ...section, values: Object.fromEntries(Object.entries(section.values)
+          .filter(([key, value]) => value !== oldValues[key])) };
+      });
+      renderSections(edits);
+      refreshSelect(fields.provider);
+    }
     onDirty();
   }
 
-  async function refresh() {
+  async function refresh(options = {}) {
     if (disposed) return null;
-    initialize(await invoke("settings_voice_get"));
+    const next = await invoke("settings_voice_get");
+    if (!disposed) initialize(next, options);
     return snapshot;
   }
 
-  async function refreshCurrent() {
+  async function refreshCurrent({ preserveDraft = false } = {}) {
     if (!isAvailable()) {
+      if (preserveDraft && snapshot && draftSignature(currentDraft()) !== baseline) {
+        throw new Error("语音管理暂不可用，未保存的语音改动已保留，请稍后重新检查。");
+      }
       if (!disposed) renderUnavailable();
       return null;
     }
     try {
-      return await refresh();
-    } catch {
+      return await refresh({ preserveDraft });
+    } catch (error) {
+      if (preserveDraft && snapshot) throw error;
       if (!disposed) renderUnavailable();
       return null;
     }

--- a/desktop/frontend/studio/index.html
+++ b/desktop/frontend/studio/index.html
@@ -119,10 +119,15 @@
 
           <section id="page-voice-model" class="settings-page">
             <fieldset class="settings-group">
-              <legend>语音模型</legend>
+              <legend>角色包中的模型</legend>
+              <p class="setting-desc">当前编辑副本中的模型文件，关闭语音时也会显示。位置相对于角色包根目录。</p>
+              <div id="modelFileList" class="model-file-list" aria-label="角色包中的语音模型"></div>
+            </fieldset>
+            <fieldset class="settings-group">
+              <legend>GPT-SoVITS 配置</legend>
               <div class="setting-row">
                 <div class="setting-row-text">
-                  <span class="setting-title">启用语音</span>
+                  <span class="setting-title">启用 GPT-SoVITS</span>
                   <span class="setting-desc">使用角色包内的 GPT-SoVITS 配置。</span>
                 </div>
                 <label class="check-control" for="voiceEnabled">

--- a/desktop/frontend/studio/studio.js
+++ b/desktop/frontend/studio/studio.js
@@ -75,6 +75,7 @@ const fields = {
   voiceEnabled: document.getElementById("voiceEnabled"),
   voiceEnabledLabel: document.getElementById("voiceEnabledLabel"),
   voiceModelFields: document.getElementById("voiceModelFields"),
+  modelFileList: document.getElementById("modelFileList"),
   gptModelPath: document.getElementById("gptModelPath"),
   importGptModelButton: document.getElementById("importGptModelButton"),
   clearGptModelButton: document.getElementById("clearGptModelButton"),
@@ -109,7 +110,7 @@ const pageMeta = {
   basic: { title: "基础信息", subtitle: "名称与开场白" },
   card: { title: "人设卡", subtitle: "系统人设" },
   portrait: { title: "立绘", subtitle: "默认立绘与表情映射" },
-  "voice-model": { title: "语音模型", subtitle: "GPT-SoVITS 模型与默认语言" },
+  "voice-model": { title: "语音模型", subtitle: "包内模型文件与 GPT-SoVITS 配置" },
   "reference-audio": { title: "参考语音", subtitle: "音频、参考文本与回复语气描述词" },
   theme: { title: "配色", subtitle: "角色包自带主题色" },
 };
@@ -685,6 +686,7 @@ async function flushDraftAutosave() {
   try {
     const result = await draftAutosavePromise;
     currentDoc = result.doc || doc;
+    renderModelFiles(result.model_files);
     const existing = (request.characters || []).find((item) => item.id === currentDoc.id);
     if (existing) {
       existing.display_name = currentDoc.display_name;
@@ -718,6 +720,7 @@ function setCurrentDoc(payload, draftCharacter = null, options = {}) {
   stopReferenceAudioPreview();
   currentWorkspaceId = payload.workspace_id || payload.doc?.id || "";
   currentDoc = payload.doc || null;
+  renderModelFiles(payload.model_files);
   if (Array.isArray(payload.characters)) {
     request.characters = payload.characters;
   }
@@ -757,6 +760,36 @@ function renderEditor() {
   syncVoiceEnabledState();
   refreshControls();
   renderingEditor = false;
+}
+
+function renderModelFiles(modelFiles = []) {
+  fields.modelFileList.replaceChildren();
+  if (!modelFiles.length) {
+    const empty = document.createElement("p");
+    empty.className = "setting-desc";
+    empty.textContent = "角色包内没有 .ckpt、.pth 或 .onnx 模型文件。";
+    fields.modelFileList.append(empty);
+    return;
+  }
+  for (const model of modelFiles) {
+    const relativePath = String(model.relative_path || "");
+    const row = document.createElement("div");
+    row.className = "model-file";
+    const name = document.createElement("span");
+    name.className = "setting-title model-file-name";
+    name.textContent = relativePath.split("/").pop();
+    const size = document.createElement("span");
+    size.className = "setting-desc";
+    const bytes = Number(model.byte_length) || 0;
+    size.textContent = bytes >= 1024 ** 2
+      ? `${(bytes / 1024 ** 2).toFixed(1)} MiB`
+      : `${(bytes / 1024).toFixed(1)} KiB`;
+    const path = document.createElement("span");
+    path.className = "setting-desc model-file-path";
+    path.textContent = relativePath;
+    row.append(name, size, path);
+    fields.modelFileList.append(row);
+  }
 }
 
 function renderExpressions(expressions, defaultPortrait = "") {
@@ -1498,6 +1531,7 @@ async function discardCurrentDraft() {
     }
     currentWorkspaceId = "";
     currentDoc = null;
+    renderModelFiles();
     editingCharacterId = "";
     temporaryCharacter = null;
     renderCharacterOptions();
@@ -1842,6 +1876,7 @@ async function commitCharacter({ publish = false } = {}) {
       request.characters = payload.characters;
     }
     currentDoc = payload.doc || collectDoc();
+    renderModelFiles(payload.model_files);
     editingCharacterId = currentDoc.id || editingCharacterId;
     temporaryCharacter = null;
     renderCharacterOptions();

--- a/desktop/frontend/studio/styles.css
+++ b/desktop/frontend/studio/styles.css
@@ -148,6 +148,34 @@
   max-width: none;
 }
 
+.model-file-list {
+  display: grid;
+  gap: 10px;
+  max-height: 300px;
+  overflow-y: auto;
+  min-width: 0;
+}
+
+.model-file {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 5px 16px;
+  padding: 12px;
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-md);
+}
+
+.model-file-name,
+.model-file-path {
+  overflow-wrap: anywhere;
+  user-select: text;
+}
+
+.model-file-path {
+  grid-column: 1 / -1;
+  font-family: "Cascadia Code", "SFMono-Regular", Consolas, monospace;
+}
+
 .compact-button {
   min-width: 72px;
   padding-inline: 12px;

--- a/desktop/frontend/tests/appearance-runtime.test.js
+++ b/desktop/frontend/tests/appearance-runtime.test.js
@@ -102,7 +102,7 @@ test("settings snapshot binds Rust-injected window core and character identity",
   assert.throws(() => validateAppearanceSnapshot({ ...snapshot, appearance: { ...snapshot.appearance, coreGenerationId: "old" } }));
 });
 
-test("Core generation replacement rebinds appearance in place and keeps global save actions usable", async () => {
+test("Studio publication merges only edited appearance fields and saves against the new generation", async () => {
   class Control {
     constructor() {
       this.value = "";
@@ -142,6 +142,11 @@ test("Core generation replacement rebinds appearance in place and keeps global s
     },
     appearance: { schemaVersion: 1, coreGenerationId: generationId, characterId: "Sakura", values },
   });
+  let nextSnapshot = makeSnapshot("generation-b");
+  nextSnapshot.appearance.values = {
+    ...values, controlPanelWidth: 700,
+    themeTokens: { ...themeTokens, primary: "#abcdef", accent: "#fedcba" },
+  };
   let intervalCallback = null;
   let nextFrame = null;
   const calls = [];
@@ -158,9 +163,9 @@ test("Core generation replacement rebinds appearance in place and keeps global s
       invoke: async (command, args) => {
         calls.push([command, args]);
         if (command === "runtime_lifecycle_snapshot") {
-          return { supervisor: { generationId: "generation-b" } };
+          return { supervisor: { generationId: nextSnapshot.presentation.generationId } };
         }
-        if (command === "settings_character_appearance_get") return makeSnapshot("generation-b");
+        if (command === "settings_character_appearance_get") return nextSnapshot;
         if (command === "settings_character_appearance_save") {
           return { coreGenerationId: "generation-b", characterId: "Sakura", values: args.values };
         }
@@ -177,10 +182,15 @@ test("Core generation replacement rebinds appearance in place and keeps global s
     await controller.initialize(makeSnapshot("generation-a"));
     controls.portraitScale.value = "135";
     controls.portraitScale.fire("input");
+    themes.accent_color.value = "#123456";
+    controls.themeColors.fire("input");
     assert.equal(controller.isDirty(), true);
     await intervalCallback();
     assert.equal(controller.isDirty(), true);
     assert.equal(controls.portraitScale.value, "135");
+    assert.equal(controls.controlPanelWidth.value, "700");
+    assert.equal(themes.primary_color.value, "#abcdef");
+    assert.equal(themes.accent_color.value, "#123456");
     assert.equal(controls.applyButton.disabled, false);
     assert.equal(controls.saveButton.disabled, false);
     await controller.save();
@@ -188,6 +198,22 @@ test("Core generation replacement rebinds appearance in place and keeps global s
     assert.ok(calls.some(([command]) => command === "settings_character_appearance_get"));
     assert.ok(calls.some(([command]) => command === "settings_character_appearance_save"));
     assert.equal(nextFrame, null);
+
+    nextSnapshot = makeSnapshot("generation-c");
+    nextSnapshot.appearance.values = { ...values, themeTokens: { ...themeTokens, primary: "#998877" } };
+    await intervalCallback();
+    assert.equal(themes.primary_color.value, "#998877");
+    assert.equal(controller.isDirty(), false, "a clean Settings page accepts the published appearance without creating a draft");
+
+    controls.portraitScale.value = "140";
+    controls.portraitScale.fire("input");
+    nextSnapshot = makeSnapshot("generation-d");
+    nextSnapshot.presentation.characterId = "Other";
+    nextSnapshot.appearance.characterId = "Other";
+    await intervalCallback();
+    assert.equal(controls.portraitScale.value, "125");
+    assert.equal(controller.isDirty(), false, "edits cannot cross to another character");
+    controller.dispose();
   } finally {
     globalThis.window = previousWindow;
   }

--- a/desktop/frontend/tests/settings-studio-integration.test.js
+++ b/desktop/frontend/tests/settings-studio-integration.test.js
@@ -1,0 +1,193 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import vm from "node:vm";
+import test from "node:test";
+
+import * as characterRuntime from "../settings/character-switch-runtime.js";
+import { normalizeCharacterSettingsSnapshot } from "../settings/root-settings-runtime.js";
+
+const source = readFileSync(new URL("../settings/settings.js", import.meta.url), "utf8");
+
+// Settings starts its window on import. Run its actual handlers with an isolated
+// DOM/IPC boundary so these tests never open a window or write user settings.
+function settingsHandlers(names, globals) {
+  const context = vm.createContext({ ...characterRuntime, normalizeCharacterSettingsSnapshot, ...globals });
+  for (const name of names) {
+    const start = source.search(new RegExp(`^(?:async )?function ${name}\\(`, "m"));
+    assert.notEqual(start, -1, `missing Settings handler ${name}`);
+    const end = source.indexOf("\n}", start) + 2;
+    vm.runInContext(source.slice(start, end), context, { filename: `settings.js:${name}` });
+  }
+  return context;
+}
+
+function control() {
+  return {
+    disabled: false, value: "", textContent: "", children: [],
+    classList: { toggle() {}, contains: () => false },
+    append(item) { this.children.push(item); },
+    setAttribute() {}, removeAttribute() {},
+  };
+}
+
+function catalog(ids = ["alpha", "beta"]) {
+  return {
+    schemaVersion: 1, revision: 1, currentCharacterId: "alpha",
+    characters: ids.map((id) => ({ id, displayName: id, hasVoice: true, hasExportableVoice: true })),
+  };
+}
+
+function characterSettings() {
+  const fields = Object.fromEntries([
+    "saveButton", "applyButton", "characterSelect", "characterImportButton", "ttsVoiceImportButton",
+    "characterExportButton", "characterEditorButton", "characterArchiveHint",
+  ].map((key) => [key, control()]));
+  fields.pages = Object.fromEntries(["character", "appearance", "voice", "memory"].map((key) => [key, control()]));
+  const calls = [];
+  let dirty = true;
+  const context = settingsHandlers([
+    "syncCharacterArchiveState", "selectedCharacter", "pendingRuntimeCharacterId", "setCharacterArchiveBusy",
+    "runCharacterArchiveAction", "launchCharacterStudio", "refreshDirty", "renderCharacters",
+    "applyRuntimeCharacterSnapshot", "refreshRuntimeCharacterCatalog", "rebindSettingsAfterCharacterSwitch",
+  ], {
+    fields, document: { body: control(), createElement: control },
+    request: { character: normalizeCharacterSettingsSnapshot(catalog()).character },
+    runtimeSettingsHost: true, runtimeCharacterSnapshot: catalog(), runtimeCharacterDraftId: "alpha",
+    characterArchiveBusy: false, characterSwitching: false, submissionBusy: false,
+    characterCatalogRefreshRevision: 0, memoryState: {},
+    currentCharacterHasDrafts: () => dirty, computeDirty: () => dirty,
+    refreshSelect() {}, renderMemorySurface() {}, renderMemoryPage() {},
+    setError(message) { assert.equal(message, "", message); },
+    invoke: async (command, args) => { calls.push([command, args]); },
+    rootSettingsClient: { charactersGet: async () => catalog() },
+    runtimeProviderModelController: null, runtimeScreenAwarenessController: null,
+    runtimeAppearanceController: null, runtimeToolsController: null,
+    runtimePluginController: null, runtimeVoiceController: null,
+  });
+  context.applyRuntimeCharacterSnapshot(catalog());
+  return { context, fields, calls, markSaved: () => { dirty = false; } };
+}
+
+test("unsaved layout and pending character selection both allow opening Studio without saving", async () => {
+  const { context, fields, calls, markSaved } = characterSettings();
+  for (const characterId of ["alpha", "beta"]) {
+    context.runtimeCharacterDraftId = characterId;
+    fields.characterSelect.value = characterId;
+    context.refreshDirty();
+    assert.equal(fields.characterEditorButton.disabled, false);
+    assert.equal(fields.ttsVoiceImportButton.disabled, true);
+    await context.launchCharacterStudio();
+    assert.equal(calls.at(-1)[0], "open_character_studio");
+    assert.equal(calls.at(-1)[1].characterId, characterId);
+    assert.equal(context.runtimeCharacterSnapshot.currentCharacterId, "alpha");
+    assert.equal(fields.characterEditorButton.disabled, false);
+  }
+  assert.deepEqual(calls.map(([command]) => command), ["open_character_studio", "open_character_studio"]);
+
+  context.runtimeCharacterDraftId = "alpha";
+  fields.characterSelect.value = "alpha";
+  markSaved();
+  context.refreshDirty();
+  assert.equal(fields.characterEditorButton.disabled, false);
+  assert.equal(fields.ttsVoiceImportButton.disabled, false, "saving updates draft-dependent controls without reopening Settings");
+  context.characterSwitching = true;
+  context.syncCharacterArchiveState();
+  assert.equal(fields.characterEditorButton.disabled, true, "a live Core switch still locks the entry");
+});
+
+test("Studio catalog publication retains a valid pending selection but drops a removed target", async () => {
+  const { context, fields } = characterSettings();
+  context.runtimeCharacterDraftId = "beta";
+  fields.characterSelect.value = "beta";
+  await context.refreshRuntimeCharacterCatalog({});
+  assert.equal(fields.characterSelect.value, "beta");
+  assert.equal(context.pendingRuntimeCharacterId(), "beta");
+  context.rootSettingsClient.charactersGet = async () => catalog(["alpha"]);
+  await context.refreshRuntimeCharacterCatalog({});
+  assert.equal(fields.characterSelect.value, "alpha");
+  assert.equal(context.pendingRuntimeCharacterId(), null);
+});
+
+test("current-character publication refreshes the bound controllers and unlocks Settings with drafts intact", async () => {
+  const { context, fields } = characterSettings();
+  context.runtimeCharacterDraftId = "beta";
+  fields.characterSelect.value = "beta";
+  const refreshed = [];
+  context.invoke = async () => ({
+    supervisor: { generationId: "generation-b" },
+    snapshot: { generationId: "generation-b", readiness: "ready" },
+    characterPresentation: { generationId: "generation-b", characterId: "alpha" },
+  });
+  context.runtimeAppearanceController = {
+    rebindGeneration: async (generationId) => { refreshed.push(generationId); },
+  };
+  context.runtimeVoiceController = {
+    refreshCurrent: async ({ preserveDraft }) => { assert.equal(preserveDraft, true); refreshed.push("voice"); },
+  };
+  await context.refreshRuntimeCharacterCatalog({ generationId: "generation-b" });
+  assert.deepEqual(refreshed, ["generation-b", "voice"]);
+  assert.equal(fields.characterSelect.value, "beta");
+  assert.equal(context.currentCharacterHasDrafts(), true);
+  assert.equal(context.characterSwitching, false);
+  assert.equal(context.memoryState.rebinding, false);
+  assert.equal(fields.characterEditorButton.disabled, false);
+});
+
+test("plugin refresh retains Memory editors and detaches results from the old generation", async () => {
+  const pluginSnapshot = { plugins: [{
+    installId: "memory", pluginId: "com.example.memory", sections: [{
+      sectionId: "archive", surface: "memory", values: {}, fields: [], actions: [],
+      collections: [{ collectionId: "entries", pageSize: 20, fields: [], filters: [], columns: [] }],
+    }],
+  }] };
+  const states = new Map();
+  let resolveOldQuery;
+  let queries = 0;
+  const context = settingsHandlers([
+    "applyRuntimePluginSnapshot", "pluginCollectionKey", "pluginCollectionRuntimeState", "queryPluginCollection", "clonePlain",
+  ], {
+    request: {}, pluginCollectionState: states, pluginState: {},
+    window: { clearTimeout() {}, setTimeout() { assert.fail("stale query scheduled work"); } },
+    initializePluginState() {},
+    renderPluginPage() {}, renderMemorySurface() {}, renderAboutComponents() {},
+    characterSwitching: false, memoryState: {}, pendingRuntimeCharacterId: () => null,
+    projectPluginActivity: () => ({}), memoryActivityBlocksCollection: () => false,
+    runtimePluginController: { collection() {
+      queries += 1;
+      return queries === 1 ? new Promise((resolve) => { resolveOldQuery = resolve; })
+        : Promise.resolve({ items: [{ itemId: "fresh" }], total: 1, nextCursor: null });
+    } },
+  });
+  context.applyRuntimePluginSnapshot(pluginSnapshot);
+  const oldPlugin = context.request.plugins.items[0];
+  const oldSection = oldPlugin.settings[0];
+  const oldCollection = oldSection.collections[0];
+  const oldState = context.pluginCollectionRuntimeState(oldPlugin, oldSection, oldCollection);
+  oldState.editor = { itemId: "note", values: { content: "未保存的记忆" } };
+  oldState.search = "旅行";
+  const pending = context.queryPluginCollection(oldPlugin, oldSection, oldCollection, { render: false });
+
+  context.applyRuntimePluginSnapshot(pluginSnapshot, { preserveDraft: true });
+  const newPlugin = context.request.plugins.items[0];
+  const newSection = newPlugin.settings[0];
+  const newCollection = newSection.collections[0];
+  const newState = context.pluginCollectionRuntimeState(newPlugin, newSection, newCollection);
+  assert.notEqual(newState, oldState);
+  assert.equal(JSON.stringify(newState.editor), JSON.stringify(oldState.editor));
+  assert.equal(newState.search, "旅行");
+  resolveOldQuery({ items: [{ itemId: "stale" }], total: 1, nextCursor: null });
+  await pending;
+  assert.equal(newState.items.length, 0);
+  await context.queryPluginCollection(oldPlugin, oldSection, oldCollection);
+  assert.equal(queries, 1, "old scheduled callbacks cannot issue new queries");
+  await context.queryPluginCollection(newPlugin, newSection, newCollection, { render: false });
+  assert.equal(newState.items[0].itemId, "fresh");
+  assert.equal(newState.editor.values.content, "未保存的记忆");
+
+  newState.editor = null;
+  context.applyRuntimePluginSnapshot(pluginSnapshot, { preserveDraft: true });
+  assert.equal([...states.values()][0].editor, null, "a clean collection must not acquire a phantom draft");
+
+  context.applyRuntimePluginSnapshot(pluginSnapshot);
+  assert.equal(states.size, 0, "an explicit discard still clears collection drafts");
+});

--- a/desktop/frontend/tests/voice-runtime.test.js
+++ b/desktop/frontend/tests/voice-runtime.test.js
@@ -78,6 +78,78 @@ function fixture() {
   };
 }
 
+for (const sameCharacter of [true, false]) {
+  test(`Studio refresh ${sameCharacter ? "preserves edited voice fields" : "does not carry voice drafts to another character"}`, async () => {
+    const { controls, document, created } = fixture();
+    const original = snapshot();
+    original.sections[0].fields.push(field({ key: "retrySeconds", value: 20 }));
+    original.sections[0].values.retrySeconds = 20;
+    const next = structuredClone(original);
+    next.coreGenerationId = "generation-b";
+    if (!sameCharacter) next.character = { characterId: "beta", displayName: "Beta" };
+    next.sections[0].fields[0].value = 90;
+    next.sections[0].fields[1].value = 30;
+    next.sections[0].values = { timeoutSeconds: 90, retrySeconds: 30 };
+    const calls = [];
+    const controller = createVoiceController({
+      document,
+      invoke: async (command, args) => {
+        calls.push([command, args]);
+        if (command === "settings_voice_get") return next;
+        if (command === "settings_voice_save") return {
+          applicationState: "applied", saveState: "complete", savedSections: [],
+          selectionSaved: true, reasonCode: "READY", snapshot: {},
+        };
+        throw new Error(`unexpected ${command}`);
+      },
+    });
+    controller.initialize(original);
+    const timeout = created.find((item) => item.tagName === "input" && item.value === "60");
+    timeout.value = "120";
+    timeout.fire("input");
+    controls.ttsEnabled.checked = false;
+    controls.ttsProvider.value = "org.demo.graph-voice";
+    controls.ttsProvider.fire("change");
+
+    await controller.refreshCurrent({ preserveDraft: true });
+
+    assert.deepEqual(calls.map(([command]) => command), ["settings_voice_get"]);
+    assert.equal(controller.isDirty(), sameCharacter);
+    assert.equal(controls.ttsEnabled.checked, !sameCharacter);
+    assert.equal(controls.ttsProvider.value, sameCharacter ? "org.demo.graph-voice" : "com.example.neural-voice");
+    await controller.save();
+    const saved = calls.find(([command]) => command === "settings_voice_save")[1];
+    assert.equal(saved.coreGenerationId, "generation-b");
+    assert.equal(saved.draft.characterId, sameCharacter ? "alpha" : "beta");
+    assert.deepEqual(saved.draft.sections, sameCharacter ? [{
+      pluginId: "com.example.neural-voice", sectionId: "runtime",
+      values: { timeoutSeconds: 120, retrySeconds: 30 },
+    }] : []);
+    assert.equal(controller.isDirty(), false);
+  });
+}
+
+test("a failed Studio refresh retains voice drafts for the next successful refresh", async () => {
+  const { controls, document } = fixture();
+  let failing = true;
+  const controller = createVoiceController({
+    document,
+    invoke: async () => {
+      if (failing) throw new Error("Core unavailable");
+      return snapshot({ coreGenerationId: "generation-b" });
+    },
+  });
+  controller.initialize(snapshot());
+  controls.ttsEnabled.checked = false;
+  await assert.rejects(controller.refreshCurrent({ preserveDraft: true }), /Core unavailable/);
+  assert.equal(controls.ttsEnabled.checked, false);
+  assert.equal(controller.isDirty(), true);
+  failing = false;
+  await controller.refreshCurrent({ preserveDraft: true });
+  assert.equal(controls.ttsEnabled.checked, false);
+  assert.equal(controller.isDirty(), true);
+});
+
 test("voice settings accept unknown Provider IDs and reject private fields", () => {
   const value = snapshot();
   assert.deepEqual(exactVoiceSnapshot(value), value);

--- a/docs/specs/runtime-v2/character-studio.md
+++ b/docs/specs/runtime-v2/character-studio.md
@@ -4,7 +4,7 @@ status: normative
 audience: maintainer
 source_of_truth: self
 status_source: ../../plans/runtime-v2/work-packages.md
-updated: 2026-09-04
+updated: 2026-09-06
 ---
 
 # Runtime v2 角色工坊
@@ -22,8 +22,11 @@ GPT-SoVITS 模型、参考语音试听、发布、放弃草稿和 `.char` 导出
 
 ## 窗口与设置
 
-- 设置页只能在角色选择已提交，且外观、语音、Memory 没有角色级草稿时打开工坊。Provider、Tools、Plugin
-  等全局设置草稿不阻断。
+- 设置页可以直接打开所选角色的工坊，无需先保存或应用设置。外观、语音、Memory 等未保存改动，以及
+  尚未应用的角色选择都不阻断入口；打开工坊不会自动保存这些改动或切换当前角色。
+- 工坊发布后，设置页接续新的 Core generation。同一角色只保留相对原基线实际修改的外观和语音字段，
+  未修改字段使用新快照；待应用的角色选择（角色仍在目录中时）和记忆编辑草稿也保留。草稿仍由用户
+  在设置页保存或放弃。真正切换角色时继续清理旧角色状态，不能把旧角色的草稿带给新角色。
 - `open_character_studio({ characterId })` 创建或聚焦唯一 `studio` 窗口。窗口初始化完成前保持隐藏。
 - 工坊外壳使用当前已生效的 Runtime 外观主题，与设置页保持一致。角色包配色只在“配色”页编辑和保存，
   不改变工坊窗口本身的颜色。
@@ -71,6 +74,9 @@ studio.operation.cancel
 路径和导入源都要检查路径穿越；角色包或草稿资源不能经过符号链接。尾点角色 ID 继续通过可移植目录名保存，
 保证 Windows 与旧草稿兼容。
 
+每个角色复用一个草稿目录。自动保存只更新 `draft.json`，不复制整个包，也不创建历史备份；已导入且不再被
+表单引用的资源按原有规则清理。未发布修改必须跨重启保留；关闭窗口时可以释放 clean 工作区。
+
 导入类型固定为 `portrait`、`portraitFolder`、`gptModel`、`sovitsModel`、`referenceAudio` 和
 `referenceAudioFolder`。大文件复制和重复文件比较都要分块检查取消。文件夹导入在全部文件复制完成后一次
 登记；任一文件失败或用户取消时，只删除本批新建的资源，不改动此前已有的同名文件。
@@ -80,9 +86,19 @@ extension 必须原样保留。GPT-SoVITS 打开时兼容 legacy `voice` 与 Run
 `voice`、`sakura.tts` 和 `sakura.tts.gpt-sovits`。Genie 等非 Studio 管理的语音 Provider 不能因为普通
 主题保存而被切换或禁用。
 
+“语音模型”页独立列出当前编辑副本中可读取元数据的 `.ckpt`、`.pth` 和 `.onnx` 文件，显示文件名、大小及
+角色包内相对路径。列表不依赖 GPT-SoVITS 是否启用，也不要求文件已经登记到 Provider 配置；使用 Genie
+或关闭语音时仍可查看。打开、草稿保存和发布响应通过只读 `modelFiles` 返回 `relativePath`、`byteLength`，
+切换角色、导入模型和清理草稿资源后同步刷新。枚举只读取文件元数据，不读取模型内容、不跟随符号链接或
+目录联接，也不把模型列表写入角色配置。下方编辑区明确标为 GPT-SoVITS 配置，查看文件不会切换 Provider。
+
 ## 发布、导出与取消
 
-发布顺序固定为：
+发布前校验草稿，并与已安装包逐文件比较实际内容。比较包括模型、立绘、未知资源和目录结构，大文件按块
+检查取消，不单凭文件大小或修改时间判断相同。两者完全一致时只把草稿标记为 clean，不复制 staging、
+不新增备份，也不停止当前 generation 或触发 Core 重建。首次保存旧包时，manifest 的规范化仍可能产生变化。
+
+内容发生变化时，发布顺序固定为：
 
 ```text
 完整校验
@@ -94,6 +110,7 @@ extension 必须原样保留。GPT-SoVITS 打开时兼容 legacy `voice` 与 Run
 -> rollback 移入 backups
 -> 校验正式角色、写入 clean 草稿状态并构造返回数据
 -> 删除 journal
+-> 清理该角色超出保留数量的历史备份
 ```
 
 `CharacterRegistry` 不扫描事务根和旧版严格命名的 staging、rollback、recovery 目录。写 journal 前取消或
@@ -102,6 +119,14 @@ extension 必须原样保留。GPT-SoVITS 打开时兼容 legacy `voice` 与 Run
 启动仍要从完整 backup 重试。新角色发布中断时删除未完成的正式目录。恢复会把草稿重新标记为 dirty。
 删除 journal 是提交点；此后的 Core 重载失败不能回滚已经发布的文件。
 
+每个角色保留最近两份完整包备份。只在保存成功后清理更早的备份，无变化的重复保存也会执行清理，便于
+收敛旧版累积的历史。清理只处理 `backups` 直接子目录中符合工坊时间戳命名、且 manifest ID 与本次角色
+一致的备份；其他角色、手动命名、清单无法读取或经过链接的目录不参与。新备份记录备份时间，同一秒内的
+保存不按随机后缀决定先后。journal 存在时禁止清理；清理失败保留保存结果，记录日志并提示下次保存重试。
+
+以每版约 300 MB 的角色为例，两份历史备份约占 600 MB，编辑中的草稿另占约 300 MB，发布暂存目录会短暂
+增加约 300 MB。真实修改仍使用完整包事务复制，空间按保留版本的实际大小计算，不随成功保存次数持续增长。
+
 导入、发布和含语音导出使用单操作 ID。`studio.operation.cancel` 在复制或校验阶段设置取消标记；进入目录
 切换、资源登记或导出文件替换阶段后返回 `finalizing`，界面显示“正在完成保存”。最后一次取消检查与进入
 提交阶段必须在同一把 operation lock 中完成。导出先写同目录临时 `.char`，ZIP 中的大文件按块压缩；提交前
@@ -109,7 +134,7 @@ extension 必须原样保留。GPT-SoVITS 打开时兼容 legacy `voice` 与 Run
 
 ## 运行态与临时资源
 
-发布非当前角色返回 `changePlan: unchanged`，不能切换桌宠。发布当前角色返回
+发布非当前角色或内容未变化时返回 `changePlan: unchanged`，不能切换桌宠。发布当前角色且内容有变化时返回
 `changePlan: core_restart_required`。替换目录前，Core 先取消并关闭旧 generation 的聊天、TTS 和插件读取者；
 Rust 随后只发起一次现有 Core restart，并关闭旧音频状态。停止这些读取者后发布仍失败时，错误响应带
 `generationInvalidated: true`，Rust 仍要重建已经失效的 generation。保存已经成功而 restart 请求失败时返回

--- a/tests/unit/test_character_studio.py
+++ b/tests/unit/test_character_studio.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
+import time
 import zipfile
 from pathlib import Path
 
@@ -142,6 +144,182 @@ def test_invalid_published_save_preserves_the_original_character(tmp_path: Path)
     assert (package / "portraits" / "default.png").read_bytes() == b"portrait"
 
 
+def test_repeated_publish_keeps_only_two_recent_complete_backups(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    package = _write_character(tmp_path)
+    model = package / "voice" / "models" / "model.ckpt"
+    model.parent.mkdir(parents=True)
+    model.write_bytes(b"model" * 1024)
+    service = CharacterStudioService(tmp_path)
+    opened = service.open_character("sakura")
+    # Exercise timestamp collisions: UUID suffixes must not decide recency.
+    strftime = time.strftime
+    monkeypatch.setattr("app.config.character_studio.time.strftime", lambda fmt, *args:
+                        "20260905-120000" if fmt == "%Y%m%d-%H%M%S" else strftime(fmt, *args))
+    for index in range(8):
+        opened["doc"]["card_text"] = f"revision {index}"
+        service.save_character(opened["doc"], opened["workspace_id"])
+        backups = list(service.backup_root.iterdir())
+        assert len(backups) == min(index + 1, 2)
+        assert all((backup / "voice/models/model.ckpt").read_bytes() == model.read_bytes()
+                   for backup in backups)
+    assert {(backup / "card.md").read_text(encoding="utf-8") for backup in backups} == {
+        "revision 5", "revision 6",
+    }
+    assert (package / "card.md").read_text(encoding="utf-8") == "revision 7"
+
+
+def test_unchanged_publish_does_not_copy_or_backup_and_detects_asset_changes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    package = _write_character(tmp_path)
+    service = CharacterStudioService(tmp_path)
+    opened = service.open_character("sakura")
+    saved = service.save_character(opened["doc"], opened["workspace_id"])
+    backups = list(service.backup_root.iterdir())
+    original_manifest_stat = (package / "character.json").stat()
+
+    def unexpected_copy(*args, **kwargs):
+        pytest.fail("unchanged publish must not copy the package")
+
+    with monkeypatch.context() as patch:
+        patch.setattr("app.config.character_studio._copytree_cancellable", unexpected_copy)
+        for _ in range(3):
+            saved = service.save_character(saved["doc"], opened["workspace_id"])
+            assert saved["changed"] is False
+            assert saved["is_dirty"] is False
+    assert list(service.backup_root.iterdir()) == backups
+    assert (package / "character.json").stat().st_mtime_ns == original_manifest_stat.st_mtime_ns
+
+    # Same path, size and mtime can still hide changed bytes (e.g. an external edit).
+    portrait = Path(opened["package_dir"]) / "portraits/default.png"
+    original_stat = portrait.stat()
+    portrait.write_bytes(b"modified")
+    os.utime(portrait, ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns))
+    saved = service.save_character(saved["doc"], opened["workspace_id"])
+    assert saved["changed"] is True
+    assert (package / "portraits/default.png").read_bytes() == b"modified"
+
+
+def test_autosave_reuses_one_draft_and_preserves_unpublished_work(tmp_path: Path) -> None:
+    _write_character(tmp_path)
+    service = CharacterStudioService(tmp_path)
+    opened = service.open_character("sakura")
+    for index in range(20):
+        opened["doc"]["card_text"] = f"draft {index}"
+        service.save_workspace_draft(opened["workspace_id"], opened["doc"])
+    assert list(service.backup_root.iterdir()) == []
+    assert len(list(service.workspace_characters_dir.iterdir())) == 1
+    assert service.release_workspace("sakura")["released"] is False
+    restarted = CharacterStudioService(tmp_path)
+    assert restarted.open_character("sakura")["doc"]["card_text"] == "draft 19"
+    restarted.save_character(opened["doc"], opened["workspace_id"])
+    assert restarted.release_workspace("sakura")["released"] is True
+    assert list(restarted.workspace_characters_dir.iterdir()) == []
+
+
+def test_unchanged_publish_can_be_cancelled_during_large_file_comparison(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_character(tmp_path)
+    service = CharacterStudioService(tmp_path)
+    opened = service.open_character("sakura")
+    portrait = Path(opened["package_dir"]) / "portraits/default.png"
+    portrait.write_bytes(b"p" * (3 * 1024 * 1024))
+    saved = service.save_character(opened["doc"], opened["workspace_id"])
+    backups = list(service.backup_root.iterdir())
+    checkpoints = 0
+    comparing_portrait = False
+    from app.config.character_studio import _files_equal_cancellable as original_compare
+
+    def compare(source, target, *, cancel_check):
+        nonlocal comparing_portrait
+        comparing_portrait = source == portrait
+        return original_compare(source, target, cancel_check=cancel_check)
+
+    monkeypatch.setattr("app.config.character_studio._files_equal_cancellable", compare)
+
+    def cancel_comparison() -> None:
+        nonlocal checkpoints
+        if comparing_portrait:
+            checkpoints += 1
+            if checkpoints == 2:
+                raise CharacterStudioOperationCancelled()
+
+    with pytest.raises(CharacterStudioOperationCancelled):
+        service.save_character(saved["doc"], opened["workspace_id"], cancel_check=cancel_comparison)
+    assert list(service.backup_root.iterdir()) == backups
+    assert not service._publish_journal_path.exists()
+    assert service._read_state("sakura")["dirty"] is True
+
+
+def test_successful_save_prunes_legacy_backups_only_for_the_matching_role(tmp_path: Path) -> None:
+    package = _write_character(tmp_path)
+    other = _write_character(tmp_path, "sakura-extra")
+    service = CharacterStudioService(tmp_path)
+    opened = service.open_character("sakura")
+    saved = service.save_character(opened["doc"], opened["workspace_id"])
+    legacy = []
+    for index in range(5):
+        path = service.backup_root / f"sakura-20200101-00000{index}"
+        shutil.copytree(package, path)
+        legacy.append(path)
+    unrelated = service.backup_root / "sakura-extra-20200101-000000"
+    shutil.copytree(other, unrelated)
+    wrong_id = service.backup_root / "sakura-20200101-000010"
+    shutil.copytree(other, wrong_id)
+    manual = service.backup_root / "sakura-manual"
+    shutil.copytree(package, manual)
+    damaged = service.backup_root / "sakura-20200101-000011"
+    damaged.mkdir()
+    (damaged / "character.json").write_text("broken json", encoding="utf-8")
+    service.save_character(saved["doc"], opened["workspace_id"])
+    assert [path for path in legacy if path.exists()] == legacy[-1:]
+    assert all(path.exists() for path in (unrelated, wrong_id, manual, damaged))
+
+
+def test_backup_cleanup_failure_does_not_rollback_a_committed_publish(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    package = _write_character(tmp_path)
+    model = package / "voice/models/model.ckpt"
+    model.parent.mkdir(parents=True)
+    model.write_bytes(b"locked model")
+    service = CharacterStudioService(tmp_path)
+    opened = service.open_character("sakura")
+    strftime = time.strftime
+    monkeypatch.setattr("app.config.character_studio.time.strftime", lambda fmt, *args:
+                        "20260905-120000" if fmt == "%Y%m%d-%H%M%S" else strftime(fmt, *args))
+    for index in range(2):
+        opened["doc"]["card_text"] = f"revision {index}"
+        service.save_character(opened["doc"], opened["workspace_id"])
+    original_rmtree = shutil.rmtree
+
+    def fail_backup_cleanup(path, *args, **kwargs):
+        if Path(path).name == "voice" and Path(path).parent.parent == service.backup_root:
+            assert not service._publish_journal_path.exists()
+            raise PermissionError("backup locked")
+        return original_rmtree(path, *args, **kwargs)
+
+    with monkeypatch.context() as patch:
+        patch.setattr("app.config.character_studio.shutil.rmtree", fail_backup_cleanup)
+        opened["doc"]["card_text"] = "committed revision"
+        saved = service.save_character(opened["doc"], opened["workspace_id"])
+    assert (package / "card.md").read_text(encoding="utf-8") == "committed revision"
+    assert saved["is_dirty"] is False
+    assert "备份" in saved["message"]
+    assert len(list(service.backup_root.iterdir())) == 3
+    assert all((path / "character.json").is_file() for path in service.backup_root.iterdir())
+    # A later no-op save retries cleanup without generating another backup.
+    service.save_character(saved["doc"], opened["workspace_id"])
+    assert len(list(service.backup_root.iterdir())) == 2
+    assert {(path / "card.md").read_text(encoding="utf-8")
+            for path in service.backup_root.iterdir()} == {"revision 0", "revision 1"}
+    assert all((path / "portraits/default.png").read_bytes() == b"portrait"
+               for path in service.backup_root.iterdir())
+
+
 def test_character_studio_rejects_unsafe_ids_and_external_workspaces(tmp_path: Path) -> None:
     service = CharacterStudioService(tmp_path)
 
@@ -192,6 +370,11 @@ def test_character_studio_recovery_survives_a_second_interruption(
     service = CharacterStudioService(tmp_path)
     opened = service.open_character("sakura")
     doc = opened["doc"]
+    doc["card_text"] = "earlier revision"
+    service.save_character(doc, opened["workspace_id"])
+    doc["card_text"] = "original card"
+    service.save_character(doc, opened["workspace_id"])
+    assert len(list(service.backup_root.iterdir())) == 2
     doc["card_text"] = "replacement card"
     from app.config.character_studio import rename_with_retry as original_rename
 
@@ -206,6 +389,7 @@ def test_character_studio_recovery_survives_a_second_interruption(
     )
     with pytest.raises(SystemExit, match="publish exit"):
         service.save_character(doc, opened["workspace_id"])
+    assert len(list(service.backup_root.iterdir())) == 3
 
     def interrupt_before_recovery_install(source: Path, target: Path, *args, **kwargs) -> None:
         if Path(source).name == "recovery":
@@ -225,6 +409,7 @@ def test_character_studio_recovery_survives_a_second_interruption(
     assert (package / "card.md").read_text(encoding="utf-8") == "original card"
     assert not recovered._publish_journal_path.exists()
     assert not recovered._publish_transactions_root.exists()
+    assert len(list(recovered.backup_root.iterdir())) == 3
 
 
 def test_new_character_recovery_removal_survives_a_second_interruption(

--- a/tests/unit/test_core_host_character_studio.py
+++ b/tests/unit/test_core_host_character_studio.py
@@ -86,6 +86,90 @@ def test_open_uses_real_current_character_in_catalog(tmp_path: Path) -> None:
     assert not next(item for item in result["characters"] if item["id"] == "alpha")["isCurrent"]
 
 
+@pytest.mark.parametrize("provider,enabled", [
+    ("sakura.tts.gpt-sovits", True),
+    ("sakura.tts.gpt-sovits", False),
+    ("sakura.tts.genie", True),
+    (None, False),
+])
+def test_model_inventory_is_visible_independently_of_voice_configuration(
+    tmp_path: Path, provider: str | None, enabled: bool,
+) -> None:
+    _write_character(tmp_path, "alpha")
+    package = tmp_path / "characters/alpha"
+    resources = {
+        "voice/models/alpha.ckpt": b"gpt-model",
+        "voice/models/alpha.pth": b"sovits-model",
+        "voice/onnx/encoder.onnx": b"onnx-model",
+    }
+    for relative_path, content in resources.items():
+        path = package / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+    (package / "voice/refs").mkdir()
+    (package / "voice/refs/neutral.wav").write_bytes(b"audio")
+    (package / "voice/refs/ref.txt").write_text(
+        "voice/refs/neutral.wav|JA|hello|neutral\n", encoding="utf-8",
+    )
+    manifest_path = package / "character.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if provider is not None:
+        manifest["extensions"] = {
+            "sakura.tts": {"enabled": enabled, "provider": provider},
+            provider: {
+                "gptModel": "voice/models/alpha.ckpt",
+                "sovitsModel": "voice/models/alpha.pth",
+            },
+        }
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    boundary = CharacterStudioBoundary(GENERATION, CREDENTIAL, tmp_path)
+    opened = boundary.handle(_request("studio.character.open", {"characterId": "alpha"}))["payload"]
+    expected = [{"relativePath": path, "byteLength": len(content)}
+                for path, content in resources.items()]
+    assert opened["modelFiles"] == expected
+    if not enabled or provider == "sakura.tts.genie":
+        assert opened["doc"]["voice"] is None
+    opened["doc"]["cardText"] = "edited card"
+    saved = boundary.handle(_request("studio.draft.save", {
+        "workspaceId": opened["workspaceId"], "doc": opened["doc"],
+    }))["payload"]
+    assert saved["modelFiles"] == expected
+    assert json.loads(manifest_path.read_text(encoding="utf-8")) == manifest
+    assert str(tmp_path) not in json.dumps(saved)
+    publish_result = boundary.handle(_request("studio.character.publish", {
+        "workspaceId": opened["workspaceId"], "doc": saved["doc"],
+    }))
+    assert publish_result["ok"] is True, publish_result
+    published = publish_result["payload"]
+    assert published["modelFiles"] == expected
+    if provider == "sakura.tts.genie" or not enabled:
+        assert json.loads(manifest_path.read_text(encoding="utf-8")).get("extensions") == manifest.get("extensions")
+
+
+def test_model_inventory_updates_after_import_and_draft_asset_removal(tmp_path: Path) -> None:
+    boundary = CharacterStudioBoundary(GENERATION, CREDENTIAL, tmp_path)
+    opened = boundary.handle(_request("studio.character.create", {
+        "doc": {"id": "alpha", "displayName": "Alpha"},
+    }))["payload"]
+    assert opened["modelFiles"] == []
+    source = tmp_path / "model.ckpt"
+    source.write_bytes(b"gpt-model")
+    imported = boundary.handle(_request("studio.asset.import", {
+        "workspaceId": opened["workspaceId"], "kind": "gptModel", "path": str(source),
+    }))["payload"]
+    doc = opened["doc"]
+    doc["voice"] = {"gptModel": imported["relativePath"]}
+    saved = boundary.handle(_request("studio.draft.save", {
+        "workspaceId": opened["workspaceId"], "doc": doc,
+    }))["payload"]
+    assert saved["modelFiles"] == [{"relativePath": "voice/models/model.ckpt", "byteLength": 9}]
+    saved["doc"]["voice"]["gptModel"] = ""
+    cleared = boundary.handle(_request("studio.draft.save", {
+        "workspaceId": opened["workspaceId"], "doc": saved["doc"],
+    }))["payload"]
+    assert cleared["modelFiles"] == []
+
+
 def test_publish_reports_restart_only_for_current_character(tmp_path: Path) -> None:
     _write_character(tmp_path, "alpha")
     _write_character(tmp_path, "beta")
@@ -115,6 +199,17 @@ def test_publish_reports_restart_only_for_current_character(tmp_path: Path) -> N
 
     assert current["ok"] is True
     assert current["payload"]["changePlan"] == "core_restart_required"
+    assert quiesced == ["alpha"]
+
+    repeated = boundary.handle(
+        _request(
+            "studio.character.publish",
+            {"workspaceId": opened["workspaceId"], "doc": current["payload"]["doc"]},
+        )
+    )
+    assert repeated["ok"] is True
+    assert repeated["payload"]["changePlan"] == "unchanged"
+    assert repeated["payload"]["isDirty"] is False
     assert quiesced == ["alpha"]
 
     other = boundary.handle(


### PR DESCRIPTION
角色工坊反复保存大型角色包会积累备份。现在逐文件比较内容，相同内容保存不再复制发布目录或新增备份；内容变化后保留最近两份有效备份，清理失败保留保存结果并提示重试。

语音模型页展示 .ckpt、.pth、.onnx 的文件名、大小和包内路径，不依赖启用的语音引擎。设置页有未保存的外观或语音改动时仍可进入“修改角色”，发布刷新保留设置草稿，保存后立即更新入口状态。

验证：
- 本分支后端 38 项通过、2 项跳过；相关前端 21 项通过。
- docs profile 和 git diff --check 通过。
- 与气泡布局、Genie 分支按全部 6 种顺序试合并，无冲突且结果一致；组合状态下 172 项 Python、48 项前端测试及 docs profile 通过，4 项 Python 测试跳过。

本次未重新进行完整桌面窗口人工验收。目标为当前 main；三个任务均从 main 的 ff926b85 开始。
